### PR TITLE
M0 + M1: Helm chart delivery skeleton and KWOK test fabric

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Go
+/bin/
+*.test
+*.out
+
+# Node
+node_modules/
+ui/dist/
+*.tsbuildinfo
+
+# Local state
+*.db
+*.sqlite
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,255 @@
+# k8s-dencer — single entry point for build, deploy, lint and demo.
+#
+# Everything runs in-cluster: there is no out-of-cluster dev shortcut. The Helm
+# chart is the product, so the same chart is used locally and in production,
+# separated only by a values overlay under charts/k8s-dencer/ci/.
+
+SHELL := /usr/bin/env bash
+.DEFAULT_GOAL := help
+.SHELLFLAGS := -eu -o pipefail -c
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+# orbstack | k3d | kind | minikube
+# Selects both the images-load implementation and the ci/ values overlay.
+# Nothing outside this file and charts/k8s-dencer/ci/ may assume a provider.
+CLUSTER_PROVIDER ?= orbstack
+
+NAMESPACE   ?= k8s-dencer
+RELEASE     ?= k8s-dencer
+CHART       ?= charts/k8s-dencer
+
+# Local port for `make ui`. Not 8080: kagent's own UI port-forward commonly
+# holds that, and the collision is silent enough to waste real time.
+UI_PORT     ?= 8090
+
+# Demo fabric (POC only). Separate releases and namespaces from the product so
+# the topology can be torn down without touching k8s-dencer.
+KWOK_CHART_VERSION ?= 0.3.0
+KWOK_NAMESPACE     ?= kwok
+DEMO_NAMESPACE     ?= dencer-demo
+DEMO_RELEASE       ?= dencer-demo
+SCENARIO           ?= a-fragmented
+
+# A dirty suffix keeps uncommitted builds from reusing a clean tag, and the
+# changing tag is what makes `helm upgrade` roll pods without a manual restart.
+GIT_SHA     := $(shell git rev-parse --short HEAD 2>/dev/null || echo nogit)
+GIT_DIRTY   := $(shell test -n "$$(git status --porcelain 2>/dev/null)" && echo -dirty || true)
+IMAGE_TAG   ?= $(GIT_SHA)$(GIT_DIRTY)
+
+IMAGE_PREFIX ?= k8s-dencer
+PLATFORMS    ?= linux/amd64,linux/arm64
+
+# Pinned tool versions, installed into ./bin so a workstation without brew
+# still gets a reproducible lint.
+KUBECONFORM_VERSION ?= v0.7.0
+LOCALBIN := $(CURDIR)/bin
+KUBECONFORM := $(LOCALBIN)/kubeconform
+
+export PATH := $(LOCALBIN):$(PATH)
+
+# ---------------------------------------------------------------------------
+# Help
+# ---------------------------------------------------------------------------
+
+.PHONY: help
+help: ## Show available targets
+	@echo "k8s-dencer  (provider=$(CLUSTER_PROVIDER)  tag=$(IMAGE_TAG))"
+	@echo
+	@grep -hE '^[a-zA-Z_-]+:.*?## ' $(MAKEFILE_LIST) \
+		| sort \
+		| awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}'
+
+# ---------------------------------------------------------------------------
+# Tools
+# ---------------------------------------------------------------------------
+
+$(LOCALBIN):
+	@mkdir -p $(LOCALBIN)
+
+$(KUBECONFORM): | $(LOCALBIN)
+	@echo "==> installing kubeconform $(KUBECONFORM_VERSION)"
+	@GOBIN=$(LOCALBIN) go install github.com/yannh/kubeconform/cmd/kubeconform@$(KUBECONFORM_VERSION)
+
+.PHONY: tools
+tools: $(KUBECONFORM) ## Install pinned tooling into ./bin
+
+# ---------------------------------------------------------------------------
+# Build
+# ---------------------------------------------------------------------------
+
+.PHONY: build
+build: ## Compile the Go binaries locally
+	go build ./...
+
+.PHONY: test
+test: ## Run Go and UI tests
+	go vet ./...
+	go test ./...
+	cd ui && npm run typecheck
+
+.PHONY: images
+images: ## Build native-arch images for the local cluster
+	@echo "==> building images tagged $(IMAGE_TAG) (native arch)"
+	docker buildx build --load \
+		-f build/Dockerfile.go \
+		--build-arg COMPONENT=planner \
+		--build-arg VERSION=$(IMAGE_TAG) \
+		-t $(IMAGE_PREFIX)-planner:$(IMAGE_TAG) .
+	docker buildx build --load \
+		-f build/Dockerfile.go \
+		--build-arg COMPONENT=ui-backend \
+		--build-arg VERSION=$(IMAGE_TAG) \
+		-t $(IMAGE_PREFIX)-ui-backend:$(IMAGE_TAG) .
+	docker buildx build --load \
+		-f build/Dockerfile.ui \
+		-t $(IMAGE_PREFIX)-ui-frontend:$(IMAGE_TAG) .
+
+.PHONY: images-release
+images-release: ## Build multi-arch images (buildx cannot --load these; use --push)
+	@echo "==> building $(PLATFORMS) images tagged $(IMAGE_TAG)"
+	@echo "    note: multi-platform builds cannot be loaded into the local"
+	@echo "    docker image store; add --push and a registry to publish."
+	docker buildx build --platform $(PLATFORMS) \
+		-f build/Dockerfile.go \
+		--build-arg COMPONENT=planner \
+		--build-arg VERSION=$(IMAGE_TAG) \
+		-t $(IMAGE_PREFIX)-planner:$(IMAGE_TAG) .
+	docker buildx build --platform $(PLATFORMS) \
+		-f build/Dockerfile.go \
+		--build-arg COMPONENT=ui-backend \
+		--build-arg VERSION=$(IMAGE_TAG) \
+		-t $(IMAGE_PREFIX)-ui-backend:$(IMAGE_TAG) .
+	docker buildx build --platform $(PLATFORMS) \
+		-f build/Dockerfile.ui \
+		-t $(IMAGE_PREFIX)-ui-frontend:$(IMAGE_TAG) .
+
+.PHONY: images-load
+images-load: ## Make locally built images visible to the cluster
+ifeq ($(CLUSTER_PROVIDER),orbstack)
+	@echo "==> orbstack shares the docker image store; nothing to load"
+else ifeq ($(CLUSTER_PROVIDER),k3d)
+	k3d image import $(IMAGE_PREFIX)-planner:$(IMAGE_TAG) $(IMAGE_PREFIX)-ui-backend:$(IMAGE_TAG) $(IMAGE_PREFIX)-ui-frontend:$(IMAGE_TAG)
+else ifeq ($(CLUSTER_PROVIDER),kind)
+	kind load docker-image $(IMAGE_PREFIX)-planner:$(IMAGE_TAG) $(IMAGE_PREFIX)-ui-backend:$(IMAGE_TAG) $(IMAGE_PREFIX)-ui-frontend:$(IMAGE_TAG)
+else ifeq ($(CLUSTER_PROVIDER),minikube)
+	minikube image load $(IMAGE_PREFIX)-planner:$(IMAGE_TAG)
+	minikube image load $(IMAGE_PREFIX)-ui-backend:$(IMAGE_TAG)
+	minikube image load $(IMAGE_PREFIX)-ui-frontend:$(IMAGE_TAG)
+else
+	$(error unknown CLUSTER_PROVIDER: $(CLUSTER_PROVIDER))
+endif
+
+# ---------------------------------------------------------------------------
+# Lint
+# ---------------------------------------------------------------------------
+
+.PHONY: lint
+lint: $(KUBECONFORM) ## Chart portability gate: lint, render and assert the contract
+	@KUBECONFORM=$(KUBECONFORM) CHART=$(CHART) ./hack/lint-chart.sh
+
+# ---------------------------------------------------------------------------
+# Deploy
+# ---------------------------------------------------------------------------
+
+.PHONY: deploy
+deploy: ## Install/upgrade the product chart with the provider overlay
+	helm upgrade --install $(RELEASE) $(CHART) \
+		--namespace $(NAMESPACE) --create-namespace \
+		-f $(CHART)/ci/$(CLUSTER_PROVIDER)-values.yaml \
+		--set planner.image.tag=$(IMAGE_TAG) \
+		--set uiBackend.image.tag=$(IMAGE_TAG) \
+		--set uiFrontend.image.tag=$(IMAGE_TAG) \
+		--wait --timeout 5m
+
+.PHONY: ui
+ui: ## Port-forward the UI and print its URL (Ctrl-C to stop)
+	@if lsof -nP -iTCP:$(UI_PORT) -sTCP:LISTEN >/dev/null 2>&1; then \
+		echo "port $(UI_PORT) is already in use by:"; \
+		lsof -nP -iTCP:$(UI_PORT) -sTCP:LISTEN | tail -n +2 | awk '{print "    " $$1 " (pid " $$2 ")"}'; \
+		echo "retry on another port:  make ui UI_PORT=8091"; \
+		exit 1; \
+	fi
+	@svc=$$(kubectl get svc -n $(NAMESPACE) -l app.kubernetes.io/component=ui-frontend \
+		-o jsonpath='{.items[0].metadata.name}' 2>/dev/null); \
+	if [ -z "$$svc" ]; then \
+		echo "no ui-frontend service in namespace $(NAMESPACE); run 'make deploy' first"; \
+		exit 1; \
+	fi; \
+	echo "==> k8s-dencer UI"; \
+	echo "    http://localhost:$(UI_PORT)"; \
+	lb=$$(kubectl get svc -n $(NAMESPACE) $$svc \
+		-o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null); \
+	if [ -n "$$lb" ]; then \
+		echo "    http://$$lb                     (LoadBalancer)"; \
+		echo "    http://$$svc.$(NAMESPACE).k8s.orb.local  (OrbStack DNS)"; \
+	fi; \
+	echo "    Ctrl-C to stop"; \
+	kubectl port-forward -n $(NAMESPACE) svc/$$svc $(UI_PORT):80
+
+.PHONY: status
+status: ## Show what is running
+	kubectl get pods,svc,pvc -n $(NAMESPACE)
+
+.PHONY: logs
+logs: ## Tail the planner log
+	kubectl logs -n $(NAMESPACE) -l app.kubernetes.io/component=planner -f --tail=50
+
+.PHONY: undeploy
+undeploy: ## Remove the product release
+	-helm uninstall $(RELEASE) --namespace $(NAMESPACE)
+
+# ---------------------------------------------------------------------------
+# Demo fabric (POC only — never part of the product chart)
+# ---------------------------------------------------------------------------
+
+.PHONY: kwok-up
+kwok-up: ## Install the KWOK fake-node fabric
+	@# Charts are served from the classic repo; the OCI path advertised in the
+	@# KWOK docs currently has no tags published.
+	helm repo add kwok https://kwok.sigs.k8s.io/charts/ >/dev/null 2>&1 || true
+	helm repo update kwok >/dev/null
+	helm upgrade --install kwok kwok/kwok --version $(KWOK_CHART_VERSION) \
+		--namespace $(KWOK_NAMESPACE) --create-namespace \
+		-f demo/kwok-values.yaml --wait --timeout 3m
+	helm upgrade --install kwok-stage-fast kwok/stage-fast --version $(KWOK_CHART_VERSION) \
+		--namespace $(KWOK_NAMESPACE) --wait --timeout 2m
+
+.PHONY: kwok-down
+kwok-down: ## Remove the KWOK fabric
+	-helm uninstall kwok-stage-fast --namespace $(KWOK_NAMESPACE)
+	-helm uninstall kwok --namespace $(KWOK_NAMESPACE)
+
+.PHONY: demo-up
+demo-up: ## Install the synthetic topology (SCENARIO=a-fragmented)
+	helm upgrade --install $(DEMO_RELEASE) demo/charts/dencer-demo \
+		--namespace $(DEMO_NAMESPACE) --create-namespace \
+		--set scenario=$(SCENARIO) --wait --timeout 3m
+
+.PHONY: demo-down
+demo-down: ## Remove the synthetic topology (deletes the fake nodes)
+	-helm uninstall $(DEMO_RELEASE) --namespace $(DEMO_NAMESPACE)
+
+.PHONY: scenario
+scenario: ## Switch scenario: make scenario S=b-pdb-blocked
+	@if [ -z "$(S)" ]; then \
+		echo "usage: make scenario S=<a-fragmented|b-pdb-blocked|c-topology-spread|d-anti-affinity|e-tainted-pool>"; \
+		exit 1; \
+	fi
+	helm upgrade --install $(DEMO_RELEASE) demo/charts/dencer-demo \
+		--namespace $(DEMO_NAMESPACE) --create-namespace \
+		--set scenario=$(S) --wait --timeout 3m
+
+.PHONY: demo
+demo: kwok-up demo-up images images-load deploy ## Full POC: fabric + topology + product
+	@echo
+	@echo "==> demo ready. 'make ui' to open it, 'make down' to tear it all down."
+
+.PHONY: down
+down: undeploy demo-down kwok-down ## Remove every release this repo installs
+
+.PHONY: clean
+clean: ## Remove build artifacts
+	rm -rf $(LOCALBIN) ui/dist

--- a/README.md
+++ b/README.md
@@ -1,2 +1,176 @@
 # k8s-dencer
+
 k8s-dencer continuously analyzes your Kubernetes cluster's constraints (PDBs, topology spread, affinity, taints) and builds a node consolidation plan — broken into discrete, impact-rated steps you can inspect and run on your own terms, on request or during a maintenance window. Nothing executes without explicit approval.
+
+**Phase 1 is read-only by construction.** It plans and explains; it never cordons, drains or evicts. The ServiceAccount is not granted `pods/eviction`, and `make lint` fails the build if any values profile ever grants it.
+
+Full design: [docs/k8s-consolidation-agent-architecture.md](docs/k8s-consolidation-agent-architecture.md)
+
+---
+
+## Status
+
+Phase 1 (MVP) — visibility and explainability. No execution capability.
+
+| Milestone | Scope | State |
+|---|---|---|
+| **M0** | Helm chart to full production contract, three images, delivery skeleton | **done** |
+| **M1** | KWOK fake-node fabric + five constraint scenarios as Helm releases | **done** |
+| M2 | Domain model + cluster state collector (informers over nodes/pods/PDBs) | next |
+| M3 | Constraint analyzer (PDB headroom, topology, affinity, taints) | pending |
+| M4 | Consolidation planner (greedy first-fit-decreasing) | pending |
+| M5 | Impact classifier (Green/Yellow/Red + rationale) | pending |
+| M6 | Plan store (SQLite) + REST/WS API + graph payload | pending |
+| M7 | UI: before/after canvas, step timeline scrubber, constraint inspector | pending |
+| M8 | Kagent agent: read-only MCP tools + `Agent` CR | pending |
+
+Deferred to later phases: Executor, Safety Guard, Scheduler Simulator, `MaintenanceWindow` CRD, Postgres store, multi-agent orchestration.
+
+### What actually runs today
+
+The three components deploy and serve, but the planner is a heartbeat and the UI is a placeholder that verifies backend connectivity — the real planning and visualisation land in M4 and M7.
+
+---
+
+## Quick start
+
+**Prerequisites:** a Kubernetes cluster, Docker, Helm 3.8+, Go 1.26+, Node 22+. Kagent is optional and, if wanted, must be installed separately (see [Kagent](#kagent) below).
+
+```bash
+make demo     # KWOK fabric + 30-node topology + build images + install the chart
+make ui       # port-forward and print the URLs
+make down     # remove all three releases
+```
+
+`make` with no target lists everything.
+
+---
+
+## Layout
+
+```
+api/v1alpha1/      CRD types (ConsolidationPolicy) — importable, not internal/
+cmd/               planner, ui-backend — one dir per shipped image
+internal/
+  model/           domain types; NO k8s imports, so the planner is testable from a YAML snapshot
+  cluster/         informer-backed collector + MetricsSource interface
+  constraints/     PDB / topology / affinity / taint analysis
+  planner/         Strategy interface + greedy bin-packing
+  impact/          Green/Yellow/Red classifier + rationale
+  store/           Store interface, sqlite/, migrations/
+  api/             rest/ ws/ graph/ agenttools/
+ui/                React + Vite + Cytoscape.js
+charts/k8s-dencer/ THE product deliverable — see Chart below
+demo/              POC only: KWOK values + the synthetic topology chart
+build/             Dockerfile.go (parameterised by COMPONENT) + Dockerfile.ui
+hack/              lint-chart.sh — the portability gate
+```
+
+Structural rules worth preserving:
+
+- `internal/model` has **zero** Kubernetes imports. That is what lets the planner be tested against a fixture snapshot with no cluster.
+- `api/` stays out of `internal/` so CRD types remain importable by other tools.
+- `demo/` is never referenced by the product chart. It installs as a separate release and can be torn down independently.
+- CRD YAML is generated into `config/crd/bases` and copied into the chart by make — never hand-maintained in two places.
+
+---
+
+## The chart is the product
+
+`charts/k8s-dencer` must install on any conformant cluster (EKS/GKE/AKS/on-prem). Local concerns live in a values overlay under `charts/k8s-dencer/ci/`, never in the defaults.
+
+**Defaults are vendor-neutral:** `ClusterIP` + optional Ingress (never LoadBalancer), restricted-PSS security contexts, per-component `resources`/probes/`nodeSelector`/`tolerations`/`affinity`/`topologySpreadConstraints`, `serviceAccount.annotations` for EKS IRSA and GKE Workload Identity, configurable `persistence` with `storageClass: ""` inheriting the cluster default, and a `kubeVersion: ">=1.27.0-0"` floor.
+
+**Forbidden in chart defaults:** LoadBalancer services, `hostPath`, `imagePullPolicy: Always`, hardcoded storage classes or node names, any reference to OrbStack or KWOK.
+
+### Values profiles
+
+| Profile | Purpose |
+|---|---|
+| `values.yaml` | vendor-neutral production defaults |
+| `ci/minimal-values.yaml` | every optional feature off — must still be a valid restricted-PSS install |
+| `ci/production-values.yaml` | cloud-shaped: Ingress + TLS, PVC, IRSA, PDB, NetworkPolicy, ServiceMonitor |
+| `ci/orbstack-values.yaml` | the local POC overlay — the only place OrbStack assumptions are allowed |
+
+### The portability gate
+
+```bash
+make lint
+```
+
+Runs `helm lint` and `kubeconform --strict` across every profile, then asserts the contract:
+
+1. production renders Ingress, PVC, PDB, NetworkPolicy, ServiceMonitor and an IRSA-annotated ServiceAccount
+2. production greps clean for `orbstack`, `kwok`, `hostPath`, `LoadBalancer`, `imagePullPolicy: Always`
+3. minimal keeps `runAsNonRoot` / `readOnlyRootFilesystem` / `allowPrivilegeEscalation: false` with all optionals off
+4. **no profile grants `pods/eviction`**
+5. `database.type=sqlite` with `uiBackend.replicaCount=2` is rejected by `values.schema.json`
+6. the packaged chart excludes the `ci/` fixtures
+
+### Known constraints
+
+- **SQLite is single-writer.** `uiBackend.replicaCount` is pinned to 1 and enforced by the schema; the planner is co-scheduled with ui-backend via a `requiredDuringScheduling` podAffinity, because a ReadWriteOnce claim only permits multiple pods on the same node. Both constraints disappear when the Postgres store lands.
+- **PDBs use `maxUnavailable`, never `minAvailable`.** A `minAvailable` PDB on a single-replica Deployment makes its own pod undrainable — the exact pathology this product exists to detect.
+
+---
+
+## Test fabric (KWOK)
+
+A node-consolidation planner cannot be tested on a single-node cluster. [KWOK](https://kwok.sigs.k8s.io/) provides fake nodes with no kubelet, so a laptop presents a 30-node topology while the **real** scheduler, PDB accounting and eviction API all apply.
+
+```bash
+make kwok-up                        # upstream kwok + stage-fast charts (pinned 0.3.0 / app v0.8.0)
+make demo-up                        # 30 fake nodes across 3 zones + the base workload
+make scenario S=b-pdb-blocked       # switch constraint scenario
+make demo-down && make kwok-down
+```
+
+> KWOK's docs advertise OCI coordinates at `oci://registry.k8s.io/kwok/charts/*`, but that path currently publishes no tags. The Makefile uses the classic repo `https://kwok.sigs.k8s.io/charts/`.
+
+### Scenarios
+
+The base filler workload deploys in **every** scenario, so there is always something to consolidate; the scenario layers the constraint that should change how steps are rated.
+
+| Scenario | Shape | Expected planner behaviour |
+|---|---|---|
+| `a-fragmented` | 90 pods at ~37% requested over 30 nodes | collapses toward ~12 nodes, all steps Green |
+| `b-pdb-blocked` | `payments` minAvailable 3/3, `catalog` 1/3 | payments steps Red naming the PDB; catalog stays Green |
+| `c-topology-spread` | 6 replicas, `maxSkew: 1` over 3 zones | moves preserve 2-per-zone |
+| `d-anti-affinity` | 5 replicas, required anti-affinity on hostname | each pins a node open; rationale names the rule |
+| `e-tainted-pool` | 3 nodes tainted `dedicated=batch` | pool neither packed into nor drained out of |
+
+Verified against the live cluster: evicting a `payments` pod is refused with `TooManyRequests`, while `catalog` succeeds — real PDB enforcement on fake nodes.
+
+---
+
+## Kagent
+
+Kagent is a **prerequisite**, not installed by this repo. Chart resources are gated behind `kagent.enabled` (default `false`) so the product installs cleanly on clusters without the `kagent.dev` CRDs.
+
+When enabled, the chart creates a `RemoteMCPServer` pointing at the ui-backend's `/mcp` endpoint and an `Agent` CR scoped to explanation only. The MCP tools themselves land in M8, so until then the `RemoteMCPServer` will show `ACCEPTED: False` — expected, and a useful signal for when M8 is actually complete.
+
+---
+
+## Development
+
+```bash
+make build          # compile Go
+make test           # go vet + go test + UI typecheck
+make images         # native-arch images for the local cluster
+make images-release # multi-arch linux/amd64,linux/arm64
+make deploy         # helm upgrade --install with the provider overlay
+make status         # pods, services, PVCs
+make logs           # tail the planner
+```
+
+**Images carry no registry by default locally.** OrbStack's Kubernetes reads the local Docker image store, so `docker build` + `helm upgrade` is the whole loop — no registry, no push. `IMAGE_TAG` is the git short SHA plus a `-dirty` suffix, which changes the podspec on every build so pods roll without a manual restart.
+
+> `docker buildx` cannot `--load` a multi-platform build into the local image store. `make images` builds native-only for the dev loop; `make images-release` does the multi-arch build.
+
+### Targeting a different cluster
+
+`CLUSTER_PROVIDER` (`orbstack` | `k3d` | `kind` | `minikube`) selects both the `images-load` implementation and the values overlay. Only `orbstack` is exercised today; the others exist so a migration is a variable change, not a refactor. Nothing outside the Makefile and `charts/k8s-dencer/ci/` may assume a provider.
+
+```bash
+make demo CLUSTER_PROVIDER=k3d
+```

--- a/build/Dockerfile.go
+++ b/build/Dockerfile.go
@@ -1,0 +1,43 @@
+# Shared build for the Go components. The COMPONENT arg selects which cmd/ to
+# build, so planner and ui-backend cannot drift in base image or hardening.
+#
+#   docker buildx build -f build/Dockerfile.go --build-arg COMPONENT=planner .
+#
+# syntax=docker/dockerfile:1
+
+ARG GO_VERSION=1.26
+
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS build
+
+WORKDIR /src
+
+# Dependencies first so a source-only change reuses the module layer.
+COPY go.mod go.sum* ./
+RUN go mod download
+
+COPY . .
+
+ARG COMPONENT
+ARG VERSION=dev
+ARG TARGETOS
+ARG TARGETARCH
+
+# CGO off keeps the binary static, which is what distroless/static and
+# readOnlyRootFilesystem both require.
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    go build \
+      -trimpath \
+      -ldflags="-s -w -X main.version=${VERSION}" \
+      -o /out/app \
+      ./cmd/${COMPONENT}
+
+FROM gcr.io/distroless/static-debian12:nonroot
+
+COPY --from=build /out/app /app
+
+# 65532 is distroless' nonroot user; the chart asserts the same uid so a base
+# image change cannot silently drop the pod to root.
+USER 65532:65532
+
+ENTRYPOINT ["/app"]

--- a/build/Dockerfile.ui
+++ b/build/Dockerfile.ui
@@ -1,0 +1,31 @@
+# Frontend image: Vite build served by nginx-unprivileged.
+#
+# nginx-unprivileged is used rather than stock nginx so the container runs as a
+# non-root user and binds an unprivileged port, which the chart's restricted
+# securityContext requires.
+#
+# syntax=docker/dockerfile:1
+
+ARG NODE_VERSION=22
+
+FROM --platform=$BUILDPLATFORM node:${NODE_VERSION}-alpine AS build
+
+WORKDIR /src
+
+COPY ui/package.json ui/package-lock.json* ./
+RUN npm ci
+
+COPY ui/ ./
+RUN npm run build
+
+FROM nginxinc/nginx-unprivileged:1.27-alpine
+
+COPY --from=build /src/dist /usr/share/nginx/html
+COPY ui/nginx.conf /etc/nginx/conf.d/default.conf
+
+# The API base URL is injected at pod start from a ConfigMap mounted over this
+# file. Baking it into the bundle would tie the image to one cluster.
+COPY ui/public/config.js /usr/share/nginx/html/config.js
+
+USER 101
+EXPOSE 8080

--- a/charts/k8s-dencer/.helmignore
+++ b/charts/k8s-dencer/.helmignore
@@ -1,0 +1,8 @@
+.DS_Store
+.git/
+.gitignore
+*.tmproj
+.vscode/
+.idea/
+# ci/ profiles are lint fixtures, not part of the packaged chart.
+ci/

--- a/charts/k8s-dencer/Chart.yaml
+++ b/charts/k8s-dencer/Chart.yaml
@@ -1,0 +1,31 @@
+apiVersion: v2
+name: k8s-dencer
+description: |
+  Continuously analyses Kubernetes scheduling constraints (PDBs, topology
+  spread, affinity, taints) and builds a node consolidation plan as discrete,
+  impact-rated steps. Phase 1 is read-only: it plans and explains, it never
+  evicts.
+type: application
+
+# Chart version tracks the chart; appVersion tracks the images. Component image
+# tags default to appVersion so a chart release pins a coherent image set.
+version: 0.1.0
+appVersion: "0.1.0"
+
+# controller-runtime and the policy/v1 PDB API used here are stable from 1.21,
+# but the chart relies on 1.27-era defaults for restricted Pod Security
+# Standards admission, so that is the supported floor.
+kubeVersion: ">=1.27.0-0"
+
+home: https://github.com/atedgimo/k8s-dencer
+sources:
+  - https://github.com/atedgimo/k8s-dencer
+keywords:
+  - kubernetes
+  - descheduler
+  - consolidation
+  - bin-packing
+  - cost-optimization
+maintainers:
+  - name: Moti Atedgi
+    email: atedgimo@gmail.com

--- a/charts/k8s-dencer/ci/minimal-values.yaml
+++ b/charts/k8s-dencer/ci/minimal-values.yaml
@@ -1,0 +1,24 @@
+# Smallest possible install: every optional feature off.
+#
+# Asserts the chart still renders a valid, restricted-PSS-compliant install
+# when nothing is enabled — the state a first-time user lands in.
+
+persistence:
+  enabled: false
+
+uiFrontend:
+  replicaCount: 1
+  podDisruptionBudget:
+    enabled: false
+
+ingress:
+  enabled: false
+
+networkPolicy:
+  enabled: false
+
+serviceMonitor:
+  enabled: false
+
+kagent:
+  enabled: false

--- a/charts/k8s-dencer/ci/orbstack-values.yaml
+++ b/charts/k8s-dencer/ci/orbstack-values.yaml
@@ -1,0 +1,68 @@
+# Local POC overlay for the OrbStack cluster.
+#
+# This is the ONLY place in the repo allowed to encode OrbStack assumptions.
+# Nothing here may migrate into values.yaml.
+
+# No registry: OrbStack's Kubernetes reads the local Docker image store
+# directly, so `docker build` + `helm upgrade` is the whole loop. Requires a
+# non-:latest tag, which the Makefile supplies from the git SHA.
+planner:
+  image:
+    registry: ""
+    repository: k8s-dencer-planner
+    pullPolicy: IfNotPresent
+  resources:
+    requests:
+      cpu: 25m
+      memory: 64Mi
+    limits:
+      cpu: 500m
+      memory: 256Mi
+
+uiBackend:
+  image:
+    registry: ""
+    repository: k8s-dencer-ui-backend
+    pullPolicy: IfNotPresent
+  resources:
+    requests:
+      cpu: 25m
+      memory: 64Mi
+    limits:
+      cpu: 500m
+      memory: 256Mi
+
+uiFrontend:
+  replicaCount: 1
+  image:
+    registry: ""
+    repository: k8s-dencer-ui-frontend
+    pullPolicy: IfNotPresent
+  # OrbStack maps LoadBalancer services onto *.k8s.orb.local and makes them
+  # reachable from macOS, which avoids installing an ingress controller on a
+  # cluster that ships without one.
+  service:
+    type: LoadBalancer
+  config:
+    kagentUrl: http://localhost:8080
+  podDisruptionBudget:
+    enabled: false
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      cpu: 100m
+      memory: 64Mi
+
+persistence:
+  enabled: true
+  # Empty inherits OrbStack's default local-path StorageClass.
+  storageClass: ""
+  size: 1Gi
+
+# Kagent 0.9.12 is already installed in this cluster.
+kagent:
+  enabled: true
+  namespace: kagent
+  modelConfig: default-model-config

--- a/charts/k8s-dencer/ci/production-values.yaml
+++ b/charts/k8s-dencer/ci/production-values.yaml
@@ -1,0 +1,87 @@
+# Cloud-shaped profile. This is the portability gate: `make lint` renders it
+# and asserts the output contains an Ingress, a PVC, a PDB and an annotated
+# ServiceAccount, and contains no OrbStack, LoadBalancer, hostPath or KWOK
+# artifacts anywhere.
+
+serviceAccount:
+  create: true
+  annotations:
+    # EKS IRSA. The GKE equivalent would be iam.gke.io/gcp-service-account.
+    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/k8s-dencer
+
+imagePullSecrets:
+  - name: registry-credentials
+
+commonLabels:
+  app.kubernetes.io/env: production
+
+persistence:
+  enabled: true
+  storageClass: gp3
+  size: 10Gi
+  accessModes:
+    - ReadWriteOnce
+
+planner:
+  logLevel: info
+  resyncPeriod: 60s
+  resources:
+    requests:
+      cpu: 200m
+      memory: 512Mi
+    limits:
+      cpu: "2"
+      memory: 2Gi
+  priorityClassName: system-cluster-critical
+  tolerations:
+    - key: CriticalAddonsOnly
+      operator: Exists
+
+uiBackend:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi
+
+uiFrontend:
+  replicaCount: 3
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/component: ui-frontend
+  podDisruptionBudget:
+    enabled: true
+    maxUnavailable: 1
+
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - host: dencer.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: dencer-tls
+      hosts:
+        - dencer.example.com
+
+networkPolicy:
+  enabled: true
+
+serviceMonitor:
+  enabled: true
+  labels:
+    release: kube-prometheus-stack
+
+kagent:
+  enabled: true
+  namespace: kagent

--- a/charts/k8s-dencer/templates/NOTES.txt
+++ b/charts/k8s-dencer/templates/NOTES.txt
@@ -1,0 +1,36 @@
+k8s-dencer {{ .Chart.AppVersion }} installed as {{ .Release.Name }} in {{ .Release.Namespace }}.
+
+This release is READ-ONLY. It plans and explains node consolidation; it never
+cordons, drains or evicts. The ServiceAccount has no eviction permission.
+
+Reach the UI:
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}
+{{- end }}
+{{- else if eq .Values.uiFrontend.service.type "LoadBalancer" }}
+  kubectl get svc -n {{ .Release.Namespace }} {{ include "k8s-dencer.fullname" . }}-ui-frontend -w
+{{- else }}
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "k8s-dencer.fullname" . }}-ui-frontend 8080:{{ .Values.uiFrontend.service.port }}
+  open http://localhost:8080
+{{- end }}
+
+Verify the read-only guarantee:
+  kubectl auth can-i create pods/eviction \
+    --as=system:serviceaccount:{{ .Release.Namespace }}:{{ include "k8s-dencer.serviceAccountName" . }}
+  # must print: no
+
+{{ if eq .Values.database.type "sqlite" -}}
+Plan store: SQLite at {{ .Values.database.sqlite.path }}{{ if .Values.persistence.enabled }} on PVC {{ include "k8s-dencer.pvcName" . }}{{ else }} on an emptyDir (NOT durable — plan history is lost on restart){{ end }}.
+SQLite is single-writer, so ui-backend is pinned to one replica and the planner
+is co-scheduled with it. Switch database.type to postgres in Phase 2 to lift both.
+{{- end }}
+
+{{ if .Values.kagent.enabled -}}
+Kagent integration is on. Check it registered:
+  kubectl get remotemcpserver -n {{ include "k8s-dencer.kagentNamespace" . }} {{ include "k8s-dencer.fullname" . }}
+  kubectl get agent -n {{ include "k8s-dencer.kagentNamespace" . }} {{ include "k8s-dencer.fullname" . }}
+{{- else -}}
+Kagent integration is off. Enable with --set kagent.enabled=true (requires the
+kagent.dev CRDs to be installed already).
+{{- end }}

--- a/charts/k8s-dencer/templates/_helpers.tpl
+++ b/charts/k8s-dencer/templates/_helpers.tpl
@@ -1,0 +1,110 @@
+{{/*
+Chart name, overridable.
+*/}}
+{{- define "k8s-dencer.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Fully qualified release name, capped at 63 chars so component suffixes and
+generated label values stay valid.
+*/}}
+{{- define "k8s-dencer.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 50 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 50 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "k8s-dencer.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Labels shared by every object in the release.
+*/}}
+{{- define "k8s-dencer.labels" -}}
+helm.sh/chart: {{ include "k8s-dencer.chart" . }}
+{{ include "k8s-dencer.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: k8s-dencer
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{- define "k8s-dencer.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "k8s-dencer.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Per-component variants. Call with (dict "ctx" $ "component" "planner").
+Selector labels must never include chart version, or an upgrade would try to
+mutate the immutable Deployment selector.
+*/}}
+{{- define "k8s-dencer.componentSelectorLabels" -}}
+{{ include "k8s-dencer.selectorLabels" .ctx }}
+app.kubernetes.io/component: {{ .component }}
+{{- end }}
+
+{{- define "k8s-dencer.componentLabels" -}}
+{{ include "k8s-dencer.labels" .ctx }}
+app.kubernetes.io/component: {{ .component }}
+{{- end }}
+
+{{- define "k8s-dencer.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "k8s-dencer.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Image reference. Call with (dict "image" .Values.<component>.image "ctx" $).
+Tag falls back to the chart appVersion so a chart release pins a coherent set.
+*/}}
+{{- define "k8s-dencer.image" -}}
+{{- $tag := .image.tag | default .ctx.Chart.AppVersion -}}
+{{- if .image.registry -}}
+{{- printf "%s/%s:%s" .image.registry .image.repository $tag -}}
+{{- else -}}
+{{- printf "%s:%s" .image.repository $tag -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Name of the PVC backing the plan store.
+*/}}
+{{- define "k8s-dencer.pvcName" -}}
+{{- if .Values.persistence.existingClaim -}}
+{{- .Values.persistence.existingClaim -}}
+{{- else -}}
+{{- printf "%s-data" (include "k8s-dencer.fullname" .) -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Namespace hosting the Kagent resources.
+*/}}
+{{- define "k8s-dencer.kagentNamespace" -}}
+{{- default .Release.Namespace .Values.kagent.namespace -}}
+{{- end }}
+
+{{/*
+In-cluster URL of the ui-backend, used by the Kagent RemoteMCPServer. Fully
+qualified because the agent may live in a different namespace.
+*/}}
+{{- define "k8s-dencer.uiBackendURL" -}}
+{{- printf "http://%s-ui-backend.%s.svc:%v" (include "k8s-dencer.fullname" .) .Release.Namespace .Values.uiBackend.service.port -}}
+{{- end }}

--- a/charts/k8s-dencer/templates/ingress.yaml
+++ b/charts/k8s-dencer/templates/ingress.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.ingress.enabled }}
+{{/*
+All traffic goes to the frontend, which reverse-proxies /api to the backend.
+One route keeps cookies, CORS and WebSocket upgrades same-origin.
+*/}}
+{{- $fullName := include "k8s-dencer.fullname" . -}}
+{{- $svcPort := .Values.uiFrontend.service.port -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "k8s-dencer.labels" . | nindent 4 }}
+  {{- with (merge (dict) .Values.ingress.annotations .Values.commonAnnotations) }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ $fullName }}-ui-frontend
+                port:
+                  number: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/k8s-dencer/templates/kagent/agent.yaml
+++ b/charts/k8s-dencer/templates/kagent/agent.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.kagent.enabled }}
+apiVersion: kagent.dev/v1alpha2
+kind: Agent
+metadata:
+  name: {{ include "k8s-dencer.fullname" . }}
+  namespace: {{ include "k8s-dencer.kagentNamespace" . }}
+  labels:
+    {{- include "k8s-dencer.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: Declarative
+  description: Explains the k8s-dencer node consolidation plan and its impact ratings.
+  declarative:
+    modelConfig: {{ .Values.kagent.modelConfig }}
+    runtime: {{ .Values.kagent.runtime }}
+    systemMessage: |-
+      You explain the k8s-dencer node consolidation plan. You are an
+      explanation layer only: the planning itself is deterministic and happens
+      outside you, and there is no execution capability in this release.
+
+      # Instructions
+        - Answer strictly from the tools. Never guess at a rating, a
+          constraint, or a step number; if the tools do not say it, reply that
+          you do not have that information.
+        - When explaining why a step is rated Green, Yellow or Red, name the
+          specific constraint that drove the rating (a PDB and its headroom, a
+          topology spread rule, an anti-affinity rule) and quote the rationale
+          the classifier produced. Do not invent your own reasoning.
+        - When asked why a node is not being drained, check the plan steps and
+          the node's constraints before answering.
+        - You cannot drain, cordon, evict or modify anything. If asked to,
+          explain that this release is read-only by design and that execution
+          arrives in a later phase.
+
+      # Response format
+        - Format responses as Markdown.
+        - Lead with the direct answer, then the supporting constraint detail.
+    tools:
+      - type: McpServer
+        mcpServer:
+          apiGroup: kagent.dev
+          kind: RemoteMCPServer
+          name: {{ include "k8s-dencer.fullname" . }}
+          toolNames:
+            {{- toYaml .Values.kagent.toolNames | nindent 12 }}
+{{- end }}

--- a/charts/k8s-dencer/templates/kagent/remotemcpserver.yaml
+++ b/charts/k8s-dencer/templates/kagent/remotemcpserver.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.kagent.enabled }}
+{{/*
+Registers the ui-backend's read-only MCP endpoint with Kagent. Mirrors the
+kagent-tool-server pattern that ships with Kagent itself.
+*/}}
+apiVersion: kagent.dev/v1alpha2
+kind: RemoteMCPServer
+metadata:
+  name: {{ include "k8s-dencer.fullname" . }}
+  namespace: {{ include "k8s-dencer.kagentNamespace" . }}
+  labels:
+    {{- include "k8s-dencer.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  description: >-
+    Read-only access to the k8s-dencer plan store, constraint analyzer and
+    impact classifier.
+  protocol: STREAMABLE_HTTP
+  url: {{ printf "%s/mcp" (include "k8s-dencer.uiBackendURL" .) | quote }}
+{{- end }}

--- a/charts/k8s-dencer/templates/networkpolicy.yaml
+++ b/charts/k8s-dencer/templates/networkpolicy.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.networkPolicy.enabled }}
+{{/*
+Restricts who may reach ui-backend. The frontend always may; Kagent may when
+the integration is on, since the agent calls the MCP endpoint directly.
+Anything else must be listed in networkPolicy.extraIngressFrom.
+*/}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "k8s-dencer.fullname" . }}-ui-backend
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "k8s-dencer.componentLabels" (dict "ctx" . "component" "ui-backend") | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "k8s-dencer.componentSelectorLabels" (dict "ctx" . "component" "ui-backend") | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "k8s-dencer.componentSelectorLabels" (dict "ctx" . "component" "ui-frontend") | nindent 14 }}
+        {{- if .Values.kagent.enabled }}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ include "k8s-dencer.kagentNamespace" . }}
+        {{- end }}
+        {{- with .Values.networkPolicy.extraIngressFrom }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.uiBackend.service.port }}
+{{- end }}

--- a/charts/k8s-dencer/templates/pdb.yaml
+++ b/charts/k8s-dencer/templates/pdb.yaml
@@ -1,0 +1,34 @@
+{{/*
+PodDisruptionBudgets for our own components.
+
+These deliberately use maxUnavailable rather than minAvailable. A PDB that
+cannot be satisfied makes its pods undrainable, which is exactly the pathology
+k8s-dencer exists to detect — shipping one would be indefensible. maxUnavailable
+always leaves a node drain a way through.
+*/}}
+{{- $components := list
+  (dict "name" "planner"     "cfg" .Values.planner)
+  (dict "name" "ui-backend"  "cfg" .Values.uiBackend)
+  (dict "name" "ui-frontend" "cfg" .Values.uiFrontend)
+-}}
+{{- range $c := $components }}
+{{- if $c.cfg.podDisruptionBudget.enabled }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "k8s-dencer.fullname" $ }}-{{ $c.name }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "k8s-dencer.componentLabels" (dict "ctx" $ "component" $c.name) | nindent 4 }}
+  {{- with $.Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  maxUnavailable: {{ $c.cfg.podDisruptionBudget.maxUnavailable }}
+  selector:
+    matchLabels:
+      {{- include "k8s-dencer.componentSelectorLabels" (dict "ctx" $ "component" $c.name) | nindent 6 }}
+{{- end }}
+{{- end }}

--- a/charts/k8s-dencer/templates/planner/deployment.yaml
+++ b/charts/k8s-dencer/templates/planner/deployment.yaml
@@ -1,0 +1,145 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "k8s-dencer.fullname" . }}-planner
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "k8s-dencer.componentLabels" (dict "ctx" . "component" "planner") | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.planner.replicaCount }}
+  # The planner is a singleton writer; Recreate avoids two of them racing on
+  # the plan store during a rollout.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "k8s-dencer.componentSelectorLabels" (dict "ctx" . "component" "planner") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "k8s-dencer.componentLabels" (dict "ctx" . "component" "planner") | nindent 8 }}
+        {{- with .Values.planner.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with (merge (dict) .Values.planner.podAnnotations .Values.commonAnnotations) }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "k8s-dencer.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.planner.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: planner
+          image: {{ include "k8s-dencer.image" (dict "image" .Values.planner.image "ctx" .) | quote }}
+          imagePullPolicy: {{ .Values.planner.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          env:
+            - name: LOG_LEVEL
+              value: {{ .Values.planner.logLevel | quote }}
+            - name: RESYNC_PERIOD
+              value: {{ .Values.planner.resyncPeriod | quote }}
+            - name: HEALTH_ADDR
+              value: ":{{ .Values.planner.healthPort }}"
+            - name: DATABASE_TYPE
+              value: {{ .Values.database.type | quote }}
+            {{- if eq .Values.database.type "sqlite" }}
+            - name: DATABASE_PATH
+              value: {{ .Values.database.sqlite.path | quote }}
+            {{- end }}
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            {{- with .Values.planner.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: health
+              containerPort: {{ .Values.planner.healthPort }}
+              protocol: TCP
+          startupProbe:
+            httpGet:
+              path: /startupz
+              port: health
+            periodSeconds: 5
+            failureThreshold: 24
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: health
+            periodSeconds: 20
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: health
+            periodSeconds: 10
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.planner.resources | nindent 12 }}
+          volumeMounts:
+            # readOnlyRootFilesystem is on, so anything needing scratch space
+            # must be an explicit volume.
+            - name: tmp
+              mountPath: /tmp
+            - name: data
+              mountPath: {{ dir .Values.database.sqlite.path }}
+            {{- with .Values.planner.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: data
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "k8s-dencer.pvcName" . }}
+          {{- else }}
+          # Not durable: plan history is lost on restart. Acceptable only for
+          # ephemeral test installs.
+          emptyDir: {}
+          {{- end }}
+        {{- with .Values.planner.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.planner.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.planner.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.planner.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.planner.affinity }}
+      affinity:
+        {{- toYaml .Values.planner.affinity | nindent 8 }}
+      {{- else if and .Values.persistence.enabled (eq .Values.database.type "sqlite") }}
+      # SQLite lives on a ReadWriteOnce claim that both the planner and the
+      # ui-backend open. RWO permits multiple pods only on the same node, so
+      # they must be co-scheduled. This constraint disappears once
+      # database.type is postgres. Override planner.affinity to opt out.
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  {{- include "k8s-dencer.componentSelectorLabels" (dict "ctx" . "component" "ui-backend") | nindent 18 }}
+      {{- end }}

--- a/charts/k8s-dencer/templates/pvc.yaml
+++ b/charts/k8s-dencer/templates/pvc.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "k8s-dencer.pvcName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "k8s-dencer.labels" . | nindent 4 }}
+  annotations:
+    # Survives `helm uninstall`: losing plan history to a chart rollback would
+    # destroy the audit trail.
+    helm.sh/resource-policy: keep
+    {{- with (merge (dict) .Values.persistence.annotations .Values.commonAnnotations) }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/k8s-dencer/templates/rbac.yaml
+++ b/charts/k8s-dencer/templates/rbac.yaml
@@ -1,0 +1,63 @@
+{{- if .Values.rbac.create }}
+{{/*
+Read-only, cluster-scoped. Phase 1 has no executor, so there is deliberately no
+pods/eviction, no nodes patch (cordon), and no create/update/delete anywhere.
+When the executor lands in Phase 2 it gets its OWN ServiceAccount and Role
+rather than widening this one.
+*/}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "k8s-dencer.fullname" . }}-read
+  labels:
+    {{- include "k8s-dencer.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+rules:
+  - apiGroups: [""]
+    resources:
+      - nodes
+      - pods
+      - namespaces
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["policy"]
+    resources:
+      - poddisruptionbudgets
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources:
+      - deployments
+      - replicasets
+      - statefulsets
+      - daemonsets
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["dencer.io"]
+    resources:
+      - consolidationpolicies
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["dencer.io"]
+    resources:
+      - consolidationpolicies/status
+    verbs: ["get", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "k8s-dencer.fullname" . }}-read
+  labels:
+    {{- include "k8s-dencer.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "k8s-dencer.fullname" . }}-read
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "k8s-dencer.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/k8s-dencer/templates/serviceaccount.yaml
+++ b/charts/k8s-dencer/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "k8s-dencer.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "k8s-dencer.labels" . | nindent 4 }}
+  {{- with (merge (dict) .Values.serviceAccount.annotations .Values.commonAnnotations) }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+# The planner needs an API token to run informers, so this stays true. The
+# frontend uses a separate token-less pod spec setting instead.
+automountServiceAccountToken: true
+{{- end }}

--- a/charts/k8s-dencer/templates/servicemonitor.yaml
+++ b/charts/k8s-dencer/templates/servicemonitor.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.serviceMonitor.enabled }}
+{{/* Requires the Prometheus Operator CRDs; off by default for that reason. */}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "k8s-dencer.fullname" . }}-ui-backend
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "k8s-dencer.componentLabels" (dict "ctx" . "component" "ui-backend") | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "k8s-dencer.componentSelectorLabels" (dict "ctx" . "component" "ui-backend") | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: {{ .Values.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+{{- end }}

--- a/charts/k8s-dencer/templates/ui-backend/deployment.yaml
+++ b/charts/k8s-dencer/templates/ui-backend/deployment.yaml
@@ -1,0 +1,151 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "k8s-dencer.fullname" . }}-ui-backend
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "k8s-dencer.componentLabels" (dict "ctx" . "component" "ui-backend") | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.uiBackend.replicaCount }}
+  strategy:
+    {{- if eq .Values.database.type "sqlite" }}
+    # SQLite is a single-writer store on a ReadWriteOnce claim: a rolling
+    # update would briefly run two writers against one file.
+    type: Recreate
+    {{- else }}
+    type: RollingUpdate
+    {{- end }}
+  selector:
+    matchLabels:
+      {{- include "k8s-dencer.componentSelectorLabels" (dict "ctx" . "component" "ui-backend") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "k8s-dencer.componentLabels" (dict "ctx" . "component" "ui-backend") | nindent 8 }}
+        {{- with .Values.uiBackend.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with (merge (dict) .Values.uiBackend.podAnnotations .Values.commonAnnotations) }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "k8s-dencer.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.uiBackend.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: ui-backend
+          image: {{ include "k8s-dencer.image" (dict "image" .Values.uiBackend.image "ctx" .) | quote }}
+          imagePullPolicy: {{ .Values.uiBackend.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          env:
+            - name: LOG_LEVEL
+              value: {{ .Values.uiBackend.logLevel | quote }}
+            - name: HTTP_ADDR
+              value: ":{{ .Values.uiBackend.service.port }}"
+            - name: DATABASE_TYPE
+              value: {{ .Values.database.type | quote }}
+            {{- if eq .Values.database.type "sqlite" }}
+            - name: DATABASE_PATH
+              value: {{ .Values.database.sqlite.path | quote }}
+            {{- else }}
+            - name: POSTGRES_HOST
+              value: {{ .Values.database.postgres.host | quote }}
+            - name: POSTGRES_PORT
+              value: {{ .Values.database.postgres.port | quote }}
+            - name: POSTGRES_DATABASE
+              value: {{ .Values.database.postgres.database | quote }}
+            - name: POSTGRES_USER
+              value: {{ .Values.database.postgres.user | quote }}
+            - name: POSTGRES_SSLMODE
+              value: {{ .Values.database.postgres.sslMode | quote }}
+            {{- with .Values.database.postgres.existingSecret }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ . }}
+                  key: {{ $.Values.database.postgres.existingSecretPasswordKey }}
+            {{- end }}
+            {{- end }}
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            {{- with .Values.uiBackend.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.uiBackend.service.port }}
+              protocol: TCP
+          startupProbe:
+            httpGet:
+              path: /startupz
+              port: http
+            periodSeconds: 5
+            failureThreshold: 24
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            periodSeconds: 20
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            periodSeconds: 10
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.uiBackend.resources | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: data
+              mountPath: {{ dir .Values.database.sqlite.path }}
+            {{- with .Values.uiBackend.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: data
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "k8s-dencer.pvcName" . }}
+          {{- else }}
+          # Not durable: plan history is lost on restart. Acceptable only for
+          # ephemeral test installs.
+          emptyDir: {}
+          {{- end }}
+        {{- with .Values.uiBackend.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.uiBackend.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.uiBackend.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.uiBackend.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.uiBackend.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/k8s-dencer/templates/ui-backend/service.yaml
+++ b/charts/k8s-dencer/templates/ui-backend/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "k8s-dencer.fullname" . }}-ui-backend
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "k8s-dencer.componentLabels" (dict "ctx" . "component" "ui-backend") | nindent 4 }}
+  {{- with (merge (dict) .Values.uiBackend.service.annotations .Values.commonAnnotations) }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.uiBackend.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.uiBackend.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "k8s-dencer.componentSelectorLabels" (dict "ctx" . "component" "ui-backend") | nindent 4 }}

--- a/charts/k8s-dencer/templates/ui-frontend/configmap.yaml
+++ b/charts/k8s-dencer/templates/ui-frontend/configmap.yaml
@@ -1,0 +1,57 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "k8s-dencer.fullname" . }}-ui-frontend
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "k8s-dencer.componentLabels" (dict "ctx" . "component" "ui-frontend") | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+data:
+  # Injected into the browser at pod start. Keeping the API endpoint out of the
+  # bundle is what lets one image serve any cluster.
+  config.js: |
+    window.__DENCER_CONFIG__ = {
+      apiBaseUrl: {{ .Values.uiFrontend.config.apiBaseUrl | quote }},
+      kagentUrl: {{ .Values.uiFrontend.config.kagentUrl | quote }}
+    };
+
+  # Supplied as a ConfigMap rather than the image's envsubst entrypoint, which
+  # would need to write into /etc/nginx/conf.d — forbidden by
+  # readOnlyRootFilesystem.
+  default.conf: |
+    server {
+        listen 8080;
+        server_name _;
+
+        root /usr/share/nginx/html;
+        index index.html;
+
+        location = /config.js {
+            add_header Cache-Control "no-store" always;
+            try_files $uri =404;
+        }
+
+        location /api/ {
+            proxy_pass {{ include "k8s-dencer.uiBackendURL" . }};
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            # The plan view streams over a WebSocket from M6.
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_read_timeout 300s;
+        }
+
+        location /assets/ {
+            add_header Cache-Control "public, max-age=31536000, immutable" always;
+            try_files $uri =404;
+        }
+
+        location / {
+            try_files $uri $uri/ /index.html;
+        }
+    }

--- a/charts/k8s-dencer/templates/ui-frontend/deployment.yaml
+++ b/charts/k8s-dencer/templates/ui-frontend/deployment.yaml
@@ -1,0 +1,122 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "k8s-dencer.fullname" . }}-ui-frontend
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "k8s-dencer.componentLabels" (dict "ctx" . "component" "ui-frontend") | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.uiFrontend.replicaCount }}
+  strategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      {{- include "k8s-dencer.componentSelectorLabels" (dict "ctx" . "component" "ui-frontend") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "k8s-dencer.componentLabels" (dict "ctx" . "component" "ui-frontend") | nindent 8 }}
+        {{- with .Values.uiFrontend.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        # Rolls the pods when the nginx config or runtime config changes.
+        checksum/config: {{ include (print $.Template.BasePath "/ui-frontend/configmap.yaml") . | sha256sum }}
+        {{- with (merge (dict) .Values.uiFrontend.podAnnotations .Values.commonAnnotations) }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      # The frontend is a static file server and never talks to the API server.
+      automountServiceAccountToken: false
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.uiFrontend.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.uiFrontend.podSecurityContext | nindent 8 }}
+      containers:
+        - name: ui-frontend
+          image: {{ include "k8s-dencer.image" (dict "image" .Values.uiFrontend.image "ctx" .) | quote }}
+          imagePullPolicy: {{ .Values.uiFrontend.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.uiFrontend.securityContext | nindent 12 }}
+          {{- with .Values.uiFrontend.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          startupProbe:
+            httpGet:
+              path: /
+              port: http
+            periodSeconds: 3
+            failureThreshold: 20
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            periodSeconds: 20
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /index.html
+              port: http
+            periodSeconds: 10
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.uiFrontend.resources | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/nginx/conf.d/default.conf
+              subPath: default.conf
+              readOnly: true
+            - name: config
+              mountPath: /usr/share/nginx/html/config.js
+              subPath: config.js
+              readOnly: true
+            # nginx needs scratch space; readOnlyRootFilesystem means these
+            # must be explicit volumes.
+            - name: tmp
+              mountPath: /tmp
+            - name: cache
+              mountPath: /var/cache/nginx
+            {{- with .Values.uiFrontend.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "k8s-dencer.fullname" . }}-ui-frontend
+        - name: tmp
+          emptyDir: {}
+        - name: cache
+          emptyDir: {}
+        {{- with .Values.uiFrontend.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.uiFrontend.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.uiFrontend.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.uiFrontend.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.uiFrontend.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/k8s-dencer/templates/ui-frontend/service.yaml
+++ b/charts/k8s-dencer/templates/ui-frontend/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "k8s-dencer.fullname" . }}-ui-frontend
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "k8s-dencer.componentLabels" (dict "ctx" . "component" "ui-frontend") | nindent 4 }}
+  {{- with (merge (dict) .Values.uiFrontend.service.annotations .Values.commonAnnotations) }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.uiFrontend.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.uiFrontend.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "k8s-dencer.componentSelectorLabels" (dict "ctx" . "component" "ui-frontend") | nindent 4 }}

--- a/charts/k8s-dencer/values.schema.json
+++ b/charts/k8s-dencer/values.schema.json
@@ -1,0 +1,370 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "k8s-dencer values",
+  "type": "object",
+  "properties": {
+    "nameOverride": { "type": "string" },
+    "fullnameOverride": { "type": "string" },
+    "imagePullSecrets": { "type": "array", "items": { "type": "object" } },
+    "commonLabels": { "type": "object" },
+    "commonAnnotations": { "type": "object" },
+
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": { "type": "boolean" },
+        "name": { "type": "string" },
+        "annotations": { "type": "object" }
+      }
+    },
+
+    "rbac": {
+      "type": "object",
+      "properties": { "create": { "type": "boolean" } }
+    },
+
+    "database": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "Plan store backend. Only sqlite is implemented; the postgres Store lands in Phase 2, at which point this enum widens.",
+          "enum": ["sqlite"]
+        },
+        "sqlite": {
+          "type": "object",
+          "properties": {
+            "path": { "type": "string", "minLength": 1 }
+          }
+        },
+        "postgres": {
+          "type": "object",
+          "properties": {
+            "host": { "type": "string" },
+            "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+            "database": { "type": "string" },
+            "user": { "type": "string" },
+            "existingSecret": { "type": "string" },
+            "existingSecretPasswordKey": { "type": "string" },
+            "sslMode": {
+              "enum": ["disable", "allow", "prefer", "require", "verify-ca", "verify-full"]
+            }
+          }
+        }
+      }
+    },
+
+    "persistence": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "existingClaim": { "type": "string" },
+        "storageClass": {
+          "description": "Empty string inherits the cluster default StorageClass.",
+          "type": "string"
+        },
+        "accessModes": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "enum": ["ReadWriteOnce", "ReadWriteMany", "ReadWriteOncePod"] }
+        },
+        "size": { "type": "string", "pattern": "^[0-9]+(\\.[0-9]+)?(Ki|Mi|Gi|Ti|K|M|G|T)?$" },
+        "annotations": { "type": "object" }
+      }
+    },
+
+    "podSecurityContext": { "$ref": "#/definitions/podSecurityContext" },
+    "securityContext": { "$ref": "#/definitions/containerSecurityContext" },
+
+    "planner": {
+      "allOf": [
+        { "$ref": "#/definitions/schedulingCommon" },
+        {
+          "type": "object",
+          "properties": {
+            "replicaCount": {
+              "description": "The planner is a singleton writer against the plan store.",
+              "type": "integer",
+              "const": 1
+            },
+            "image": { "$ref": "#/definitions/image" },
+            "logLevel": { "$ref": "#/definitions/logLevel" },
+            "resyncPeriod": { "$ref": "#/definitions/duration" },
+            "healthPort": { "$ref": "#/definitions/port" },
+            "resources": { "$ref": "#/definitions/resources" },
+            "podDisruptionBudget": { "$ref": "#/definitions/pdb" }
+          }
+        }
+      ]
+    },
+
+    "uiBackend": {
+      "allOf": [
+        { "$ref": "#/definitions/schedulingCommon" },
+        {
+          "type": "object",
+          "properties": {
+            "replicaCount": { "type": "integer", "minimum": 1 },
+            "image": { "$ref": "#/definitions/image" },
+            "logLevel": { "$ref": "#/definitions/logLevel" },
+            "service": { "$ref": "#/definitions/service" },
+            "resources": { "$ref": "#/definitions/resources" },
+            "podDisruptionBudget": { "$ref": "#/definitions/pdb" }
+          }
+        }
+      ]
+    },
+
+    "uiFrontend": {
+      "allOf": [
+        { "$ref": "#/definitions/schedulingCommon" },
+        {
+          "type": "object",
+          "properties": {
+            "replicaCount": { "type": "integer", "minimum": 1 },
+            "image": { "$ref": "#/definitions/image" },
+            "service": { "$ref": "#/definitions/service" },
+            "config": {
+              "type": "object",
+              "properties": {
+                "apiBaseUrl": { "type": "string" },
+                "kagentUrl": { "type": "string" }
+              }
+            },
+            "podSecurityContext": { "$ref": "#/definitions/podSecurityContext" },
+            "securityContext": { "$ref": "#/definitions/containerSecurityContext" },
+            "resources": { "$ref": "#/definitions/resources" },
+            "podDisruptionBudget": { "$ref": "#/definitions/pdb" }
+          }
+        }
+      ]
+    },
+
+    "ingress": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "className": { "type": "string" },
+        "annotations": { "type": "object" },
+        "hosts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["host", "paths"],
+            "properties": {
+              "host": { "type": "string", "minLength": 1 },
+              "paths": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "type": "object",
+                  "required": ["path", "pathType"],
+                  "properties": {
+                    "path": { "type": "string", "minLength": 1 },
+                    "pathType": { "enum": ["Exact", "Prefix", "ImplementationSpecific"] }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tls": { "type": "array", "items": { "type": "object" } }
+      }
+    },
+
+    "networkPolicy": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "extraIngressFrom": { "type": "array", "items": { "type": "object" } }
+      }
+    },
+
+    "serviceMonitor": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "interval": { "$ref": "#/definitions/duration" },
+        "scrapeTimeout": { "$ref": "#/definitions/duration" },
+        "labels": { "type": "object" }
+      }
+    },
+
+    "kagent": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "namespace": { "type": "string" },
+        "modelConfig": { "type": "string", "minLength": 1 },
+        "runtime": { "enum": ["python", "declarative"] },
+        "toolNames": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    }
+  },
+
+  "allOf": [
+    {
+      "$comment": "SQLite is a single-writer store on a ReadWriteOnce claim. More than one ui-backend replica risks database corruption, so the chart refuses to render it rather than letting it be discovered in production.",
+      "if": {
+        "properties": {
+          "database": {
+            "type": "object",
+            "properties": { "type": { "const": "sqlite" } },
+            "required": ["type"]
+          }
+        },
+        "required": ["database"]
+      },
+      "then": {
+        "properties": {
+          "uiBackend": {
+            "type": "object",
+            "properties": {
+              "replicaCount": {
+                "$comment": "database.type=sqlite requires uiBackend.replicaCount=1",
+                "const": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "$comment": "An existingClaim is meaningless unless persistence is on; silently ignoring it would look like the claim was used.",
+      "if": {
+        "properties": {
+          "persistence": {
+            "type": "object",
+            "properties": { "enabled": { "const": false } },
+            "required": ["enabled"]
+          }
+        },
+        "required": ["persistence"]
+      },
+      "then": {
+        "properties": {
+          "persistence": {
+            "type": "object",
+            "properties": { "existingClaim": { "const": "" } }
+          }
+        }
+      }
+    }
+  ],
+
+  "definitions": {
+    "logLevel": { "enum": ["debug", "info", "warn", "error"] },
+
+    "duration": {
+      "type": "string",
+      "pattern": "^[0-9]+(\\.[0-9]+)?(ns|us|ms|s|m|h)$"
+    },
+
+    "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+
+    "image": {
+      "type": "object",
+      "properties": {
+        "registry": { "type": "string" },
+        "repository": { "type": "string", "minLength": 1 },
+        "tag": {
+          "description": "Empty defaults to the chart appVersion.",
+          "type": "string",
+          "not": { "const": "latest" }
+        },
+        "pullPolicy": {
+          "description": "Always is rejected: it makes rollouts depend on registry availability and defeats digest-stable deploys.",
+          "enum": ["IfNotPresent", "Never"]
+        }
+      },
+      "required": ["repository"]
+    },
+
+    "service": {
+      "type": "object",
+      "properties": {
+        "type": { "enum": ["ClusterIP", "NodePort", "LoadBalancer"] },
+        "port": { "$ref": "#/definitions/port" },
+        "annotations": { "type": "object" }
+      }
+    },
+
+    "resources": {
+      "type": "object",
+      "description": "Both requests and limits are required: an unbounded component on a shared cluster is not shippable.",
+      "required": ["requests", "limits"],
+      "properties": {
+        "requests": { "$ref": "#/definitions/resourceQuantities" },
+        "limits": { "$ref": "#/definitions/resourceQuantities" }
+      }
+    },
+
+    "resourceQuantities": {
+      "type": "object",
+      "required": ["cpu", "memory"],
+      "properties": {
+        "cpu": { "type": ["string", "number"] },
+        "memory": { "type": "string" }
+      }
+    },
+
+    "pdb": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "maxUnavailable": {
+          "description": "maxUnavailable only. A minAvailable PDB can make its own pods undrainable, which is the failure mode this product exists to detect.",
+          "type": ["integer", "string"]
+        }
+      }
+    },
+
+    "podSecurityContext": {
+      "type": "object",
+      "properties": {
+        "runAsNonRoot": { "const": true },
+        "runAsUser": { "type": "integer", "minimum": 1 },
+        "runAsGroup": { "type": "integer", "minimum": 1 },
+        "fsGroup": { "type": "integer", "minimum": 1 },
+        "seccompProfile": { "type": "object" }
+      }
+    },
+
+    "containerSecurityContext": {
+      "type": "object",
+      "properties": {
+        "readOnlyRootFilesystem": { "const": true },
+        "allowPrivilegeEscalation": { "const": false },
+        "privileged": { "const": false },
+        "capabilities": {
+          "type": "object",
+          "properties": {
+            "drop": {
+              "type": "array",
+              "contains": { "const": "ALL" }
+            }
+          }
+        }
+      }
+    },
+
+    "schedulingCommon": {
+      "type": "object",
+      "properties": {
+        "podAnnotations": { "type": "object" },
+        "podLabels": { "type": "object" },
+        "nodeSelector": { "type": "object" },
+        "tolerations": { "type": "array", "items": { "type": "object" } },
+        "affinity": { "type": "object" },
+        "topologySpreadConstraints": { "type": "array", "items": { "type": "object" } },
+        "priorityClassName": { "type": "string" },
+        "extraEnv": { "type": "array", "items": { "type": "object" } },
+        "extraVolumes": { "type": "array", "items": { "type": "object" } },
+        "extraVolumeMounts": { "type": "array", "items": { "type": "object" } }
+      }
+    }
+  }
+}

--- a/charts/k8s-dencer/values.yaml
+++ b/charts/k8s-dencer/values.yaml
@@ -1,0 +1,243 @@
+# Default values for k8s-dencer.
+#
+# These defaults are vendor-neutral and must stay installable on any conformant
+# cluster (EKS/GKE/AKS/on-prem). Local-development concerns belong in an
+# overlay under ci/, never here. `make lint` enforces this.
+
+nameOverride: ""
+fullnameOverride: ""
+
+# Applied to every pod in the release.
+imagePullSecrets: []
+commonLabels: {}
+commonAnnotations: {}
+
+serviceAccount:
+  create: true
+  # Defaults to the fullname when empty.
+  name: ""
+  # EKS IRSA / GKE Workload Identity annotations go here.
+  annotations: {}
+
+rbac:
+  # Creates the cluster-scoped read-only role the planner needs to observe
+  # nodes, pods and PDBs. Disable only if you manage RBAC out of band.
+  create: true
+
+# Plan Store backend.
+database:
+  # sqlite | postgres
+  #
+  # postgres is declared for Phase 2 and is NOT implemented yet; selecting it
+  # is rejected by values.schema.json. sqlite is single-writer, which is why
+  # uiBackend is pinned to one replica with a Recreate strategy.
+  type: sqlite
+  sqlite:
+    path: /data/dencer.db
+  postgres:
+    host: ""
+    port: 5432
+    database: dencer
+    user: dencer
+    existingSecret: ""
+    existingSecretPasswordKey: password
+    sslMode: require
+
+# PersistentVolumeClaim backing the SQLite plan store.
+persistence:
+  enabled: true
+  # Bind an existing claim instead of creating one.
+  existingClaim: ""
+  # Empty inherits the cluster's default StorageClass. Never hardcode one.
+  storageClass: ""
+  accessModes:
+    - ReadWriteOnce
+  size: 1Gi
+  annotations: {}
+
+# Pod-level security context, applied to all components. Defaults satisfy the
+# restricted Pod Security Standard without modification.
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  runAsGroup: 65532
+  fsGroup: 65532
+  seccompProfile:
+    type: RuntimeDefault
+
+# Container-level security context for the Go components.
+securityContext:
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  privileged: false
+  capabilities:
+    drop:
+      - ALL
+
+planner:
+  replicaCount: 1
+  image:
+    registry: ghcr.io
+    repository: atedgimo/k8s-dencer-planner
+    # Defaults to .Chart.AppVersion.
+    tag: ""
+    pullPolicy: IfNotPresent
+  logLevel: info
+  # How often the planner recomputes. A cluster-wide pod informer is the
+  # planner's dominant memory cost on a large cluster; raise this and the
+  # resource limits together when scaling up.
+  resyncPeriod: 30s
+  healthPort: 8081
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  podAnnotations: {}
+  podLabels: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  topologySpreadConstraints: []
+  priorityClassName: ""
+  extraEnv: []
+  extraVolumes: []
+  extraVolumeMounts: []
+  # Single-replica by design; a PDB here would either be a no-op or make the
+  # pod undrainable. See podDisruptionBudget below.
+  podDisruptionBudget:
+    enabled: false
+    maxUnavailable: 1
+
+uiBackend:
+  # Pinned to 1 while database.type is sqlite. Enforced by values.schema.json.
+  replicaCount: 1
+  image:
+    registry: ghcr.io
+    repository: atedgimo/k8s-dencer-ui-backend
+    tag: ""
+    pullPolicy: IfNotPresent
+  logLevel: info
+  service:
+    type: ClusterIP
+    port: 8080
+    annotations: {}
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  podAnnotations: {}
+  podLabels: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  topologySpreadConstraints: []
+  priorityClassName: ""
+  extraEnv: []
+  extraVolumes: []
+  extraVolumeMounts: []
+  podDisruptionBudget:
+    enabled: false
+    maxUnavailable: 1
+
+uiFrontend:
+  replicaCount: 2
+  image:
+    registry: ghcr.io
+    repository: atedgimo/k8s-dencer-ui-frontend
+    tag: ""
+    pullPolicy: IfNotPresent
+  service:
+    type: ClusterIP
+    port: 80
+    annotations: {}
+  # Injected into the browser at runtime via ConfigMap, so one image works
+  # against any backend. Empty apiBaseUrl means same-origin through nginx.
+  config:
+    apiBaseUrl: ""
+    # Deep link to the Kagent chat UI; empty hides the header link.
+    kagentUrl: ""
+  # nginx-unprivileged runs as uid 101 and cannot use the Go components'
+  # 65532, so the frontend overrides the shared pod security context.
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 101
+    runAsGroup: 101
+    fsGroup: 101
+    seccompProfile:
+      type: RuntimeDefault
+  securityContext:
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    privileged: false
+    capabilities:
+      drop:
+        - ALL
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi
+  podAnnotations: {}
+  podLabels: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  topologySpreadConstraints: []
+  priorityClassName: ""
+  extraEnv: []
+  extraVolumes: []
+  extraVolumeMounts: []
+  # maxUnavailable rather than minAvailable: a PDB that cannot be satisfied is
+  # precisely the pathology this product exists to find, so ours must never
+  # block a node drain.
+  podDisruptionBudget:
+    enabled: true
+    maxUnavailable: 1
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: k8s-dencer.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+networkPolicy:
+  # Restricts ui-backend ingress to the frontend and (when enabled) Kagent.
+  enabled: false
+  # Extra selectors allowed to reach ui-backend, e.g. a Prometheus namespace.
+  extraIngressFrom: []
+
+serviceMonitor:
+  # Requires the Prometheus Operator CRDs.
+  enabled: false
+  interval: 30s
+  scrapeTimeout: 10s
+  labels: {}
+
+# Kagent integration. Off by default so the chart installs on clusters that do
+# not have the kagent.dev CRDs.
+kagent:
+  enabled: false
+  # Defaults to the release namespace.
+  namespace: ""
+  modelConfig: default-model-config
+  runtime: python
+  # Tools exposed to the agent. Read-only by construction: the MVP has no
+  # executor, so there is nothing mutating to expose.
+  toolNames:
+    - list_plan_steps
+    - explain_step
+    - get_node_constraints
+    - why_not_drained

--- a/cmd/planner/main.go
+++ b/cmd/planner/main.go
@@ -1,0 +1,76 @@
+// Command planner runs the k8s-dencer consolidation planning loop.
+//
+// M0 scaffold: serves health probes and logs a heartbeat. The cluster state
+// collector, constraint analyzer, planner and impact classifier land in M2-M5.
+package main
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/atedgimo/k8s-dencer/internal/httpserver"
+	"github.com/atedgimo/k8s-dencer/internal/telemetry"
+)
+
+func main() {
+	log := telemetry.NewLogger("planner", env("LOG_LEVEL", "info"))
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	health := &httpserver.Health{}
+	mux := http.NewServeMux()
+	health.Register(mux)
+
+	// Nothing to warm up yet, so the planner is ready as soon as it is serving.
+	// From M2 this flips only once the informer cache has synced.
+	health.SetReady(true)
+
+	go heartbeat(ctx, log, duration(log, "RESYNC_PERIOD", 30*time.Second))
+
+	if err := httpserver.Run(ctx, log, env("HEALTH_ADDR", ":8081"), mux); err != nil {
+		log.Error("http server failed", "error", err)
+		os.Exit(1)
+	}
+	log.Info("planner stopped")
+}
+
+// heartbeat stands in for the planning loop until M4, so that a deployed
+// planner visibly does something on the interval the chart configures.
+func heartbeat(ctx context.Context, log *slog.Logger, every time.Duration) {
+	ticker := time.NewTicker(every)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			log.Info("planner loop tick (no-op: planner lands in M4)")
+		}
+	}
+}
+
+func env(key, fallback string) string {
+	if v, ok := os.LookupEnv(key); ok && v != "" {
+		return v
+	}
+	return fallback
+}
+
+func duration(log *slog.Logger, key string, fallback time.Duration) time.Duration {
+	raw, ok := os.LookupEnv(key)
+	if !ok || raw == "" {
+		return fallback
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		log.Warn("invalid duration, using default", "key", key, "value", raw, "default", fallback)
+		return fallback
+	}
+	return d
+}

--- a/cmd/ui-backend/main.go
+++ b/cmd/ui-backend/main.go
@@ -1,0 +1,59 @@
+// Command ui-backend serves the k8s-dencer REST/WebSocket API, the graph
+// payload for the frontend, and the read-only MCP tool surface consumed by the
+// Kagent agent.
+//
+// M0 scaffold: health probes plus a version endpoint. The API lands in M6 and
+// the MCP tools in M8.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/atedgimo/k8s-dencer/internal/httpserver"
+	"github.com/atedgimo/k8s-dencer/internal/telemetry"
+)
+
+// version is stamped at build time via -ldflags.
+var version = "dev"
+
+func main() {
+	log := telemetry.NewLogger("ui-backend", env("LOG_LEVEL", "info"))
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	health := &httpserver.Health{}
+	mux := http.NewServeMux()
+	health.Register(mux)
+
+	mux.HandleFunc("GET /api/v1/version", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"version":  version,
+			"database": env("DATABASE_TYPE", "sqlite"),
+		})
+	})
+
+	// From M6 this flips only after the store has opened and migrated.
+	health.SetReady(true)
+
+	log.Info("starting", "version", version, "database", env("DATABASE_TYPE", "sqlite"))
+
+	if err := httpserver.Run(ctx, log, env("HTTP_ADDR", ":8080"), mux); err != nil {
+		log.Error("http server failed", "error", err)
+		os.Exit(1)
+	}
+	log.Info("ui-backend stopped")
+}
+
+func env(key, fallback string) string {
+	if v, ok := os.LookupEnv(key); ok && v != "" {
+		return v
+	}
+	return fallback
+}

--- a/demo/charts/dencer-demo/Chart.yaml
+++ b/demo/charts/dencer-demo/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: dencer-demo
+description: |
+  Synthetic cluster topology for exercising the k8s-dencer planner: KWOK fake
+  nodes across three zones plus workloads shaped to trigger specific scheduling
+  constraints.
+
+  POC tooling only. This chart is never a dependency of charts/k8s-dencer and
+  is installed as a separate release so it can be torn down independently.
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+kubeVersion: ">=1.27.0-0"

--- a/demo/charts/dencer-demo/templates/NOTES.txt
+++ b/demo/charts/dencer-demo/templates/NOTES.txt
@@ -1,0 +1,40 @@
+Synthetic topology installed: scenario "{{ .Values.scenario }}"
+
+  {{ .Values.nodes.count }} fake nodes across {{ len .Values.nodes.zones }} zones ({{ join ", " .Values.nodes.zones }})
+  {{ .Values.nodes.capacity.cpu }} CPU / {{ .Values.nodes.capacity.memory }} each
+  {{ .Values.base.replicas }} filler pods at {{ .Values.base.resources.cpu }} CPU
+{{- if eq .Values.scenario "e-tainted-pool" }}
+  + {{ .Values.taintedPool.count }} dedicated nodes tainted {{ .Values.taintedPool.taint.key }}={{ .Values.taintedPool.taint.value }}
+{{- end }}
+
+What this scenario should provoke:
+{{- if eq .Values.scenario "a-fragmented" }}
+  Pure headroom, no constraints. The planner should collapse ~{{ .Values.nodes.count }} nodes
+  toward a third of that, and every step should rate Green.
+{{- else if eq .Values.scenario "b-pdb-blocked" }}
+  payments has minAvailable equal to its replica count: zero disruption
+  headroom, so steps touching it must rate Red and name the PDB. catalog has
+  two pods of headroom and should stay Green — the classifier has to tell the
+  two apart, not just detect that a PDB exists.
+{{- else if eq .Values.scenario "c-topology-spread" }}
+  frontend must stay within maxSkew 1 across the three zones. Any proposed
+  move that breaks the spread would be refused by the scheduler.
+{{- else if eq .Values.scenario "d-anti-affinity" }}
+  cache replicas cannot share a node, so each pins a node open regardless of
+  free capacity elsewhere. Ratings should name the anti-affinity rule.
+{{- else if eq .Values.scenario "e-tainted-pool" }}
+  The batch pool is reachable only with the dedicated toleration. General
+  workloads must never be packed onto it, and batch pods must never be moved
+  off it.
+{{- end }}
+
+Inspect:
+  kubectl get nodes -l type=kwok
+  kubectl get pods -n {{ .Release.Namespace }} -o wide
+
+Switch scenario:
+  make scenario S=<a-fragmented|b-pdb-blocked|c-topology-spread|d-anti-affinity|e-tainted-pool>
+
+NOTE: these Nodes are fake. No kubelet runs on them and no container in this
+release is ever executed — kwok-controller fabricates the lifecycle. Only the
+resource requests are real, and they are the planner's entire input.

--- a/demo/charts/dencer-demo/templates/_helpers.tpl
+++ b/demo/charts/dencer-demo/templates/_helpers.tpl
@@ -1,0 +1,50 @@
+{{- define "dencer-demo.labels" -}}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/part-of: dencer-demo
+dencer.io/synthetic: "true"
+{{- end }}
+
+{{/*
+Pins a workload to the KWOK fabric.
+
+Both halves are required: the nodeAffinity keeps synthetic pods off the one
+real node, and the toleration gets them past the taint that keeps real
+workloads (kagent, k8s-dencer itself) off the fake ones.
+*/}}
+{{- define "dencer-demo.nodeAffinity" -}}
+nodeAffinity:
+  requiredDuringSchedulingIgnoredDuringExecution:
+    nodeSelectorTerms:
+      - matchExpressions:
+          - key: type
+            operator: In
+            values:
+              - kwok
+{{- end }}
+
+{{- define "dencer-demo.tolerations" -}}
+tolerations:
+  - key: kwok.x-k8s.io/node
+    operator: Exists
+    effect: NoSchedule
+{{- end }}
+
+{{/*
+Standard container for a synthetic pod. Never executed — kwok-controller fakes
+the lifecycle — so only the resource requests carry meaning. Those requests are
+the entire input to the bin-packer, since this cluster has no metrics-server.
+
+Call with (dict "ctx" $ "cpu" "1" "memory" "2Gi").
+*/}}
+{{- define "dencer-demo.container" -}}
+- name: workload
+  image: {{ .ctx.Values.image }}
+  resources:
+    requests:
+      cpu: {{ .cpu | quote }}
+      memory: {{ .memory }}
+    limits:
+      cpu: {{ .cpu | quote }}
+      memory: {{ .memory }}
+{{- end }}

--- a/demo/charts/dencer-demo/templates/base-workload.yaml
+++ b/demo/charts/dencer-demo/templates/base-workload.yaml
@@ -1,0 +1,35 @@
+{{/*
+Unconstrained filler, deployed in every scenario.
+
+This is what makes the cluster consolidatable at all: ~37% requested spread
+thinly over every node. The default scheduler's LeastAllocated scoring spreads
+these out, producing exactly the fragmentation a bin-packer should collapse.
+Each scenario then adds a constraint that should change how the planner rates
+the steps touching it.
+*/}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-filler
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "dencer-demo.labels" . | nindent 4 }}
+    dencer.io/role: filler
+spec:
+  replicas: {{ .Values.base.replicas }}
+  selector:
+    matchLabels:
+      app: dencer-filler
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: dencer-filler
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        dencer.io/synthetic: "true"
+    spec:
+      affinity:
+        {{- include "dencer-demo.nodeAffinity" . | nindent 8 }}
+      {{- include "dencer-demo.tolerations" . | nindent 6 }}
+      containers:
+        {{- include "dencer-demo.container" (dict "ctx" . "cpu" .Values.base.resources.cpu "memory" .Values.base.resources.memory) | nindent 8 }}

--- a/demo/charts/dencer-demo/templates/nodes.yaml
+++ b/demo/charts/dencer-demo/templates/nodes.yaml
@@ -1,0 +1,103 @@
+{{/*
+Fake nodes.
+
+kwok-controller adopts any Node annotated kwok.x-k8s.io/node=fake and drives
+its lifecycle without a kubelet. The NoSchedule taint is the safety barrier
+that keeps real workloads on the real node; synthetic pods tolerate it
+explicitly via the dencer-demo.tolerations helper.
+
+Node status is set on create, which the API server honours for Nodes. On
+subsequent upgrades kwok-controller owns the status instead.
+*/}}
+{{- $zones := .Values.nodes.zones -}}
+{{- $zoneCount := len $zones -}}
+{{- $cap := .Values.nodes.capacity -}}
+{{- range $i := until (int .Values.nodes.count) }}
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: kwok-node-{{ $i }}
+  annotations:
+    kwok.x-k8s.io/node: fake
+    node.alpha.kubernetes.io/ttl: "0"
+  labels:
+    {{- include "dencer-demo.labels" $ | nindent 4 }}
+    type: kwok
+    kubernetes.io/hostname: kwok-node-{{ $i }}
+    kubernetes.io/os: linux
+    kubernetes.io/arch: {{ $.Values.nodes.arch }}
+    kubernetes.io/role: agent
+    node-role.kubernetes.io/agent: ""
+    topology.kubernetes.io/zone: {{ index $zones (mod $i $zoneCount) }}
+    topology.kubernetes.io/region: synthetic
+spec:
+  taints:
+    - key: kwok.x-k8s.io/node
+      value: fake
+      effect: NoSchedule
+status:
+  phase: Running
+  capacity:
+    cpu: {{ $cap.cpu | quote }}
+    memory: {{ $cap.memory }}
+    pods: {{ $cap.pods | quote }}
+  allocatable:
+    cpu: {{ $cap.cpu | quote }}
+    memory: {{ $cap.memory }}
+    pods: {{ $cap.pods | quote }}
+  nodeInfo:
+    architecture: {{ $.Values.nodes.arch }}
+    operatingSystem: linux
+    kubeletVersion: fake
+{{- end }}
+
+{{- if eq .Values.scenario "e-tainted-pool" }}
+{{/*
+Dedicated pool. Nothing without the matching toleration may land here, so the
+planner must neither drain batch pods onto general nodes nor pack general
+workloads onto this pool.
+*/}}
+{{- $t := .Values.taintedPool.taint -}}
+{{- range $i := until (int .Values.taintedPool.count) }}
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: kwok-pool-{{ $i }}
+  annotations:
+    kwok.x-k8s.io/node: fake
+    node.alpha.kubernetes.io/ttl: "0"
+  labels:
+    {{- include "dencer-demo.labels" $ | nindent 4 }}
+    type: kwok
+    pool: {{ $t.value }}
+    kubernetes.io/hostname: kwok-pool-{{ $i }}
+    kubernetes.io/os: linux
+    kubernetes.io/arch: {{ $.Values.nodes.arch }}
+    topology.kubernetes.io/zone: {{ index $.Values.nodes.zones (mod $i (len $.Values.nodes.zones)) }}
+    topology.kubernetes.io/region: synthetic
+spec:
+  taints:
+    - key: kwok.x-k8s.io/node
+      value: fake
+      effect: NoSchedule
+    - key: {{ $t.key }}
+      value: {{ $t.value }}
+      effect: NoSchedule
+status:
+  phase: Running
+  capacity:
+    cpu: {{ $.Values.nodes.capacity.cpu | quote }}
+    memory: {{ $.Values.nodes.capacity.memory }}
+    pods: {{ $.Values.nodes.capacity.pods | quote }}
+  allocatable:
+    cpu: {{ $.Values.nodes.capacity.cpu | quote }}
+    memory: {{ $.Values.nodes.capacity.memory }}
+    pods: {{ $.Values.nodes.capacity.pods | quote }}
+  nodeInfo:
+    architecture: {{ $.Values.nodes.arch }}
+    operatingSystem: linux
+    kubeletVersion: fake
+{{- end }}
+{{- end }}

--- a/demo/charts/dencer-demo/templates/scenario-b-pdb-blocked.yaml
+++ b/demo/charts/dencer-demo/templates/scenario-b-pdb-blocked.yaml
@@ -1,0 +1,88 @@
+{{- if eq .Values.scenario "b-pdb-blocked" }}
+{{/*
+Two PDBs with opposite headroom, so the impact classifier has to distinguish
+them rather than just detecting "a PDB exists".
+
+  payments  3 replicas, minAvailable 3  -> zero headroom, evicting any pod is
+                                           refused by the API server. Steps
+                                           touching it must rate Red.
+  catalog   3 replicas, minAvailable 1  -> two pods of headroom. Steps touching
+                                           it should stay Green.
+*/}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-payments
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "dencer-demo.labels" . | nindent 4 }}
+    dencer.io/role: pdb-blocked
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: dencer-payments
+  template:
+    metadata:
+      labels:
+        app: dencer-payments
+        dencer.io/synthetic: "true"
+    spec:
+      affinity:
+        {{- include "dencer-demo.nodeAffinity" . | nindent 8 }}
+      {{- include "dencer-demo.tolerations" . | nindent 6 }}
+      containers:
+        {{- include "dencer-demo.container" (dict "ctx" . "cpu" "1" "memory" "2Gi") | nindent 8 }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Release.Name }}-payments
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "dencer-demo.labels" . | nindent 4 }}
+spec:
+  # Equal to the replica count: no pod may ever be evicted voluntarily.
+  minAvailable: 3
+  selector:
+    matchLabels:
+      app: dencer-payments
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-catalog
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "dencer-demo.labels" . | nindent 4 }}
+    dencer.io/role: pdb-healthy
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: dencer-catalog
+  template:
+    metadata:
+      labels:
+        app: dencer-catalog
+        dencer.io/synthetic: "true"
+    spec:
+      affinity:
+        {{- include "dencer-demo.nodeAffinity" . | nindent 8 }}
+      {{- include "dencer-demo.tolerations" . | nindent 6 }}
+      containers:
+        {{- include "dencer-demo.container" (dict "ctx" . "cpu" "1" "memory" "2Gi") | nindent 8 }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Release.Name }}-catalog
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "dencer-demo.labels" . | nindent 4 }}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: dencer-catalog
+{{- end }}

--- a/demo/charts/dencer-demo/templates/scenario-c-topology-spread.yaml
+++ b/demo/charts/dencer-demo/templates/scenario-c-topology-spread.yaml
@@ -1,0 +1,42 @@
+{{- if eq .Values.scenario "c-topology-spread" }}
+{{/*
+Zone-spread workload with maxSkew 1 and DoNotSchedule.
+
+Any consolidation that moves these pods must keep the per-zone counts within 1
+of each other. A naive bin-packer that ignores topology will propose a packing
+the scheduler then refuses, which is exactly the failure the planner must not
+produce.
+*/}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-frontend
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "dencer-demo.labels" . | nindent 4 }}
+    dencer.io/role: topology-spread
+spec:
+  # Divisible by the three zones, so a correct plan keeps exactly 2 per zone.
+  replicas: 6
+  selector:
+    matchLabels:
+      app: dencer-frontend
+  template:
+    metadata:
+      labels:
+        app: dencer-frontend
+        dencer.io/synthetic: "true"
+    spec:
+      affinity:
+        {{- include "dencer-demo.nodeAffinity" . | nindent 8 }}
+      {{- include "dencer-demo.tolerations" . | nindent 6 }}
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              app: dencer-frontend
+      containers:
+        {{- include "dencer-demo.container" (dict "ctx" . "cpu" "1" "memory" "2Gi") | nindent 8 }}
+{{- end }}

--- a/demo/charts/dencer-demo/templates/scenario-d-anti-affinity.yaml
+++ b/demo/charts/dencer-demo/templates/scenario-d-anti-affinity.yaml
@@ -1,0 +1,41 @@
+{{- if eq .Values.scenario "d-anti-affinity" }}
+{{/*
+Required pod anti-affinity on hostname: no two replicas may share a node.
+
+These are the pods that block consolidation hardest — each one pins a node
+open, and no amount of free capacity elsewhere lets two of them merge. The
+planner must recognise that draining one of these nodes requires a node that
+holds no other replica, and the classifier should surface the anti-affinity
+rule by name rather than reporting a generic "cannot move".
+*/}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-cache
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "dencer-demo.labels" . | nindent 4 }}
+    dencer.io/role: anti-affinity
+spec:
+  replicas: 5
+  selector:
+    matchLabels:
+      app: dencer-cache
+  template:
+    metadata:
+      labels:
+        app: dencer-cache
+        dencer.io/synthetic: "true"
+    spec:
+      affinity:
+        {{- include "dencer-demo.nodeAffinity" . | nindent 8 }}
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  app: dencer-cache
+      {{- include "dencer-demo.tolerations" . | nindent 6 }}
+      containers:
+        {{- include "dencer-demo.container" (dict "ctx" . "cpu" "1" "memory" "2Gi") | nindent 8 }}
+{{- end }}

--- a/demo/charts/dencer-demo/templates/scenario-e-tainted-pool.yaml
+++ b/demo/charts/dencer-demo/templates/scenario-e-tainted-pool.yaml
@@ -1,0 +1,45 @@
+{{- if eq .Values.scenario "e-tainted-pool" }}
+{{/*
+Dedicated node pool.
+
+The batch workload tolerates the dedicated taint and selects the pool; nothing
+else can land there. Two things must hold in the plan: general workloads are
+never packed onto the pool (they lack the toleration), and batch pods are never
+moved off it onto general nodes (they would be evicted straight back).
+
+The pool is deliberately under-packed, so a planner that ignores taints will
+see attractive free capacity and propose an impossible move.
+*/}}
+{{- $t := .Values.taintedPool.taint -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-batch
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "dencer-demo.labels" . | nindent 4 }}
+    dencer.io/role: tainted-pool
+spec:
+  replicas: 4
+  selector:
+    matchLabels:
+      app: dencer-batch
+  template:
+    metadata:
+      labels:
+        app: dencer-batch
+        dencer.io/synthetic: "true"
+    spec:
+      nodeSelector:
+        pool: {{ $t.value }}
+      tolerations:
+        - key: kwok.x-k8s.io/node
+          operator: Exists
+          effect: NoSchedule
+        - key: {{ $t.key }}
+          value: {{ $t.value }}
+          operator: Equal
+          effect: NoSchedule
+      containers:
+        {{- include "dencer-demo.container" (dict "ctx" . "cpu" "1" "memory" "2Gi") | nindent 8 }}
+{{- end }}

--- a/demo/charts/dencer-demo/templates/validate.yaml
+++ b/demo/charts/dencer-demo/templates/validate.yaml
@@ -1,0 +1,9 @@
+{{/*
+Fail loudly on an unknown scenario. Without this a typo would silently install
+only the base workload, and the missing constraint would look like a planner
+bug rather than a values mistake.
+*/}}
+{{- $valid := list "a-fragmented" "b-pdb-blocked" "c-topology-spread" "d-anti-affinity" "e-tainted-pool" -}}
+{{- if not (has .Values.scenario $valid) -}}
+{{- fail (printf "unknown scenario %q; valid scenarios are: %s" .Values.scenario (join ", " $valid)) -}}
+{{- end -}}

--- a/demo/charts/dencer-demo/values.yaml
+++ b/demo/charts/dencer-demo/values.yaml
@@ -1,0 +1,50 @@
+# Synthetic topology for the k8s-dencer POC.
+#
+# Requires the upstream kwok + stage-fast charts (`make kwok-up`).
+
+# Which constraint scenario to layer on top of the base workload.
+#
+#   a-fragmented      no constraints; pure bin-packing headroom
+#   b-pdb-blocked     PDB with zero disruption headroom
+#   c-topology-spread maxSkew 1 across three zones
+#   d-anti-affinity   required pod anti-affinity singletons
+#   e-tainted-pool    dedicated tainted node pool
+#
+# The base workload is always deployed so every scenario has something to
+# consolidate; the scenario adds the constraint that should change the ratings.
+scenario: a-fragmented
+
+nodes:
+  # 30 fake nodes cost nothing to run (no kubelets) but give the bin-packer a
+  # problem worth solving. Each is deliberately larger than the real node.
+  count: 30
+  zones:
+    - zone-a
+    - zone-b
+    - zone-c
+  capacity:
+    cpu: "8"
+    memory: 32Gi
+    pods: "110"
+  # Fake nodes advertise the host architecture so scheduling predicates behave
+  # the same way they would on a real pool.
+  arch: arm64
+
+# Extra nodes carrying a dedicated taint, used only by scenario e.
+taintedPool:
+  count: 3
+  taint:
+    key: dedicated
+    value: batch
+
+base:
+  # 90 pods over 30 nodes at 1 CPU each is ~37% requested: fragmented enough
+  # that a bin-packer should collapse it to roughly a third of the nodes.
+  replicas: 90
+  resources:
+    cpu: "1"
+    memory: 2Gi
+
+# Pods are never executed: kwok-controller fakes their lifecycle, so this image
+# is never pulled. It exists only to make the podspec valid.
+image: registry.k8s.io/pause:3.9

--- a/demo/kwok-values.yaml
+++ b/demo/kwok-values.yaml
@@ -1,0 +1,20 @@
+# Values for the upstream kwok chart (kwok/kwok).
+#
+# kwok-controller fakes the kubelet for every Node annotated
+# kwok.x-k8s.io/node=fake: it marks them Ready and drives pod lifecycle on
+# them without running any containers. That is what lets a single-node laptop
+# cluster present the 30-node topology the planner needs.
+#
+# Installed by `make kwok-up`. The chart version is pinned in the Makefile.
+
+# The controller is the only real workload the fabric adds, so keep it small:
+# it must not distort the utilisation picture on the one real node.
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    cpu: 500m
+    memory: 256Mi
+
+replicas: 1

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/atedgimo/k8s-dencer
+
+go 1.26.5

--- a/hack/lint-chart.sh
+++ b/hack/lint-chart.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+#
+# Chart portability gate.
+#
+# Renders every values profile and asserts the contract from the plan: the
+# production profile must be free of any local-development artifact, the
+# minimal profile must still be a valid install, and the SQLite single-writer
+# guard must actually reject a multi-replica ui-backend.
+#
+# Run via `make lint`.
+
+set -euo pipefail
+
+CHART="${CHART:-charts/k8s-dencer}"
+KUBECONFORM="${KUBECONFORM:-kubeconform}"
+K8S_VERSION="${K8S_VERSION:-1.30.0}"
+
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+bold()  { printf '\033[1m%s\033[0m\n' "$*"; }
+
+fail() { red "FAIL: $*"; exit 1; }
+
+render() {
+  local profile="$1"
+  if [[ "$profile" == "defaults" ]]; then
+    helm template dencer "$CHART" --namespace k8s-dencer
+  else
+    helm template dencer "$CHART" --namespace k8s-dencer -f "$CHART/ci/${profile}-values.yaml"
+  fi
+}
+
+bold "==> helm lint"
+for profile in minimal production orbstack; do
+  helm lint "$CHART" -f "$CHART/ci/${profile}-values.yaml" >/dev/null \
+    || fail "helm lint failed for $profile"
+done
+helm lint "$CHART" >/dev/null || fail "helm lint failed for defaults"
+green "  all profiles lint clean"
+
+bold "==> render + kubeconform"
+for profile in defaults minimal production orbstack; do
+  # CRD-backed kinds (ServiceMonitor, kagent.dev/*) have no upstream schema, so
+  # they are skipped rather than failing the run.
+  render "$profile" | "$KUBECONFORM" \
+    -strict \
+    -summary \
+    -ignore-missing-schemas \
+    -kubernetes-version "$K8S_VERSION" \
+    >/dev/null || fail "kubeconform rejected profile: $profile"
+  green "  $profile validates"
+done
+
+bold "==> contract: production profile carries no local assumptions"
+prod="$(render production)"
+for forbidden in orbstack Orbstack OrbStack kwok KWOK hostPath 'type: LoadBalancer' 'imagePullPolicy: Always'; do
+  if grep -qi -- "$forbidden" <<<"$prod"; then
+    grep -in -- "$forbidden" <<<"$prod" | head -3
+    fail "production profile contains forbidden token: $forbidden"
+  fi
+done
+green "  no forbidden tokens"
+
+bold "==> contract: production profile renders the expected objects"
+for kind in "kind: Ingress" "kind: PersistentVolumeClaim" "kind: PodDisruptionBudget" "kind: NetworkPolicy" "kind: ServiceMonitor"; do
+  grep -q -- "$kind" <<<"$prod" || fail "production profile is missing $kind"
+done
+grep -q "eks.amazonaws.com/role-arn" <<<"$prod" \
+  || fail "production profile lost the ServiceAccount IRSA annotation"
+green "  Ingress, PVC, PDB, NetworkPolicy, ServiceMonitor and IRSA annotation all present"
+
+bold "==> contract: minimal profile is a valid restricted-PSS install"
+minimal="$(render minimal)"
+grep -q "runAsNonRoot: true" <<<"$minimal"          || fail "minimal profile lost runAsNonRoot"
+grep -q "readOnlyRootFilesystem: true" <<<"$minimal" || fail "minimal profile lost readOnlyRootFilesystem"
+grep -q "allowPrivilegeEscalation: false" <<<"$minimal" || fail "minimal profile lost allowPrivilegeEscalation"
+green "  restricted security context intact with all optionals off"
+
+bold "==> contract: no eviction permission anywhere (Phase 1 is read-only)"
+for profile in defaults minimal production orbstack; do
+  if render "$profile" | grep -q "pods/eviction"; then
+    fail "$profile grants pods/eviction; Phase 1 must be read-only"
+  fi
+done
+green "  no profile grants pods/eviction"
+
+bold "==> contract: SQLite guard rejects a second ui-backend replica"
+if helm template dencer "$CHART" \
+     --set database.type=sqlite \
+     --set uiBackend.replicaCount=2 >/dev/null 2>&1; then
+  fail "schema accepted uiBackend.replicaCount=2 with SQLite; it must be rejected"
+fi
+green "  rejected as expected"
+
+bold "==> contract: chart packages without the ci/ fixtures"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+helm package "$CHART" -d "$tmp" >/dev/null
+if tar -tzf "$tmp"/*.tgz | grep -q '/ci/'; then
+  fail "packaged chart ships the ci/ lint fixtures"
+fi
+green "  ci/ excluded from the package"
+
+green "
+All chart contract checks passed."

--- a/internal/httpserver/server.go
+++ b/internal/httpserver/server.go
@@ -1,0 +1,77 @@
+// Package httpserver provides the health-probe HTTP server shared by the
+// k8s-dencer components, along with graceful shutdown on SIGTERM.
+package httpserver
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"sync/atomic"
+	"time"
+)
+
+// Health tracks a component's readiness. Liveness is implicit: if the process
+// is serving, it is alive. Readiness is flipped by the component once its
+// dependencies (informer caches, database migrations) are satisfied.
+type Health struct {
+	ready atomic.Bool
+}
+
+// SetReady marks the component ready to serve traffic.
+func (h *Health) SetReady(ready bool) { h.ready.Store(ready) }
+
+// IsReady reports whether the component has declared itself ready.
+func (h *Health) IsReady() bool { return h.ready.Load() }
+
+// Register installs /healthz, /readyz and /startupz on mux.
+//
+// Startup and liveness share a handler on purpose: the kubelet uses the startup
+// probe to grant a longer grace period before liveness begins, so both need to
+// answer the same "is the process up" question.
+func (h *Health) Register(mux *http.ServeMux) {
+	alive := func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}
+	mux.HandleFunc("GET /healthz", alive)
+	mux.HandleFunc("GET /startupz", alive)
+	mux.HandleFunc("GET /readyz", func(w http.ResponseWriter, _ *http.Request) {
+		if !h.ready.Load() {
+			http.Error(w, "not ready", http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ready"))
+	})
+}
+
+// Run serves mux on addr until ctx is cancelled, then drains in-flight requests
+// within the shutdown grace period. It returns nil on a clean shutdown.
+func Run(ctx context.Context, log *slog.Logger, addr string, mux *http.ServeMux) error {
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		log.Info("http server listening", "addr", addr)
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errCh <- err
+			return
+		}
+		errCh <- nil
+	}()
+
+	select {
+	case err := <-errCh:
+		return err
+	case <-ctx.Done():
+		log.Info("shutdown signal received, draining")
+		shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 20*time.Second)
+		defer cancel()
+		return srv.Shutdown(shutdownCtx)
+	}
+}

--- a/internal/telemetry/logger.go
+++ b/internal/telemetry/logger.go
@@ -1,0 +1,29 @@
+// Package telemetry provides logging and observability wiring shared by all
+// k8s-dencer components.
+package telemetry
+
+import (
+	"log/slog"
+	"os"
+	"strings"
+)
+
+// NewLogger returns a structured JSON logger at the given level. Level strings
+// are matched case-insensitively; anything unrecognised falls back to info so a
+// typo in the chart's log level can never silence a component.
+func NewLogger(component, level string) *slog.Logger {
+	var lvl slog.Level
+	switch strings.ToLower(level) {
+	case "debug":
+		lvl = slog.LevelDebug
+	case "warn", "warning":
+		lvl = slog.LevelWarn
+	case "error":
+		lvl = slog.LevelError
+	default:
+		lvl = slog.LevelInfo
+	}
+
+	handler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: lvl})
+	return slog.New(handler).With("component", component)
+}

--- a/ui/index.html
+++ b/ui/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>k8s-dencer</title>
+    <!-- Runtime config, replaced by a ConfigMap mount in-cluster. Loaded
+         before the bundle so window.__DENCER_CONFIG__ is always defined. -->
+    <script src="/config.js"></script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/ui/nginx.conf
+++ b/ui/nginx.conf
@@ -1,0 +1,40 @@
+# Default server block baked into the image so `docker run` works standalone.
+#
+# In-cluster the chart mounts a ConfigMap over this file with the real backend
+# Service name templated in. A ConfigMap is used rather than the image's
+# envsubst entrypoint because that entrypoint writes into /etc/nginx/conf.d,
+# which readOnlyRootFilesystem forbids.
+
+server {
+    listen 8080;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Runtime config must never be cached: it is how a redeploy changes the
+    # API endpoint without rebuilding the image.
+    location = /config.js {
+        add_header Cache-Control "no-store" always;
+        try_files $uri =404;
+    }
+
+    location /api/ {
+        proxy_pass http://ui-backend:8080;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_read_timeout 300s;
+    }
+
+    # Hashed assets are immutable; the entry HTML is not.
+    location /assets/ {
+        add_header Cache-Control "public, max-age=31536000, immutable" always;
+        try_files $uri =404;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,0 +1,1888 @@
+{
+  "name": "k8s-dencer-ui",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "k8s-dencer-ui",
+      "version": "0.1.0",
+      "dependencies": {
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
+      },
+      "devDependencies": {
+        "@types/react": "^18.3.12",
+        "@types/react-dom": "^18.3.1",
+        "@vitejs/plugin-react": "^4.3.4",
+        "typescript": "^5.7.2",
+        "vite": "^6.0.5"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.31",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.1.tgz",
+      "integrity": "sha512-HYXq73DDpCtNzOmrFsm9eSwCvWCql0RzqjpDzXN9EadiLJ4DNat0nsZ/Bzmy+Ud12mb4/zKDY0cQ805ZzN+i0A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+      "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.44",
+        "caniuse-lite": "^1.0.30001806",
+        "electron-to-chromium": "^1.5.393",
+        "node-releases": "^2.0.51",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.396",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.396.tgz",
+      "integrity": "sha512-yHiw2Y3C3H9U6TMbOfoWK/BPreiOPXRfTWPBwQBoZG6/8TB6eOPnsy5oaRYuatR7Fw2SJ4kKforgufeo7fq0EQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "k8s-dencer-ui",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "typecheck": "tsc -b --noEmit"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "@vitejs/plugin-react": "^4.3.4",
+    "typescript": "^5.7.2",
+    "vite": "^6.0.5"
+  }
+}

--- a/ui/public/config.js
+++ b/ui/public/config.js
@@ -1,0 +1,10 @@
+// Default runtime configuration. In-cluster this file is replaced by a
+// ConfigMap mount, so the same image works against any backend without a
+// rebuild. Keep this a plain script, not a module: index.html loads it before
+// the bundle so the values are available at first render.
+window.__DENCER_CONFIG__ = {
+  // Same-origin by default: nginx proxies /api to the ui-backend Service.
+  apiBaseUrl: "",
+  // Deep link to the Kagent chat UI; empty hides the header link.
+  kagentUrl: "",
+};

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useState } from "react";
+import { runtimeConfig } from "./runtime-config";
+
+interface VersionInfo {
+  version: string;
+  database: string;
+}
+
+type Status =
+  | { state: "loading" }
+  | { state: "ok"; info: VersionInfo }
+  | { state: "error"; message: string };
+
+/**
+ * M0 placeholder. It deliberately calls the backend rather than rendering a
+ * static page: that makes deploying the chart a real end-to-end check of
+ * frontend -> nginx proxy -> ui-backend Service wiring.
+ *
+ * The graph canvas, step timeline and constraint inspector land in M7.
+ */
+export default function App() {
+  const { apiBaseUrl, kagentUrl } = runtimeConfig();
+  const [status, setStatus] = useState<Status>({ state: "loading" });
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    fetch(`${apiBaseUrl}/api/v1/version`, { signal: controller.signal })
+      .then(async (res) => {
+        if (!res.ok) {
+          throw new Error(`backend returned ${res.status}`);
+        }
+        return (await res.json()) as VersionInfo;
+      })
+      .then((info) => setStatus({ state: "ok", info }))
+      .catch((err: unknown) => {
+        if (controller.signal.aborted) return;
+        setStatus({
+          state: "error",
+          message: err instanceof Error ? err.message : String(err),
+        });
+      });
+
+    return () => controller.abort();
+  }, [apiBaseUrl]);
+
+  return (
+    <main className="shell">
+      <header className="header">
+        <div>
+          <h1>k8s-dencer</h1>
+          <p className="tagline">Node consolidation planning, explained.</p>
+        </div>
+        {kagentUrl && (
+          <a className="link" href={kagentUrl} target="_blank" rel="noreferrer">
+            Ask the agent →
+          </a>
+        )}
+      </header>
+
+      <section className="panel">
+        <h2>Backend</h2>
+        {status.state === "loading" && <p className="muted">Connecting…</p>}
+        {status.state === "ok" && (
+          <dl className="facts">
+            <dt>Status</dt>
+            <dd>
+              <span className="dot dot-ok" aria-hidden="true" />
+              Connected
+            </dd>
+            <dt>Version</dt>
+            <dd>{status.info.version}</dd>
+            <dt>Plan store</dt>
+            <dd>{status.info.database}</dd>
+          </dl>
+        )}
+        {status.state === "error" && (
+          <p className="error">
+            <span className="dot dot-err" aria-hidden="true" />
+            Cannot reach ui-backend: {status.message}
+          </p>
+        )}
+      </section>
+
+      <section className="panel">
+        <h2>Milestone</h2>
+        <p className="muted">
+          M0 — delivery skeleton. The relationship graph, step timeline and
+          constraint inspector arrive in M7.
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1,0 +1,141 @@
+/*
+ * Dark-first token set. M7 builds the real design system on these; keeping the
+ * names stable now avoids a rename pass later.
+ */
+:root {
+  --bg: #0e1116;
+  --surface: #161b22;
+  --border: #262c36;
+  --text: #e6edf3;
+  --text-muted: #8b949e;
+  --accent: #4f9cf9;
+  --ok: #3fb950;
+  --err: #f85149;
+
+  --radius: 10px;
+  --gap: 1rem;
+
+  color-scheme: dark light;
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --bg: #ffffff;
+    --surface: #f6f8fa;
+    --border: #d8dee4;
+    --text: #1f2328;
+    --text-muted: #59636e;
+    --accent: #0969da;
+    --ok: #1a7f37;
+    --err: #cf222e;
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+  line-height: 1.5;
+}
+
+.shell {
+  max-width: 60rem;
+  margin: 0 auto;
+  padding: 2.5rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--gap);
+}
+
+h1 {
+  margin: 0;
+  font-size: 1.6rem;
+  letter-spacing: -0.02em;
+}
+
+h2 {
+  margin: 0 0 0.75rem;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+}
+
+.tagline {
+  margin: 0.25rem 0 0;
+  color: var(--text-muted);
+}
+
+.link {
+  color: var(--accent);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.link:hover {
+  text-decoration: underline;
+}
+
+.panel {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1.25rem;
+}
+
+.facts {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.4rem 1.25rem;
+  margin: 0;
+}
+
+.facts dt {
+  color: var(--text-muted);
+}
+
+.facts dd {
+  margin: 0;
+  font-variant-numeric: tabular-nums;
+}
+
+.muted {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.error {
+  margin: 0;
+  color: var(--err);
+}
+
+/* Status is never conveyed by colour alone: the dot is paired with a label. */
+.dot {
+  display: inline-block;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  margin-right: 0.5rem;
+  vertical-align: middle;
+}
+
+.dot-ok {
+  background: var(--ok);
+}
+
+.dot-err {
+  background: var(--err);
+}

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -1,0 +1,15 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App";
+import "./index.css";
+
+const root = document.getElementById("root");
+if (!root) {
+  throw new Error("#root not found");
+}
+
+createRoot(root).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/ui/src/runtime-config.ts
+++ b/ui/src/runtime-config.ts
@@ -1,0 +1,25 @@
+export interface RuntimeConfig {
+  /** Base URL for the ui-backend API. Empty means same-origin via nginx. */
+  apiBaseUrl: string;
+  /** Deep link to the Kagent chat UI. Empty hides the header link. */
+  kagentUrl: string;
+}
+
+declare global {
+  interface Window {
+    __DENCER_CONFIG__?: Partial<RuntimeConfig>;
+  }
+}
+
+const defaults: RuntimeConfig = {
+  apiBaseUrl: "",
+  kagentUrl: "",
+};
+
+/**
+ * Reads configuration injected at pod start. Falls back to same-origin
+ * defaults so `npm run dev` works without a ConfigMap.
+ */
+export function runtimeConfig(): RuntimeConfig {
+  return { ...defaults, ...(window.__DENCER_CONFIG__ ?? {}) };
+}

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "allowImportingTsExtensions": true
+  },
+  "include": ["src"]
+}

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    outDir: "dist",
+    sourcemap: true,
+  },
+  server: {
+    port: 5173,
+    // Local dev proxies to a port-forwarded ui-backend; in-cluster the nginx
+    // config does this instead, so no API host is ever baked into the bundle.
+    proxy: {
+      "/api": "http://localhost:8080",
+    },
+  },
+});


### PR DESCRIPTION
Phase 1 of k8s-dencer is read-only: it plans and explains node consolidation and never cordons, drains or evicts. This PR lands the delivery mechanism and the test topology. The planner is still a heartbeat and the UI a placeholder — those arrive in M4 and M7.

## M0 — the chart as the product

The Helm chart must install on any conformant cluster, so it was built to that contract up front rather than retrofitted. Everything OrbStack-shaped is confined to a values overlay.

- Vendor-neutral defaults: `ClusterIP` + optional Ingress, restricted-PSS security contexts, per-component resources/probes/scheduling knobs, `serviceAccount.annotations` for IRSA and Workload Identity, configurable persistence, `kubeVersion` floor.
- `values.schema.json` enforcing the surface, including a guard rejecting `uiBackend.replicaCount > 1` while the store is SQLite.
- Four values profiles: defaults / minimal / production / orbstack.
- `hack/lint-chart.sh` portability gate — `helm lint` + `kubeconform --strict` across every profile, then asserts the production profile carries no local assumptions and **no profile ever grants `pods/eviction`**.
- `Dockerfile.go` parameterised by `COMPONENT` so planner and ui-backend cannot drift in base image or hardening. Both land on distroless static nonroot (~15MB).

## M1 — synthetic topology

A consolidation planner cannot be tested on a single node, so KWOK provides 30 fake nodes with no kubelet while the real scheduler, PDB accounting and eviction API still apply.

- `demo/charts/dencer-demo` renders the nodes across three zones plus constraint-shaped workloads. Separate release; the product chart never references it.
- Five scenarios, all verified live: fragmented, pdb-blocked, topology-spread, anti-affinity, tainted-pool. The base filler workload deploys in every scenario so there is always something to consolidate.

## Verified

```
30 fake nodes Ready (10 per zone)   90 filler pods across 22 nodes
real node runs only real workloads  make lint: all contract checks pass
kubectl auth can-i create pods/eviction --as=…:k8s-dencer  ->  no
```

Constraint enforcement is genuinely real — evicting a pod behind a `minAvailable: 3` of 3 PDB is refused with `TooManyRequests`, while a 1-of-3 PDB permits it. On fake nodes.

## Two upstream facts, both found by hitting them

- KWOK's documented OCI coordinates (`oci://registry.k8s.io/kwok/charts/*`) publish **no tags**; the classic repo is used instead.
- `docker buildx` cannot `--load` a multi-platform build, so `make images` is native-arch for the dev loop and `make images-release` is multi-arch.

## Reviewer notes

- Single commit: the Makefile spans both milestones, so splitting would leave a non-building intermediate commit.
- SQLite forces two coupled constraints — `replicaCount: 1` and a `requiredDuringScheduling` podAffinity co-scheduling planner with ui-backend, since a ReadWriteOnce claim only permits multiple pods on one node. Both disappear when the Postgres store lands.
- PDBs on our own components use `maxUnavailable`, never `minAvailable`: a `minAvailable` PDB on a single-replica Deployment makes its own pod undrainable, which is the exact pathology this product detects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)