### PR TITLE
M3: constraint analyzer and placement evaluator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -236,15 +236,42 @@ kwok-down: ## Remove the KWOK fabric
 	-helm uninstall kwok-stage-fast --namespace $(KWOK_NAMESPACE)
 	-helm uninstall kwok --namespace $(KWOK_NAMESPACE)
 
+# No --wait on the demo chart. Deployment readiness is not a meaningful gate
+# here: kwok-controller fabricates pod readiness with podPlayStageParallelism 4,
+# and its pod-ready Stage only selects pods still in phase Pending. A pod that
+# reaches Running without Ready=True never re-matches the stage and stays
+# not-ready forever, so --wait turns a cosmetic fabric quirk into a failed
+# install. Use `make demo-wait` to block on pods being *scheduled*, which is
+# what the planner actually cares about.
 .PHONY: demo-up
 demo-up: ## Install the synthetic topology (SCENARIO=a-fragmented)
 	helm upgrade --install $(DEMO_RELEASE) demo/charts/dencer-demo \
 		--namespace $(DEMO_NAMESPACE) --create-namespace \
-		--set scenario=$(SCENARIO) --wait --timeout 3m
+		--set scenario=$(SCENARIO)
 
+.PHONY: demo-wait
+demo-wait: ## Block until every demo pod is scheduled onto a node
+	@echo "==> waiting for demo pods to be scheduled"
+	@for i in $$(seq 1 60); do \
+		unscheduled=$$(kubectl get pods -n $(DEMO_NAMESPACE) \
+			--field-selector spec.nodeName= --no-headers 2>/dev/null | wc -l | tr -d ' '); \
+		total=$$(kubectl get pods -n $(DEMO_NAMESPACE) --no-headers 2>/dev/null | wc -l | tr -d ' '); \
+		if [ "$$unscheduled" = "0" ] && [ "$$total" != "0" ]; then \
+			echo "    $$total pods scheduled"; exit 0; \
+		fi; \
+		sleep 2; \
+	done; \
+	echo "    timed out with $$unscheduled pod(s) unscheduled"; exit 1
+
+# Deletes the namespace as well as the release. A failed `helm upgrade` can
+# leave resources behind that are no longer in the release manifest, and
+# `helm uninstall` will not touch those orphans — they then show up as
+# workloads from a scenario that is supposedly not active.
 .PHONY: demo-down
 demo-down: ## Remove the synthetic topology (deletes the fake nodes)
 	-helm uninstall $(DEMO_RELEASE) --namespace $(DEMO_NAMESPACE)
+	-kubectl delete namespace $(DEMO_NAMESPACE) --wait=false
+	-kubectl delete nodes -l dencer.io/synthetic=true --wait=false
 
 .PHONY: scenario
 scenario: ## Switch scenario: make scenario S=b-pdb-blocked
@@ -254,7 +281,8 @@ scenario: ## Switch scenario: make scenario S=b-pdb-blocked
 	fi
 	helm upgrade --install $(DEMO_RELEASE) demo/charts/dencer-demo \
 		--namespace $(DEMO_NAMESPACE) --create-namespace \
-		--set scenario=$(S) --wait --timeout 3m
+		--set scenario=$(S)
+	@$(MAKE) --no-print-directory demo-wait
 
 .PHONY: demo
 demo: kwok-up demo-up images images-load deploy ## Full POC: fabric + topology + product

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Phase 1 (MVP) — visibility and explainability. No execution capability.
 | **M0** | Helm chart to full production contract, three images, delivery skeleton | **done** |
 | **M1** | KWOK fake-node fabric + five constraint scenarios as Helm releases | **done** |
 | **M2** | Domain model + informer-backed cluster state collector | **done** |
-| M3 | Constraint analyzer (PDB headroom, topology, affinity, taints) | next |
-| M4 | Consolidation planner (greedy first-fit-decreasing) | pending |
+| **M3** | Constraint analyzer + placement feasibility evaluator | **done** |
+| M4 | Consolidation planner (greedy first-fit-decreasing) | next |
 | M5 | Impact classifier (Green/Yellow/Red + rationale) | pending |
 | M6 | Plan store (SQLite) + REST/WS API + graph payload | pending |
 | M7 | UI: before/after canvas, step timeline scrubber, constraint inspector | pending |
@@ -32,13 +32,18 @@ The planner watches the cluster through informers and publishes an immutable
 `ClusterSnapshot` every resync period:
 
 ```
-snapshot: nodes=31 nodesOccupied=22 pods=117 pdbs=2 pdbsBlocking=1
-          cpuRequestedPct=37.0% memRequestedPct=18.8% usageData=false
+snapshot:    nodes=31 nodesOccupied=22 pods=117 pdbs=2 pdbsBlocking=1
+             cpuRequestedPct=37.0% memRequestedPct=18.8% usageData=false
+constraints: movable=118 blocked=4 stuck=25 pdbBlocked=3 antiAffinity=0
+             spreadBound=1 controllerPinned=1 nodesUndrainable=4
 ```
 
 Nothing yet *plans* against those snapshots — the bin-packer is M4 — and the UI
 is still a placeholder that only verifies backend connectivity. The plan store
 and API are M6.
+
+Two debug endpoints on the planner's health port expose the current state as
+YAML: `/debug/snapshot` and `/debug/constraints`.
 
 ---
 
@@ -64,7 +69,7 @@ cmd/               planner, ui-backend — one dir per shipped image
 internal/
   model/           domain types; NO k8s imports, so the planner is testable from a YAML snapshot
   cluster/         informer-backed collector, k8s->model conversion, MetricsSource
-  constraints/     PDB / topology / affinity / taint analysis
+  constraints/     effective per-pod constraints + explanations; placement feasibility
   planner/         Strategy interface + greedy bin-packing
   impact/          Green/Yellow/Red classifier + rationale
   store/           Store interface, sqlite/, migrations/
@@ -171,6 +176,24 @@ Two conversion details are worth knowing, since both are easy to get subtly wron
 
 - **Effective requests** follow Kubernetes' own rule — per resource, the greater of the summed app-container requests and the largest init container, plus pod overhead, with sidecars (init containers with `restartPolicy: Always`) added rather than maxed.
 - **PDB headroom comes from `status.disruptionsAllowed`, not `spec.minAvailable`.** The spec says what was asked for; the status says what the API server will actually permit right now. That difference is what separates "a PDB exists" from "this drain will be refused".
+
+## Constraints and explanations
+
+`internal/constraints` derives the effective constraint set for every pod — PDB membership and live headroom, topology spread, node and pod affinity, taints and tolerations, resource requests — and answers `NodeDrainable(node)` for the planner.
+
+**Every explanation string is produced once, here.** The UI's constraint inspector and the Kagent agent both surface these exact strings rather than deriving their own, so the two can never disagree about why a pod cannot move. Explanations name the object responsible and include live numbers, because *"a PDB blocks this"* is not an explanation:
+
+```
+PodDisruptionBudget dencer-demo/dencer-demo-payments currently allows 0
+disruptions (3 healthy, 3 required). The API server will refuse to evict this pod.
+
+PodDisruptionBudget dencer-demo/dencer-demo-catalog allows 2 more concurrent
+disruption(s) (3 healthy, 1 required).
+```
+
+The same package holds `Placement`, the feasibility evaluator — taints, node selector, node affinity, resources, pod affinity/anti-affinity across topology domains, and hard topology spread. It lives here rather than in the packer so that the analyzer's explanations and the planner's decisions come from the same code; an explanation that disagrees with the plan is worse than none.
+
+Only **hard** constraints affect feasibility. A `ScheduleAnyway` spread constraint or a preferred affinity is recorded and explained but never reported as a blocker — treating a preference as a blocker would make the planner refuse moves the scheduler allows.
 
 ## Kagent
 

--- a/cmd/planner/main.go
+++ b/cmd/planner/main.go
@@ -21,6 +21,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/atedgimo/k8s-dencer/internal/cluster"
+	"github.com/atedgimo/k8s-dencer/internal/constraints"
 	"github.com/atedgimo/k8s-dencer/internal/httpserver"
 	"github.com/atedgimo/k8s-dencer/internal/model"
 	"github.com/atedgimo/k8s-dencer/internal/telemetry"
@@ -61,11 +62,23 @@ func run(ctx context.Context, log *slog.Logger) error {
 	}
 
 	var latest atomic.Pointer[model.ClusterSnapshot]
+	var latestAnalysis atomic.Pointer[constraints.Analysis]
 
 	health := &httpserver.Health{}
 	mux := http.NewServeMux()
 	health.Register(mux)
-	mux.HandleFunc("GET /debug/snapshot", snapshotHandler(&latest))
+	mux.HandleFunc("GET /debug/snapshot", yamlHandler(func() any {
+		if v := latest.Load(); v != nil {
+			return v
+		}
+		return nil
+	}))
+	mux.HandleFunc("GET /debug/constraints", yamlHandler(func() any {
+		if v := latestAnalysis.Load(); v != nil {
+			return v
+		}
+		return nil
+	}))
 
 	// Informers run for the process lifetime; a cache failure is fatal because
 	// planning against a dead cache would silently use stale state.
@@ -89,7 +102,7 @@ func run(ctx context.Context, log *slog.Logger) error {
 	ticker := time.NewTicker(resync)
 	defer ticker.Stop()
 
-	collect(ctx, log, collector, &latest)
+	collect(ctx, log, collector, &latest, &latestAnalysis)
 
 	for {
 		select {
@@ -100,12 +113,18 @@ func run(ctx context.Context, log *slog.Logger) error {
 		case err := <-serveErr:
 			return err
 		case <-ticker.C:
-			collect(ctx, log, collector, &latest)
+			collect(ctx, log, collector, &latest, &latestAnalysis)
 		}
 	}
 }
 
-func collect(ctx context.Context, log *slog.Logger, c *cluster.Collector, latest *atomic.Pointer[model.ClusterSnapshot]) {
+func collect(
+	ctx context.Context,
+	log *slog.Logger,
+	c *cluster.Collector,
+	latest *atomic.Pointer[model.ClusterSnapshot],
+	latestAnalysis *atomic.Pointer[constraints.Analysis],
+) {
 	snap, err := c.Snapshot(ctx)
 	if err != nil {
 		log.Error("snapshot failed", "error", err)
@@ -141,21 +160,43 @@ func collect(ctx context.Context, log *slog.Logger, c *cluster.Collector, latest
 		"podSlotsUsedPct", pct(pods),
 		"usageData", snap.HasUsageData,
 	)
+
+	analysis := constraints.Analyze(snap)
+	latestAnalysis.Store(analysis)
+
+	cs := analysis.Summarize()
+	undrainable := 0
+	for _, n := range snap.Nodes {
+		if drainable, _ := analysis.NodeDrainable(n.Name); !drainable {
+			undrainable++
+		}
+	}
+
+	log.Info("constraints",
+		"movable", cs.Movable,
+		"blocked", cs.Blocked,
+		"stuck", cs.Stuck,
+		"pdbBlocked", cs.PDBBlocked,
+		"antiAffinity", cs.AntiAffinity,
+		"spreadBound", cs.SpreadBound,
+		"controllerPinned", cs.ControllerPin,
+		"nodesUndrainable", undrainable,
+	)
 }
 
-// snapshotHandler serves the latest snapshot as YAML.
+// yamlHandler serves whatever load returns, as YAML.
 //
 // This is how test/fixtures are captured: the golden planner tests replay real
 // cluster state, so the fixtures must come from a real cluster rather than
 // being written by hand.
-func snapshotHandler(latest *atomic.Pointer[model.ClusterSnapshot]) http.HandlerFunc {
+func yamlHandler(load func() any) http.HandlerFunc {
 	return func(w http.ResponseWriter, _ *http.Request) {
-		snap := latest.Load()
-		if snap == nil {
-			http.Error(w, "no snapshot taken yet", http.StatusServiceUnavailable)
+		v := load()
+		if v == nil {
+			http.Error(w, "nothing collected yet", http.StatusServiceUnavailable)
 			return
 		}
-		out, err := yaml.Marshal(snap)
+		out, err := yaml.Marshal(v)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/internal/constraints/analyzer.go
+++ b/internal/constraints/analyzer.go
@@ -1,0 +1,380 @@
+package constraints
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/atedgimo/k8s-dencer/internal/model"
+)
+
+// Analyze derives the effective constraint set for every pod in the snapshot.
+//
+// Explanations are written here once and consumed verbatim downstream. They
+// name the specific object responsible and include the live numbers, because
+// "a PDB blocks this" is not an explanation — "PodDisruptionBudget
+// dencer-demo/payments currently allows 0 disruptions (3 healthy, 3 required)"
+// is.
+func Analyze(snap *model.ClusterSnapshot) *Analysis {
+	placement := NewPlacement(snap)
+	pdbIndex := indexPDBs(snap)
+
+	analysis := &Analysis{
+		TakenAt: snap.TakenAt,
+		Pods:    make([]PodConstraints, 0, len(snap.Pods)),
+	}
+
+	for _, pod := range snap.Pods {
+		analysis.Pods = append(analysis.Pods, analyzePod(pod, snap, placement, pdbIndex))
+	}
+
+	// Sorted so the output is stable regardless of the order the informer
+	// cache happened to list pods in.
+	sort.Slice(analysis.Pods, func(i, j int) bool {
+		return analysis.Pods[i].Key() < analysis.Pods[j].Key()
+	})
+	analysis.index = make(map[string]int, len(analysis.Pods))
+	for i, pc := range analysis.Pods {
+		analysis.index[pc.Key()] = i
+	}
+	return analysis
+}
+
+func analyzePod(pod model.Pod, snap *model.ClusterSnapshot, placement *Placement, pdbIndex map[string][]model.PodDisruptionBudget) PodConstraints {
+	pc := PodConstraints{
+		Namespace: pod.Namespace,
+		Name:      pod.Name,
+		NodeName:  pod.NodeName,
+		Movable:   pod.IsMovable(),
+	}
+
+	// Controller pinning comes first: if the pod cannot move at all, the rest
+	// of the constraint set is context rather than explanation.
+	if pod.Owner != nil && pod.Owner.Kind == "DaemonSet" {
+		pc.Constraints = append(pc.Constraints, Constraint{
+			Kind:     KindControllerPinned,
+			Subject:  pod.Owner.Kind + "/" + pod.Owner.Name,
+			Hard:     true,
+			Blocking: true,
+			Explanation: fmt.Sprintf(
+				"Managed by DaemonSet %s, so it is pinned to node %s. Draining the node does not free this pod's capacity — it is recreated there.",
+				pod.Owner.Name, pod.NodeName),
+		})
+	}
+	if pod.Terminating {
+		pc.Constraints = append(pc.Constraints, Constraint{
+			Kind:        KindControllerPinned,
+			Hard:        true,
+			Blocking:    true,
+			Explanation: "Pod is already terminating.",
+		})
+	}
+
+	pc.Constraints = append(pc.Constraints, pdbConstraints(pod, pdbIndex)...)
+	pc.Constraints = append(pc.Constraints, resourceConstraint(pod, snap, placement))
+
+	if c, ok := nodeSelectorConstraint(pod, snap); ok {
+		pc.Constraints = append(pc.Constraints, c)
+	}
+	if c, ok := nodeAffinityConstraint(pod, snap); ok {
+		pc.Constraints = append(pc.Constraints, c)
+	}
+	pc.Constraints = append(pc.Constraints, podAffinityConstraints(pod)...)
+	pc.Constraints = append(pc.Constraints, topologySpreadConstraints(pod, snap)...)
+	if c, ok := taintToleranceConstraint(pod, snap); ok {
+		pc.Constraints = append(pc.Constraints, c)
+	}
+	if pod.HasPersistentVol {
+		pc.Constraints = append(pc.Constraints, Constraint{
+			Kind:        KindPersistentVolume,
+			Hard:        false,
+			Blocking:    false,
+			Explanation: "Uses a PersistentVolumeClaim. Depending on the volume's topology it may not be able to follow the pod to another node.",
+		})
+	}
+
+	// A pod already blocked from eviction has no candidate nodes worth
+	// computing, and skipping the scan keeps the analysis cheap on large
+	// clusters.
+	for _, c := range pc.Constraints {
+		if c.Blocking {
+			pc.Movable = false
+		}
+	}
+	if pc.Movable {
+		pc.CandidateNodes = placement.CandidateNodes(pod)
+	}
+
+	return pc
+}
+
+// pdbConstraints reports every PDB covering the pod. Both the blocking and the
+// healthy case are recorded: the classifier needs to distinguish "protected by
+// a PDB with room" from "protected by a PDB with none", and only the second is
+// a reason a step is Red.
+func pdbConstraints(pod model.Pod, index map[string][]model.PodDisruptionBudget) []Constraint {
+	var out []Constraint
+	for _, pdb := range index[pod.Namespace] {
+		if pdb.Selector.IsEmpty() || !pdb.Selector.Matches(pod.Labels) {
+			continue
+		}
+		if pdb.Blocks() {
+			out = append(out, Constraint{
+				Kind:     KindPDB,
+				Subject:  pdb.Key(),
+				Hard:     true,
+				Blocking: true,
+				Explanation: fmt.Sprintf(
+					"PodDisruptionBudget %s currently allows 0 disruptions (%d healthy, %d required). The API server will refuse to evict this pod.",
+					pdb.Key(), pdb.CurrentHealthy, pdb.DesiredHealthy),
+			})
+			continue
+		}
+		out = append(out, Constraint{
+			Kind:     KindPDB,
+			Subject:  pdb.Key(),
+			Hard:     true,
+			Blocking: false,
+			Explanation: fmt.Sprintf(
+				"PodDisruptionBudget %s allows %d more concurrent disruption(s) (%d healthy, %d required).",
+				pdb.Key(), pdb.DisruptionsAllowed, pdb.CurrentHealthy, pdb.DesiredHealthy),
+		})
+	}
+	return out
+}
+
+func resourceConstraint(pod model.Pod, snap *model.ClusterSnapshot, placement *Placement) Constraint {
+	fits := 0
+	for _, n := range snap.Nodes {
+		if n.Name == pod.NodeName {
+			continue
+		}
+		need := pod.Requests.Add(model.Resources{Pods: 1})
+		if need.Fits(placement.Free(n.Name)) {
+			fits++
+		}
+	}
+	other := len(snap.Nodes) - 1
+	return Constraint{
+		Kind:     KindResources,
+		Hard:     true,
+		Blocking: false,
+		Explanation: fmt.Sprintf(
+			"Requests %s. %d of %d other nodes have enough free capacity right now.",
+			pod.Requests, fits, other),
+	}
+}
+
+func nodeSelectorConstraint(pod model.Pod, snap *model.ClusterSnapshot) (Constraint, bool) {
+	if len(pod.NodeSelector) == 0 {
+		return Constraint{}, false
+	}
+	matching := 0
+	for _, n := range snap.Nodes {
+		ok := true
+		for k, v := range pod.NodeSelector {
+			if n.Labels[k] != v {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			matching++
+		}
+	}
+	pairs := make([]string, 0, len(pod.NodeSelector))
+	for k, v := range pod.NodeSelector {
+		pairs = append(pairs, k+"="+v)
+	}
+	sort.Strings(pairs)
+
+	return Constraint{
+		Kind:     KindNodeSelector,
+		Subject:  strings.Join(pairs, ","),
+		Hard:     true,
+		Blocking: matching == 0,
+		Explanation: fmt.Sprintf(
+			"Node selector %s restricts placement to %d of %d nodes.",
+			strings.Join(pairs, ","), matching, len(snap.Nodes)),
+	}, true
+}
+
+func nodeAffinityConstraint(pod model.Pod, snap *model.ClusterSnapshot) (Constraint, bool) {
+	if pod.NodeAffinity == nil || len(pod.NodeAffinity.RequiredTerms) == 0 {
+		return Constraint{}, false
+	}
+	matching := 0
+	for _, n := range snap.Nodes {
+		for _, term := range pod.NodeAffinity.RequiredTerms {
+			sel := model.LabelSelector{MatchExpressions: term.MatchExpressions}
+			if sel.Matches(n.Labels) {
+				matching++
+				break
+			}
+		}
+	}
+	return Constraint{
+		Kind:     KindNodeAffinity,
+		Subject:  describeTerms(pod.NodeAffinity.RequiredTerms),
+		Hard:     true,
+		Blocking: matching == 0,
+		Explanation: fmt.Sprintf(
+			"Required node affinity (%s) restricts placement to %d of %d nodes.",
+			describeTerms(pod.NodeAffinity.RequiredTerms), matching, len(snap.Nodes)),
+	}, true
+}
+
+func podAffinityConstraints(pod model.Pod) []Constraint {
+	if pod.PodAffinity == nil {
+		return nil
+	}
+	var out []Constraint
+	for _, term := range pod.PodAffinity.RequiredAntiAffinity {
+		out = append(out, Constraint{
+			Kind:     KindPodAntiAffinity,
+			Subject:  term.TopologyKey,
+			Hard:     true,
+			Blocking: false,
+			Explanation: fmt.Sprintf(
+				"Required anti-affinity on %s against pods matching %s: this pod cannot share a %s with another matching replica, so it holds its node open.",
+				term.TopologyKey, describeSelector(term.LabelSelector), shortTopology(term.TopologyKey)),
+		})
+	}
+	for _, term := range pod.PodAffinity.RequiredAffinity {
+		out = append(out, Constraint{
+			Kind:     KindPodAffinity,
+			Subject:  term.TopologyKey,
+			Hard:     true,
+			Blocking: false,
+			Explanation: fmt.Sprintf(
+				"Required pod affinity on %s: must be co-located with pods matching %s.",
+				term.TopologyKey, describeSelector(term.LabelSelector)),
+		})
+	}
+	return out
+}
+
+func topologySpreadConstraints(pod model.Pod, snap *model.ClusterSnapshot) []Constraint {
+	var out []Constraint
+	for _, tsc := range pod.TopologySpread {
+		domains := map[string]struct{}{}
+		for _, n := range snap.Nodes {
+			if v, ok := n.Labels[tsc.TopologyKey]; ok {
+				domains[v] = struct{}{}
+			}
+		}
+		if tsc.IsHard() {
+			out = append(out, Constraint{
+				Kind:     KindTopologySpread,
+				Subject:  tsc.TopologyKey,
+				Hard:     true,
+				Blocking: false,
+				Explanation: fmt.Sprintf(
+					"Topology spread across %s with maxSkew %d (DoNotSchedule) over %d domain(s): any move must keep the per-domain counts within %d of each other.",
+					tsc.TopologyKey, tsc.MaxSkew, len(domains), tsc.MaxSkew),
+			})
+			continue
+		}
+		out = append(out, Constraint{
+			Kind:     KindTopologySpread,
+			Subject:  tsc.TopologyKey,
+			Hard:     false,
+			Blocking: false,
+			Explanation: fmt.Sprintf(
+				"Topology spread across %s with maxSkew %d (ScheduleAnyway): a preference, so it cannot block a move.",
+				tsc.TopologyKey, tsc.MaxSkew),
+		})
+	}
+	return out
+}
+
+// taintToleranceConstraint records tolerations that unlock otherwise
+// unreachable nodes. Universal tolerations are skipped: reporting "this pod
+// tolerates everything" as a placement constraint is noise.
+func taintToleranceConstraint(pod model.Pod, snap *model.ClusterSnapshot) (Constraint, bool) {
+	unlocked := map[string]struct{}{}
+	for _, n := range snap.Nodes {
+		for _, taint := range n.Taints {
+			if taint.Effect == model.TaintEffectPreferNoSchedule {
+				continue
+			}
+			for _, tol := range pod.Tolerations {
+				if tol.Key != "" && tol.ToleratesTaint(taint) {
+					unlocked[taint.Key+valueSuffix(taint.Value)] = struct{}{}
+				}
+			}
+		}
+	}
+	if len(unlocked) == 0 {
+		return Constraint{}, false
+	}
+	keys := make([]string, 0, len(unlocked))
+	for k := range unlocked {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	return Constraint{
+		Kind:     KindTaint,
+		Subject:  strings.Join(keys, ","),
+		Hard:     false,
+		Blocking: false,
+		Explanation: fmt.Sprintf(
+			"Tolerates %s, so it may be placed on nodes carrying those taints.",
+			strings.Join(keys, ", ")),
+	}, true
+}
+
+func indexPDBs(snap *model.ClusterSnapshot) map[string][]model.PodDisruptionBudget {
+	out := make(map[string][]model.PodDisruptionBudget)
+	for _, pdb := range snap.PDBs {
+		out[pdb.Namespace] = append(out[pdb.Namespace], pdb)
+	}
+	return out
+}
+
+func describeSelector(s *model.LabelSelector) string {
+	if s.IsEmpty() {
+		return "any pod"
+	}
+	parts := make([]string, 0, len(s.MatchLabels)+len(s.MatchExpressions))
+	for k, v := range s.MatchLabels {
+		parts = append(parts, k+"="+v)
+	}
+	for _, e := range s.MatchExpressions {
+		parts = append(parts, fmt.Sprintf("%s %s %v", e.Key, strings.ToLower(string(e.Operator)), e.Values))
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, ",")
+}
+
+func describeTerms(terms []model.NodeSelectorTerm) string {
+	parts := make([]string, 0, len(terms))
+	for _, t := range terms {
+		sub := make([]string, 0, len(t.MatchExpressions))
+		for _, e := range t.MatchExpressions {
+			if len(e.Values) == 0 {
+				sub = append(sub, fmt.Sprintf("%s %s", e.Key, strings.ToLower(string(e.Operator))))
+				continue
+			}
+			sub = append(sub, fmt.Sprintf("%s %s %v", e.Key, strings.ToLower(string(e.Operator)), e.Values))
+		}
+		sort.Strings(sub)
+		parts = append(parts, strings.Join(sub, " and "))
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, " or ")
+}
+
+func shortTopology(key string) string {
+	switch key {
+	case model.LabelHostname:
+		return "node"
+	case model.LabelZone:
+		return "zone"
+	case model.LabelRegion:
+		return "region"
+	default:
+		return key
+	}
+}

--- a/internal/constraints/analyzer_test.go
+++ b/internal/constraints/analyzer_test.go
@@ -1,0 +1,196 @@
+package constraints_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/atedgimo/k8s-dencer/internal/constraints"
+	"github.com/atedgimo/k8s-dencer/internal/model"
+)
+
+// loadFixture replays a snapshot captured from a live cluster. This works only
+// because internal/model imports nothing from k8s.io — the whole point of that
+// constraint.
+func loadFixture(t *testing.T, name string) *model.ClusterSnapshot {
+	t.Helper()
+	path := filepath.Join("..", "..", "test", "fixtures", name+".yaml")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Skipf("fixture %s not available: %v", name, err)
+	}
+	var snap model.ClusterSnapshot
+	if err := yaml.Unmarshal(raw, &snap); err != nil {
+		t.Fatalf("parse fixture %s: %v", name, err)
+	}
+	return &snap
+}
+
+func TestAnalyzeFragmentedFixture(t *testing.T) {
+	snap := loadFixture(t, "a-fragmented")
+	analysis := constraints.Analyze(snap)
+
+	if len(analysis.Pods) != len(snap.Pods) {
+		t.Fatalf("analyzed %d pods, snapshot has %d", len(analysis.Pods), len(snap.Pods))
+	}
+
+	summary := analysis.Summarize()
+	if summary.Pods == 0 {
+		t.Fatal("summary counted no pods")
+	}
+	if summary.Movable == 0 {
+		t.Error("no pod was considered movable in an unconstrained scenario")
+	}
+
+	// The filler workload is unconstrained apart from the KWOK node affinity,
+	// so every one of its pods must have somewhere else to go.
+	filler := 0
+	for _, pc := range analysis.Pods {
+		key := pc.Key()
+		if !strings.Contains(key, "filler") {
+			continue
+		}
+		filler++
+		if !pc.Movable {
+			t.Errorf("%s should be movable, blockers: %v", key, pc.Blockers())
+		}
+		if len(pc.CandidateNodes) == 0 {
+			t.Errorf("%s has no candidate nodes", key)
+		}
+	}
+	if filler == 0 {
+		t.Skip("fixture contains no filler pods")
+	}
+	t.Logf("fragmented: %d pods, %d movable, %d blocked, %d stuck (%d filler)",
+		summary.Pods, summary.Movable, summary.Blocked, summary.Stuck, filler)
+}
+
+// The whole product hinges on telling a PDB with headroom apart from one
+// without, and on saying so in words a human can act on.
+func TestAnalyzeDistinguishesBlockingPDBFromHealthyOne(t *testing.T) {
+	snap := loadFixture(t, "b-pdb-blocked")
+	analysis := constraints.Analyze(snap)
+
+	var payments, catalog []constraints.Constraint
+	for _, pc := range analysis.Pods {
+		key := pc.Key()
+		switch {
+		case strings.Contains(key, "payments"):
+			payments = append(payments, pc.Of(constraints.KindPDB)...)
+			if pc.Movable {
+				t.Errorf("%s must not be movable: its PDB allows no disruptions", key)
+			}
+		case strings.Contains(key, "catalog"):
+			catalog = append(catalog, pc.Of(constraints.KindPDB)...)
+			if !pc.Movable {
+				t.Errorf("%s should be movable: its PDB has headroom. blockers=%v", key, pc.Blockers())
+			}
+		}
+	}
+
+	if len(payments) == 0 || len(catalog) == 0 {
+		t.Skip("fixture lacks the pdb-blocked workloads")
+	}
+
+	for _, c := range payments {
+		if !c.Blocking {
+			t.Error("payments PDB constraint must be marked blocking")
+		}
+		if !strings.Contains(c.Explanation, "allows 0 disruptions") {
+			t.Errorf("explanation must state the headroom, got: %q", c.Explanation)
+		}
+		if !strings.Contains(c.Explanation, "payments") {
+			t.Errorf("explanation must name the responsible PDB, got: %q", c.Explanation)
+		}
+	}
+	for _, c := range catalog {
+		if c.Blocking {
+			t.Errorf("catalog PDB has headroom and must not block: %q", c.Explanation)
+		}
+	}
+	t.Logf("payments: %s", payments[0].Explanation)
+	t.Logf("catalog:  %s", catalog[0].Explanation)
+}
+
+func TestNodeDrainableReportsBlockers(t *testing.T) {
+	snap := loadFixture(t, "b-pdb-blocked")
+	analysis := constraints.Analyze(snap)
+
+	blockedNodes := 0
+	for _, n := range snap.Nodes {
+		drainable, blockers := analysis.NodeDrainable(n.Name)
+		if drainable {
+			continue
+		}
+		blockedNodes++
+		if len(blockers) == 0 {
+			t.Errorf("node %s is not drainable but reported no blockers", n.Name)
+		}
+		for _, b := range blockers {
+			if b.Explanation == "" {
+				t.Errorf("node %s has a blocker with no explanation: %+v", n.Name, b)
+			}
+		}
+	}
+	if blockedNodes == 0 {
+		t.Error("expected at least the node hosting the zero-headroom PDB to be undrainable")
+	}
+}
+
+// Every constraint must carry text a human can act on. A blank or generic
+// explanation would surface in the UI and in the agent's answers.
+func TestEveryConstraintHasAUsefulExplanation(t *testing.T) {
+	for _, fixture := range []string{"a-fragmented", "b-pdb-blocked"} {
+		snap := loadFixture(t, fixture)
+		analysis := constraints.Analyze(snap)
+
+		for _, pc := range analysis.Pods {
+			key := pc.Key()
+			for _, c := range pc.Constraints {
+				if strings.TrimSpace(c.Explanation) == "" {
+					t.Errorf("%s/%s: empty explanation", fixture, key)
+				}
+				if len(c.Explanation) < 20 {
+					t.Errorf("%s/%s: explanation too terse to be useful: %q", fixture, key, c.Explanation)
+				}
+				if c.Kind == "" {
+					t.Errorf("%s/%s: constraint has no kind: %+v", fixture, key, c)
+				}
+			}
+		}
+	}
+}
+
+// A pod is blocked or it is not; an analysis that says a pod is movable while
+// also listing a blocker would make the planner and the UI disagree.
+func TestMovableAndBlockersAreConsistent(t *testing.T) {
+	for _, fixture := range []string{"a-fragmented", "b-pdb-blocked"} {
+		snap := loadFixture(t, fixture)
+		analysis := constraints.Analyze(snap)
+		for _, pc := range analysis.Pods {
+			key := pc.Key()
+			if pc.Movable && len(pc.Blockers()) > 0 {
+				t.Errorf("%s/%s: movable but has blockers %v", fixture, key, pc.Blockers())
+			}
+		}
+	}
+}
+
+func TestAnalysisIsDeterministic(t *testing.T) {
+	snap := loadFixture(t, "a-fragmented")
+
+	first, err := yaml.Marshal(constraints.Analyze(snap))
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := yaml.Marshal(constraints.Analyze(snap))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(first) != string(second) {
+		t.Error("analysis is not deterministic across runs on identical input")
+	}
+}

--- a/internal/constraints/constraints.go
+++ b/internal/constraints/constraints.go
@@ -1,0 +1,210 @@
+// Package constraints derives the effective scheduling constraint set for
+// every pod in a ClusterSnapshot.
+//
+// The explanation text for each constraint is produced here and nowhere else.
+// The UI's constraint inspector and the Kagent agent both surface these exact
+// strings rather than deriving their own, so the two can never disagree about
+// why a pod cannot move — which would be a bad look for a product whose whole
+// value proposition is transparency.
+package constraints
+
+import "time"
+
+// Kind identifies what sort of constraint this is. Values are stable
+// identifiers: the UI filters on them and the agent reasons over them.
+type Kind string
+
+const (
+	KindResources        Kind = "Resources"
+	KindNodeSelector     Kind = "NodeSelector"
+	KindNodeAffinity     Kind = "NodeAffinity"
+	KindPodAffinity      Kind = "PodAffinity"
+	KindPodAntiAffinity  Kind = "PodAntiAffinity"
+	KindTopologySpread   Kind = "TopologySpread"
+	KindPDB              Kind = "PodDisruptionBudget"
+	KindTaint            Kind = "Taint"
+	KindControllerPinned Kind = "ControllerPinned"
+	KindPersistentVolume Kind = "PersistentVolume"
+)
+
+// Constraint is one effective restriction on where a pod may live.
+type Constraint struct {
+	Kind Kind `json:"kind"`
+	// Subject is the object responsible, e.g. "dencer-demo/payments" for a
+	// PDB or "topology.kubernetes.io/zone" for a spread constraint.
+	Subject string `json:"subject,omitempty"`
+
+	// Hard distinguishes a scheduling requirement from a preference. A
+	// preference must never be reported as the reason a pod cannot move.
+	Hard bool `json:"hard"`
+
+	// Blocking means this constraint prevents the pod from moving *right
+	// now*, as opposed to merely restricting where it could go. A PDB with
+	// headroom is a constraint; a PDB at zero headroom is blocking.
+	Blocking bool `json:"blocking"`
+
+	// Explanation is the single canonical human-readable description.
+	Explanation string `json:"explanation"`
+}
+
+// PodConstraints is the complete constraint picture for one pod.
+type PodConstraints struct {
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`
+	NodeName  string `json:"nodeName,omitempty"`
+
+	// Movable is false when the pod cannot be relocated at all, either
+	// because it is pinned to its node or because something currently blocks
+	// its eviction.
+	Movable     bool         `json:"movable"`
+	Constraints []Constraint `json:"constraints"`
+
+	// CandidateNodes are the other nodes this pod could legally occupy given
+	// current cluster state. An empty list on a movable pod means the pod is
+	// effectively stuck: there is nowhere for it to go.
+	CandidateNodes []string `json:"candidateNodes"`
+}
+
+// Key is the namespace/name identifier.
+func (p PodConstraints) Key() string { return p.Namespace + "/" + p.Name }
+
+// Blockers returns only the constraints currently preventing movement.
+func (p PodConstraints) Blockers() []Constraint {
+	var out []Constraint
+	for _, c := range p.Constraints {
+		if c.Blocking {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// Of returns the constraints of a given kind.
+func (p PodConstraints) Of(kind Kind) []Constraint {
+	var out []Constraint
+	for _, c := range p.Constraints {
+		if c.Kind == kind {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// Analysis is the constraint picture for a whole snapshot.
+//
+// Pods is a slice sorted by key rather than a map, deliberately. Go map
+// iteration order is randomised, and that randomness leaks straight into
+// serialized output — which would make the API response, the UI list order and
+// any golden test unstable for no reason.
+type Analysis struct {
+	TakenAt time.Time        `json:"takenAt"`
+	Pods    []PodConstraints `json:"pods"`
+
+	// index is built by Analyze for O(1) lookup. It is nil on an Analysis
+	// that was deserialized rather than computed, in which case ForPod falls
+	// back to a scan. Never mutated after construction, so Analysis stays
+	// safe for concurrent reads.
+	index map[string]int
+}
+
+// ForPod looks up one pod's constraints by "namespace/name".
+func (a *Analysis) ForPod(key string) (PodConstraints, bool) {
+	if a.index != nil {
+		i, ok := a.index[key]
+		if !ok {
+			return PodConstraints{}, false
+		}
+		return a.Pods[i], true
+	}
+	for _, pc := range a.Pods {
+		if pc.Key() == key {
+			return pc, true
+		}
+	}
+	return PodConstraints{}, false
+}
+
+// ForNode returns the constraints of every pod currently on a node, in the
+// same sorted order as Pods.
+func (a *Analysis) ForNode(nodeName string) []PodConstraints {
+	var out []PodConstraints
+	for _, pc := range a.Pods {
+		if pc.NodeName == nodeName {
+			out = append(out, pc)
+		}
+	}
+	return out
+}
+
+// NodeDrainable reports whether every pod on a node could be moved elsewhere,
+// and returns the constraints standing in the way if not.
+//
+// This is the question the planner actually asks of a node, so answering it
+// here keeps the reasoning in one place rather than spread across the packer.
+func (a *Analysis) NodeDrainable(nodeName string) (bool, []Constraint) {
+	var blockers []Constraint
+	drainable := true
+	for _, pc := range a.ForNode(nodeName) {
+		if !pc.Movable {
+			drainable = false
+			blockers = append(blockers, pc.Blockers()...)
+			continue
+		}
+		if len(pc.CandidateNodes) == 0 {
+			drainable = false
+			blockers = append(blockers, Constraint{
+				Kind:        KindResources,
+				Subject:     pc.Key(),
+				Hard:        true,
+				Blocking:    true,
+				Explanation: "No other node can currently accept this pod.",
+			})
+		}
+	}
+	return drainable, blockers
+}
+
+// Summary is an aggregate view for logging and the UI header.
+type Summary struct {
+	Pods          int `json:"pods"`
+	Movable       int `json:"movable"`
+	Blocked       int `json:"blocked"`
+	Stuck         int `json:"stuck"`
+	PDBBlocked    int `json:"pdbBlocked"`
+	AntiAffinity  int `json:"antiAffinity"`
+	SpreadBound   int `json:"spreadBound"`
+	ControllerPin int `json:"controllerPinned"`
+}
+
+// Summarize tallies the analysis.
+func (a *Analysis) Summarize() Summary {
+	var s Summary
+	for _, pc := range a.Pods {
+		s.Pods++
+		if pc.Movable {
+			s.Movable++
+			if len(pc.CandidateNodes) == 0 {
+				s.Stuck++
+			}
+		} else {
+			s.Blocked++
+		}
+		for _, c := range pc.Constraints {
+			switch c.Kind {
+			case KindPDB:
+				if c.Blocking {
+					s.PDBBlocked++
+				}
+			case KindPodAntiAffinity:
+				s.AntiAffinity++
+			case KindTopologySpread:
+				if c.Hard {
+					s.SpreadBound++
+				}
+			case KindControllerPinned:
+				s.ControllerPin++
+			}
+		}
+	}
+	return s
+}

--- a/internal/constraints/placement.go
+++ b/internal/constraints/placement.go
@@ -1,0 +1,445 @@
+package constraints
+
+import (
+	"fmt"
+
+	"github.com/atedgimo/k8s-dencer/internal/model"
+)
+
+// Placement is a mutable working assignment of pods to nodes.
+//
+// It exists so the planner can ask "could this pod go there?" against a
+// hypothetical packing rather than only against live cluster state. The
+// feasibility rules live here rather than in the packer so that the analyzer's
+// explanations and the packer's decisions are computed by the same code — an
+// explanation that disagrees with the plan is worse than no explanation.
+//
+// Not safe for concurrent mutation. Clone per candidate packing.
+type Placement struct {
+	nodes     map[string]*nodeState
+	nodeOrder []string
+}
+
+type nodeState struct {
+	node      model.Node
+	free      model.Resources
+	occupants []model.Pod
+}
+
+// NewPlacement builds a working assignment from a snapshot's current state.
+func NewPlacement(snap *model.ClusterSnapshot) *Placement {
+	p := &Placement{
+		nodes:     make(map[string]*nodeState, len(snap.Nodes)),
+		nodeOrder: make([]string, 0, len(snap.Nodes)),
+	}
+	for _, n := range snap.Nodes {
+		p.nodes[n.Name] = &nodeState{node: n, free: n.Allocatable}
+		p.nodeOrder = append(p.nodeOrder, n.Name)
+	}
+	for _, pod := range snap.Pods {
+		if pod.NodeName == "" {
+			continue
+		}
+		ns, ok := p.nodes[pod.NodeName]
+		if !ok {
+			continue
+		}
+		ns.occupants = append(ns.occupants, pod)
+		ns.free = ns.free.Sub(pod.Requests.Add(model.Resources{Pods: 1}))
+	}
+	return p
+}
+
+// Clone returns an independent copy, so a candidate packing can be explored
+// without disturbing the caller's state.
+func (p *Placement) Clone() *Placement {
+	out := &Placement{
+		nodes:     make(map[string]*nodeState, len(p.nodes)),
+		nodeOrder: append([]string(nil), p.nodeOrder...),
+	}
+	for name, ns := range p.nodes {
+		out.nodes[name] = &nodeState{
+			node:      ns.node,
+			free:      ns.free,
+			occupants: append([]model.Pod(nil), ns.occupants...),
+		}
+	}
+	return out
+}
+
+// NodeNames returns node names in snapshot order.
+func (p *Placement) NodeNames() []string { return p.nodeOrder }
+
+// Free returns remaining allocatable capacity on a node.
+func (p *Placement) Free(nodeName string) model.Resources {
+	if ns, ok := p.nodes[nodeName]; ok {
+		return ns.free
+	}
+	return model.Resources{}
+}
+
+// Occupants returns the pods currently assigned to a node.
+func (p *Placement) Occupants(nodeName string) []model.Pod {
+	if ns, ok := p.nodes[nodeName]; ok {
+		return ns.occupants
+	}
+	return nil
+}
+
+// IsEmpty reports whether a node holds no movable workload. DaemonSet pods do
+// not count: they are recreated on every node regardless, so a node carrying
+// only DaemonSet pods is still reclaimable.
+func (p *Placement) IsEmpty(nodeName string) bool {
+	for _, pod := range p.Occupants(nodeName) {
+		if pod.IsMovable() {
+			return false
+		}
+	}
+	return true
+}
+
+// Place assigns a pod to a node without checking feasibility. Call CanPlace
+// first unless deliberately reconstructing a known-good state.
+func (p *Placement) Place(pod model.Pod, nodeName string) {
+	ns, ok := p.nodes[nodeName]
+	if !ok {
+		return
+	}
+	pod.NodeName = nodeName
+	ns.occupants = append(ns.occupants, pod)
+	ns.free = ns.free.Sub(pod.Requests.Add(model.Resources{Pods: 1}))
+}
+
+// Remove unassigns a pod from its current node, returning its freed resources.
+func (p *Placement) Remove(pod model.Pod) {
+	ns, ok := p.nodes[pod.NodeName]
+	if !ok {
+		return
+	}
+	for i, occupant := range ns.occupants {
+		if occupant.Namespace == pod.Namespace && occupant.Name == pod.Name {
+			ns.occupants = append(ns.occupants[:i], ns.occupants[i+1:]...)
+			ns.free = ns.free.Add(pod.Requests).Add(model.Resources{Pods: 1})
+			return
+		}
+	}
+}
+
+// CanPlace reports whether pod may legally occupy node, and if not, a
+// human-readable reason.
+//
+// The checks mirror the scheduler's hard predicates in roughly the order the
+// scheduler applies them, cheapest first. Only hard constraints are evaluated:
+// a preference the scheduler would happily violate must never make the planner
+// declare a move impossible.
+func (p *Placement) CanPlace(pod model.Pod, nodeName string) (bool, string) {
+	ns, ok := p.nodes[nodeName]
+	if !ok {
+		return false, fmt.Sprintf("Node %s is not in the snapshot.", nodeName)
+	}
+	node := ns.node
+
+	if node.Unschedulable {
+		return false, fmt.Sprintf("Node %s is cordoned.", nodeName)
+	}
+	if !node.Ready {
+		return false, fmt.Sprintf("Node %s is not Ready.", nodeName)
+	}
+
+	if ok, reason := fitsTaints(pod, node); !ok {
+		return false, reason
+	}
+	if ok, reason := fitsNodeSelector(pod, node); !ok {
+		return false, reason
+	}
+	if ok, reason := fitsNodeAffinity(pod, node); !ok {
+		return false, reason
+	}
+	if ok, reason := p.fitsResources(pod, ns); !ok {
+		return false, reason
+	}
+	if ok, reason := p.fitsPodAntiAffinity(pod, ns); !ok {
+		return false, reason
+	}
+	if ok, reason := p.fitsPodAffinity(pod, ns); !ok {
+		return false, reason
+	}
+	if ok, reason := p.fitsTopologySpread(pod, nodeName); !ok {
+		return false, reason
+	}
+	return true, ""
+}
+
+// CandidateNodes lists every node other than the pod's current one that could
+// accept it.
+func (p *Placement) CandidateNodes(pod model.Pod) []string {
+	var out []string
+	for _, name := range p.nodeOrder {
+		if name == pod.NodeName {
+			continue
+		}
+		if ok, _ := p.CanPlace(pod, name); ok {
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
+func fitsTaints(pod model.Pod, node model.Node) (bool, string) {
+	for _, taint := range node.Taints {
+		// PreferNoSchedule is a soft signal; the scheduler will still place
+		// here when it must, so it cannot block a move.
+		if taint.Effect == model.TaintEffectPreferNoSchedule {
+			continue
+		}
+		tolerated := false
+		for _, tol := range pod.Tolerations {
+			if tol.ToleratesTaint(taint) {
+				tolerated = true
+				break
+			}
+		}
+		if !tolerated {
+			return false, fmt.Sprintf("Node %s carries taint %s%s:%s which this pod does not tolerate.",
+				node.Name, taint.Key, valueSuffix(taint.Value), taint.Effect)
+		}
+	}
+	return true, ""
+}
+
+func fitsNodeSelector(pod model.Pod, node model.Node) (bool, string) {
+	for k, v := range pod.NodeSelector {
+		if node.Labels[k] != v {
+			return false, fmt.Sprintf("Node %s does not carry the required label %s=%s.", node.Name, k, v)
+		}
+	}
+	return true, ""
+}
+
+func fitsNodeAffinity(pod model.Pod, node model.Node) (bool, string) {
+	if pod.NodeAffinity == nil || len(pod.NodeAffinity.RequiredTerms) == 0 {
+		return true, ""
+	}
+	// Terms are OR-ed: satisfying any one is enough.
+	for _, term := range pod.NodeAffinity.RequiredTerms {
+		sel := model.LabelSelector{MatchExpressions: term.MatchExpressions}
+		if sel.Matches(node.Labels) {
+			return true, ""
+		}
+	}
+	return false, fmt.Sprintf("Node %s does not satisfy the pod's required node affinity.", node.Name)
+}
+
+func (p *Placement) fitsResources(pod model.Pod, ns *nodeState) (bool, string) {
+	need := pod.Requests.Add(model.Resources{Pods: 1})
+	if need.Fits(ns.free) {
+		return true, ""
+	}
+	return false, fmt.Sprintf("Node %s has %s free, which cannot hold this pod's %s.",
+		ns.node.Name, ns.free, pod.Requests)
+}
+
+func (p *Placement) fitsPodAntiAffinity(pod model.Pod, ns *nodeState) (bool, string) {
+	if pod.PodAffinity == nil {
+		return true, ""
+	}
+	for _, term := range pod.PodAffinity.RequiredAntiAffinity {
+		for _, occupant := range ns.occupants {
+			if sameKey(pod, occupant) {
+				continue
+			}
+			if !p.inSameTopologyDomain(ns.node.Name, occupant.NodeName, term.TopologyKey) {
+				continue
+			}
+			if !termMatchesPod(term, occupant, pod.Namespace) {
+				continue
+			}
+			return false, fmt.Sprintf(
+				"Required anti-affinity on %s: %s already runs there and matches this pod's selector.",
+				term.TopologyKey, occupant.Key())
+		}
+		// Anti-affinity applies across the whole topology domain, not just the
+		// single node, so a zone-scoped rule must consider sibling nodes too.
+		if term.TopologyKey != model.LabelHostname {
+			if conflict := p.conflictInDomain(pod, ns.node, term); conflict != "" {
+				return false, conflict
+			}
+		}
+	}
+	return true, ""
+}
+
+func (p *Placement) conflictInDomain(pod model.Pod, node model.Node, term model.PodAffinityTerm) string {
+	domain, ok := node.Labels[term.TopologyKey]
+	if !ok {
+		return ""
+	}
+	for _, name := range p.nodeOrder {
+		if name == node.Name {
+			continue
+		}
+		other := p.nodes[name]
+		if other.node.Labels[term.TopologyKey] != domain {
+			continue
+		}
+		for _, occupant := range other.occupants {
+			if sameKey(pod, occupant) {
+				continue
+			}
+			if termMatchesPod(term, occupant, pod.Namespace) {
+				return fmt.Sprintf(
+					"Required anti-affinity on %s=%s: %s already runs in that domain.",
+					term.TopologyKey, domain, occupant.Key())
+			}
+		}
+	}
+	return ""
+}
+
+func (p *Placement) fitsPodAffinity(pod model.Pod, ns *nodeState) (bool, string) {
+	if pod.PodAffinity == nil {
+		return true, ""
+	}
+	for _, term := range pod.PodAffinity.RequiredAffinity {
+		found := false
+		domain, hasDomain := ns.node.Labels[term.TopologyKey]
+		for _, name := range p.nodeOrder {
+			other := p.nodes[name]
+			if term.TopologyKey == model.LabelHostname {
+				if name != ns.node.Name {
+					continue
+				}
+			} else if !hasDomain || other.node.Labels[term.TopologyKey] != domain {
+				continue
+			}
+			for _, occupant := range other.occupants {
+				if sameKey(pod, occupant) {
+					continue
+				}
+				if termMatchesPod(term, occupant, pod.Namespace) {
+					found = true
+					break
+				}
+			}
+			if found {
+				break
+			}
+		}
+		if !found {
+			return false, fmt.Sprintf(
+				"Required pod affinity on %s is not satisfied at node %s: no matching pod in that domain.",
+				term.TopologyKey, ns.node.Name)
+		}
+	}
+	return true, ""
+}
+
+// fitsTopologySpread checks hard spread constraints by simulating the
+// placement: counting the domain as it would be *after* the pod lands, which
+// is what the scheduler does.
+func (p *Placement) fitsTopologySpread(pod model.Pod, nodeName string) (bool, string) {
+	for _, tsc := range pod.TopologySpread {
+		if !tsc.IsHard() {
+			continue
+		}
+		target, ok := p.nodes[nodeName]
+		if !ok {
+			continue
+		}
+		targetDomain, ok := target.node.Labels[tsc.TopologyKey]
+		if !ok {
+			// A node with no value for the topology key cannot satisfy a hard
+			// spread constraint.
+			return false, fmt.Sprintf("Node %s has no %s label, required by a topology spread constraint.",
+				nodeName, tsc.TopologyKey)
+		}
+
+		counts := p.domainCounts(pod, tsc)
+		counts[targetDomain]++ // the candidate placement
+
+		minCount := -1
+		for _, c := range counts {
+			if minCount == -1 || c < minCount {
+				minCount = c
+			}
+		}
+		if minCount < 0 {
+			minCount = 0
+		}
+		if skew := counts[targetDomain] - minCount; int32(skew) > tsc.MaxSkew {
+			return false, fmt.Sprintf(
+				"Topology spread on %s would reach skew %d in domain %q, exceeding maxSkew %d.",
+				tsc.TopologyKey, skew, targetDomain, tsc.MaxSkew)
+		}
+	}
+	return true, ""
+}
+
+// domainCounts tallies matching pods per topology domain, excluding the pod
+// being placed. Every domain present in the cluster is seeded at zero so an
+// empty domain still counts toward the skew calculation.
+func (p *Placement) domainCounts(pod model.Pod, tsc model.TopologySpreadConstraint) map[string]int {
+	counts := map[string]int{}
+	for _, name := range p.nodeOrder {
+		ns := p.nodes[name]
+		domain, ok := ns.node.Labels[tsc.TopologyKey]
+		if !ok {
+			continue
+		}
+		if _, seen := counts[domain]; !seen {
+			counts[domain] = 0
+		}
+		for _, occupant := range ns.occupants {
+			if sameKey(pod, occupant) {
+				continue
+			}
+			if tsc.LabelSelector.Matches(occupant.Labels) && occupant.Namespace == pod.Namespace {
+				counts[domain]++
+			}
+		}
+	}
+	return counts
+}
+
+func (p *Placement) inSameTopologyDomain(a, b, topologyKey string) bool {
+	if topologyKey == model.LabelHostname {
+		return a == b
+	}
+	na, okA := p.nodes[a]
+	nb, okB := p.nodes[b]
+	if !okA || !okB {
+		return false
+	}
+	va, okA := na.node.Labels[topologyKey]
+	vb, okB := nb.node.Labels[topologyKey]
+	return okA && okB && va == vb
+}
+
+func termMatchesPod(term model.PodAffinityTerm, candidate model.Pod, defaultNamespace string) bool {
+	namespaces := term.Namespaces
+	if len(namespaces) == 0 {
+		namespaces = []string{defaultNamespace}
+	}
+	inScope := false
+	for _, ns := range namespaces {
+		if ns == candidate.Namespace {
+			inScope = true
+			break
+		}
+	}
+	if !inScope {
+		return false
+	}
+	return term.LabelSelector.Matches(candidate.Labels)
+}
+
+func sameKey(a, b model.Pod) bool {
+	return a.Namespace == b.Namespace && a.Name == b.Name
+}
+
+func valueSuffix(v string) string {
+	if v == "" {
+		return ""
+	}
+	return "=" + v
+}

--- a/internal/constraints/placement_test.go
+++ b/internal/constraints/placement_test.go
@@ -1,0 +1,338 @@
+package constraints_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/atedgimo/k8s-dencer/internal/constraints"
+	"github.com/atedgimo/k8s-dencer/internal/model"
+)
+
+// These exercise the feasibility rules directly with hand-built topologies.
+// The planner in M4 trusts CanPlace completely: a false positive here becomes
+// a plan the scheduler then refuses to execute.
+
+func node(name, zone string, milliCPU int64, taints ...model.Taint) model.Node {
+	return model.Node{
+		Name:        name,
+		Ready:       true,
+		Labels:      map[string]string{model.LabelZone: zone, model.LabelHostname: name},
+		Taints:      taints,
+		Capacity:    model.Resources{MilliCPU: milliCPU, MemoryBytes: 1 << 34, Pods: 110},
+		Allocatable: model.Resources{MilliCPU: milliCPU, MemoryBytes: 1 << 34, Pods: 110},
+	}
+}
+
+func pod(name, nodeName string, milliCPU int64, labels map[string]string) model.Pod {
+	return model.Pod{
+		Namespace: "default",
+		Name:      name,
+		NodeName:  nodeName,
+		Labels:    labels,
+		Phase:     model.PodRunning,
+		Requests:  model.Resources{MilliCPU: milliCPU, MemoryBytes: 1 << 30},
+	}
+}
+
+func TestCanPlaceResources(t *testing.T) {
+	snap := &model.ClusterSnapshot{
+		Nodes: []model.Node{node("a", "z1", 4000), node("b", "z1", 4000)},
+		Pods:  []model.Pod{pod("big", "b", 3500, nil)},
+	}
+	p := constraints.NewPlacement(snap)
+
+	candidate := pod("new", "", 1000, nil)
+	if ok, why := p.CanPlace(candidate, "a"); !ok {
+		t.Errorf("should fit on empty node a: %s", why)
+	}
+	if ok, _ := p.CanPlace(candidate, "b"); ok {
+		t.Error("must not fit on node b: only 500m free")
+	}
+
+	// The reason must be specific enough to show a user.
+	_, why := p.CanPlace(candidate, "b")
+	if !strings.Contains(why, "free") {
+		t.Errorf("resource rejection should describe free capacity, got: %q", why)
+	}
+}
+
+func TestCanPlaceRespectsTaints(t *testing.T) {
+	dedicated := model.Taint{Key: "dedicated", Value: "batch", Effect: model.TaintEffectNoSchedule}
+	prefer := model.Taint{Key: "soft", Effect: model.TaintEffectPreferNoSchedule}
+
+	snap := &model.ClusterSnapshot{Nodes: []model.Node{
+		node("plain", "z1", 4000),
+		node("tainted", "z1", 4000, dedicated),
+		node("soft", "z1", 4000, prefer),
+	}}
+	p := constraints.NewPlacement(snap)
+
+	plain := pod("plain-pod", "", 100, nil)
+	if ok, _ := p.CanPlace(plain, "tainted"); ok {
+		t.Error("untolerating pod must not be placed on a tainted node")
+	}
+	// PreferNoSchedule is a preference; the scheduler will still use the node,
+	// so it must not block a move.
+	if ok, why := p.CanPlace(plain, "soft"); !ok {
+		t.Errorf("PreferNoSchedule must not block placement: %s", why)
+	}
+
+	tolerating := plain
+	tolerating.Tolerations = []model.Toleration{
+		{Key: "dedicated", Operator: model.TolerationOpEqual, Value: "batch", Effect: model.TaintEffectNoSchedule},
+	}
+	if ok, why := p.CanPlace(tolerating, "tainted"); !ok {
+		t.Errorf("tolerating pod should be placeable: %s", why)
+	}
+}
+
+func TestCanPlaceRespectsNodeSelectorAndAffinity(t *testing.T) {
+	nodes := []model.Node{node("kwok", "z1", 4000), node("real", "z1", 4000)}
+	nodes[0].Labels["type"] = "kwok"
+	snap := &model.ClusterSnapshot{Nodes: nodes}
+	p := constraints.NewPlacement(snap)
+
+	selector := pod("sel", "", 100, nil)
+	selector.NodeSelector = map[string]string{"type": "kwok"}
+	if ok, _ := p.CanPlace(selector, "real"); ok {
+		t.Error("nodeSelector must exclude the unlabelled node")
+	}
+	if ok, why := p.CanPlace(selector, "kwok"); !ok {
+		t.Errorf("nodeSelector should admit the labelled node: %s", why)
+	}
+
+	affinity := pod("aff", "", 100, nil)
+	affinity.NodeAffinity = &model.NodeAffinity{RequiredTerms: []model.NodeSelectorTerm{{
+		MatchExpressions: []model.SelectorRequirement{
+			{Key: "type", Operator: model.SelectorOpIn, Values: []string{"kwok"}},
+		},
+	}}}
+	if ok, _ := p.CanPlace(affinity, "real"); ok {
+		t.Error("required node affinity must exclude the unlabelled node")
+	}
+	if ok, why := p.CanPlace(affinity, "kwok"); !ok {
+		t.Errorf("required node affinity should admit the labelled node: %s", why)
+	}
+}
+
+// Scenario d: cache replicas cannot share a node, so each one pins a node open
+// regardless of how much capacity is free elsewhere.
+func TestCanPlaceHostnameAntiAffinity(t *testing.T) {
+	labels := map[string]string{"app": "cache"}
+	snap := &model.ClusterSnapshot{
+		Nodes: []model.Node{node("a", "z1", 8000), node("b", "z1", 8000)},
+		Pods:  []model.Pod{pod("cache-0", "a", 100, labels)},
+	}
+	p := constraints.NewPlacement(snap)
+
+	candidate := pod("cache-1", "", 100, labels)
+	candidate.PodAffinity = &model.PodAffinity{RequiredAntiAffinity: []model.PodAffinityTerm{{
+		TopologyKey:   model.LabelHostname,
+		LabelSelector: &model.LabelSelector{MatchLabels: labels},
+	}}}
+
+	if ok, _ := p.CanPlace(candidate, "a"); ok {
+		t.Error("anti-affinity must forbid sharing a node with a matching pod")
+	}
+	if ok, why := p.CanPlace(candidate, "b"); !ok {
+		t.Errorf("empty node b should accept it: %s", why)
+	}
+	_, why := p.CanPlace(candidate, "a")
+	if !strings.Contains(why, "anti-affinity") {
+		t.Errorf("reason should name anti-affinity, got %q", why)
+	}
+}
+
+// A zone-scoped anti-affinity rule must consider sibling nodes in the same
+// zone, not just the target node. Checking only the target node is the easy
+// bug here, and it produces plans the scheduler rejects.
+func TestCanPlaceZoneAntiAffinitySpansNodes(t *testing.T) {
+	labels := map[string]string{"app": "zonal"}
+	snap := &model.ClusterSnapshot{
+		Nodes: []model.Node{
+			node("a1", "z1", 8000), node("a2", "z1", 8000), node("b1", "z2", 8000),
+		},
+		Pods: []model.Pod{pod("zonal-0", "a1", 100, labels)},
+	}
+	p := constraints.NewPlacement(snap)
+
+	candidate := pod("zonal-1", "", 100, labels)
+	candidate.PodAffinity = &model.PodAffinity{RequiredAntiAffinity: []model.PodAffinityTerm{{
+		TopologyKey:   model.LabelZone,
+		LabelSelector: &model.LabelSelector{MatchLabels: labels},
+	}}}
+
+	if ok, _ := p.CanPlace(candidate, "a2"); ok {
+		t.Error("a2 is empty but shares zone z1 with zonal-0; zone anti-affinity must reject it")
+	}
+	if ok, why := p.CanPlace(candidate, "b1"); !ok {
+		t.Errorf("b1 is in a different zone and should be accepted: %s", why)
+	}
+}
+
+// Scenario c: maxSkew 1 across three zones. The check must simulate the
+// placement, since the skew is evaluated after the pod lands.
+func TestCanPlaceTopologySpread(t *testing.T) {
+	labels := map[string]string{"app": "frontend"}
+	spread := []model.TopologySpreadConstraint{{
+		MaxSkew:           1,
+		TopologyKey:       model.LabelZone,
+		WhenUnsatisfiable: model.DoNotSchedule,
+		LabelSelector:     &model.LabelSelector{MatchLabels: labels},
+	}}
+
+	snap := &model.ClusterSnapshot{
+		Nodes: []model.Node{node("a", "z1", 8000), node("b", "z2", 8000), node("c", "z3", 8000)},
+		Pods: []model.Pod{
+			pod("fe-0", "a", 100, labels),
+			pod("fe-1", "b", 100, labels),
+		},
+	}
+	p := constraints.NewPlacement(snap)
+
+	candidate := pod("fe-2", "", 100, labels)
+	candidate.TopologySpread = spread
+
+	// z3 is empty; landing there gives 1/1/1 — skew 0.
+	if ok, why := p.CanPlace(candidate, "c"); !ok {
+		t.Errorf("empty zone z3 must be allowed: %s", why)
+	}
+	// z1 already has one; landing there gives 2/1/0 against empty z3 — skew 2.
+	if ok, _ := p.CanPlace(candidate, "a"); ok {
+		t.Error("placing into z1 would exceed maxSkew 1 while z3 is empty")
+	}
+	_, why := p.CanPlace(candidate, "a")
+	if !strings.Contains(why, "maxSkew") {
+		t.Errorf("reason should mention maxSkew, got %q", why)
+	}
+}
+
+// ScheduleAnyway is a preference. Reporting it as a blocker would make the
+// planner refuse moves the scheduler would happily make.
+func TestSoftTopologySpreadDoesNotBlock(t *testing.T) {
+	labels := map[string]string{"app": "frontend"}
+	snap := &model.ClusterSnapshot{
+		Nodes: []model.Node{node("a", "z1", 8000), node("b", "z2", 8000)},
+		Pods:  []model.Pod{pod("fe-0", "a", 100, labels), pod("fe-1", "a", 100, labels)},
+	}
+	p := constraints.NewPlacement(snap)
+
+	candidate := pod("fe-2", "", 100, labels)
+	candidate.TopologySpread = []model.TopologySpreadConstraint{{
+		MaxSkew:           1,
+		TopologyKey:       model.LabelZone,
+		WhenUnsatisfiable: model.ScheduleAnyway,
+		LabelSelector:     &model.LabelSelector{MatchLabels: labels},
+	}}
+
+	if ok, why := p.CanPlace(candidate, "a"); !ok {
+		t.Errorf("ScheduleAnyway must never block placement: %s", why)
+	}
+}
+
+func TestCanPlaceRejectsCordonedAndNotReady(t *testing.T) {
+	cordoned := node("cordoned", "z1", 8000)
+	cordoned.Unschedulable = true
+	notReady := node("down", "z1", 8000)
+	notReady.Ready = false
+
+	snap := &model.ClusterSnapshot{Nodes: []model.Node{cordoned, notReady, node("ok", "z1", 8000)}}
+	p := constraints.NewPlacement(snap)
+
+	candidate := pod("x", "", 100, nil)
+	if ok, _ := p.CanPlace(candidate, "cordoned"); ok {
+		t.Error("cordoned node must be rejected")
+	}
+	if ok, _ := p.CanPlace(candidate, "down"); ok {
+		t.Error("NotReady node must be rejected")
+	}
+	if ok, why := p.CanPlace(candidate, "ok"); !ok {
+		t.Errorf("healthy node should be accepted: %s", why)
+	}
+	if ok, _ := p.CanPlace(candidate, "nonexistent"); ok {
+		t.Error("unknown node must be rejected")
+	}
+}
+
+func TestPlaceRemoveAndIsEmpty(t *testing.T) {
+	snap := &model.ClusterSnapshot{
+		Nodes: []model.Node{node("a", "z1", 4000)},
+		Pods:  []model.Pod{pod("p1", "a", 1000, nil)},
+	}
+	p := constraints.NewPlacement(snap)
+
+	if p.IsEmpty("a") {
+		t.Error("node a holds a movable pod")
+	}
+	free := p.Free("a")
+	if free.MilliCPU != 3000 {
+		t.Errorf("free cpu = %d, want 3000", free.MilliCPU)
+	}
+
+	p.Remove(pod("p1", "a", 1000, nil))
+	if !p.IsEmpty("a") {
+		t.Error("node a should be empty after removal")
+	}
+	if got := p.Free("a").MilliCPU; got != 4000 {
+		t.Errorf("free cpu after removal = %d, want 4000", got)
+	}
+
+	p.Place(pod("p2", "", 500, nil), "a")
+	if got := p.Free("a").MilliCPU; got != 3500 {
+		t.Errorf("free cpu after place = %d, want 3500", got)
+	}
+}
+
+// A node holding only DaemonSet pods is still reclaimable: those pods are
+// recreated on every node regardless, so they do not keep a node alive.
+func TestIsEmptyIgnoresDaemonSetPods(t *testing.T) {
+	ds := pod("node-exporter", "a", 100, nil)
+	ds.Owner = &model.OwnerRef{Kind: "DaemonSet", Name: "node-exporter"}
+
+	snap := &model.ClusterSnapshot{
+		Nodes: []model.Node{node("a", "z1", 4000)},
+		Pods:  []model.Pod{ds},
+	}
+	p := constraints.NewPlacement(snap)
+
+	if !p.IsEmpty("a") {
+		t.Error("a node holding only DaemonSet pods must count as reclaimable")
+	}
+}
+
+// The packer explores many candidate packings; each must be isolated.
+func TestCloneIsolatesMutations(t *testing.T) {
+	snap := &model.ClusterSnapshot{
+		Nodes: []model.Node{node("a", "z1", 4000), node("b", "z1", 4000)},
+		Pods:  []model.Pod{pod("p1", "a", 1000, nil)},
+	}
+	original := constraints.NewPlacement(snap)
+	clone := original.Clone()
+
+	clone.Place(pod("p2", "", 1000, nil), "b")
+
+	if original.Free("b").MilliCPU != 4000 {
+		t.Error("mutating the clone changed the original")
+	}
+	if clone.Free("b").MilliCPU != 3000 {
+		t.Error("clone did not record its own placement")
+	}
+}
+
+func TestCandidateNodesExcludesCurrentNode(t *testing.T) {
+	snap := &model.ClusterSnapshot{
+		Nodes: []model.Node{node("a", "z1", 4000), node("b", "z1", 4000), node("c", "z1", 4000)},
+		Pods:  []model.Pod{pod("p1", "a", 1000, nil)},
+	}
+	p := constraints.NewPlacement(snap)
+
+	got := p.CandidateNodes(pod("p1", "a", 1000, nil))
+	for _, n := range got {
+		if n == "a" {
+			t.Error("candidate list must exclude the pod's current node")
+		}
+	}
+	if len(got) != 2 {
+		t.Errorf("expected 2 candidates, got %v", got)
+	}
+}


### PR DESCRIPTION
The planner now understands *why* pods can and cannot move. Every snapshot is followed by an analysis:

```
constraints: movable=118 blocked=4 stuck=25 pdbBlocked=3 antiAffinity=0
             spreadBound=1 controllerPinned=1 nodesUndrainable=4
```

Nothing packs against this yet — the bin-packer is M4.

## Explanations are produced once, here

The UI inspector and the Kagent agent will surface these exact strings rather than deriving their own, so the two can never disagree about why a pod is stuck. They name the responsible object and carry live numbers, because *"a PDB blocks this"* is not an explanation:

```
PodDisruptionBudget dencer-demo/dencer-demo-payments currently allows 0
disruptions (3 healthy, 3 required). The API server will refuse to evict this pod.

PodDisruptionBudget dencer-demo/dencer-demo-catalog allows 2 more concurrent
disruption(s) (3 healthy, 1 required).
```

A test asserts every constraint carries non-trivial explanation text, so a blank or generic string cannot reach the UI.

## Placement lives in the same package as the explanations

`Placement` is the feasibility evaluator M4 will pack against — taints, node selector, node affinity, resources, pod affinity/anti-affinity across topology domains, and hard topology spread. It sits beside the analyzer deliberately: **an explanation that contradicts the plan is worse than no explanation**, so both come from one implementation.

Only **hard** constraints affect feasibility. A `ScheduleAnyway` spread or a preferred affinity is recorded and explained but never reported as a blocker — treating a preference as a blocker would make the planner refuse moves the scheduler allows.

18 tests, including the cases that are easy to get wrong:

- zone-scoped anti-affinity must consider sibling nodes in the zone, not just the target node
- topology spread must simulate the placement, since skew is evaluated *after* the pod lands
- a node holding only DaemonSet pods still counts as reclaimable
- `Clone()` isolates candidate packings from each other

## Verified live across all five scenarios

| Scenario | Signal |
|---|---|
| `b-pdb-blocked` | `pdbBlocked=3` — the 3 payments replicas |
| `c-topology-spread` | `spreadBound=7` — 6 frontend + baseline |
| `d-anti-affinity` | `antiAffinity=5` — 5 cache replicas |
| `e-tainted-pool` | clean, no false blockers |

`stuck=25` is constant and correct: those are the real-node workloads (kagent, kube-system, k8s-dencer itself) which genuinely have nowhere to go, since the cluster has one real node and the 30 fake ones are tainted.

## Two bugs found while building this

**A determinism bug in this PR's own code.** `Analysis.Pods` was a map, and Go's randomised map iteration leaked into serialized output — two analyses of identical input differed. Caught by a determinism test I wrote alongside. Now a slice sorted by key, which also gives the UI a stable list order.

**Two demo-tooling bugs, neither in the product.** `helm --wait` on the demo chart was gating on KWOK's fabricated pod readiness. kwok-controller runs `podPlayStageParallelism: 4`, and its `pod-ready` Stage selects only pods still in `phase: Pending` — so a pod that reaches `Running` without `Ready=True` never re-matches and stays not-ready forever. Under scenario churn this left 65 of 90 pods permanently unready and failed the install. Replaced with `make demo-wait`, which blocks on pods being *scheduled*, which is what the planner cares about. Separately, a failed upgrade orphaned resources that `helm uninstall` will not remove, leaving workloads from an inactive scenario running; `demo-down` now deletes the namespace and the synthetic nodes too.

## Verified

```
make test    24 tests across model, conversion, constraints and placement
make lint    all chart contract checks pass
live         all five scenarios produce the expected constraint signals
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)