### PR TITLE
M4: consolidation planner (greedy first-fit-decreasing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Phase 1 (MVP) — visibility and explainability. No execution capability.
 | **M1** | KWOK fake-node fabric + five constraint scenarios as Helm releases | **done** |
 | **M2** | Domain model + informer-backed cluster state collector | **done** |
 | **M3** | Constraint analyzer + placement feasibility evaluator | **done** |
-| M4 | Consolidation planner (greedy first-fit-decreasing) | next |
-| M5 | Impact classifier (Green/Yellow/Red + rationale) | pending |
+| **M4** | Consolidation planner (greedy first-fit-decreasing) | **done** |
+| M5 | Impact classifier (Green/Yellow/Red + rationale) | next |
 | M6 | Plan store (SQLite) + REST/WS API + graph payload | pending |
 | M7 | UI: before/after canvas, step timeline scrubber, constraint inspector | pending |
 | M8 | Kagent agent: read-only MCP tools + `Agent` CR | pending |
@@ -32,18 +32,19 @@ The planner watches the cluster through informers and publishes an immutable
 `ClusterSnapshot` every resync period:
 
 ```
-snapshot:    nodes=31 nodesOccupied=22 pods=117 pdbs=2 pdbsBlocking=1
+snapshot:    nodes=31 nodesOccupied=24 pods=117 pdbs=0 pdbsBlocking=0
              cpuRequestedPct=37.0% memRequestedPct=18.8% usageData=false
-constraints: movable=118 blocked=4 stuck=25 pdbBlocked=3 antiAffinity=0
-             spreadBound=1 controllerPinned=1 nodesUndrainable=4
+constraints: movable=116 blocked=1 stuck=26 antiAffinity=0 spreadBound=1
+             controllerPinned=1 nodesUndrainable=1
+plan:        id=c64d1364c6c0 strategy=greedy-first-fit-decreasing steps=11
+             nodesBefore=24 nodesAfter=13 reclaims=11
 ```
 
-Nothing yet *plans* against those snapshots — the bin-packer is M4 — and the UI
-is still a placeholder that only verifies backend connectivity. The plan store
-and API are M6.
+Plans are produced but not yet *rated* — Green/Yellow/Red is M5 — not persisted
+(the plan store is M6), and not visualised (the UI is still a placeholder).
 
-Two debug endpoints on the planner's health port expose the current state as
-YAML: `/debug/snapshot` and `/debug/constraints`.
+Three debug endpoints on the planner's health port expose current state as
+YAML: `/debug/snapshot`, `/debug/constraints` and `/debug/plan`.
 
 ---
 
@@ -70,7 +71,7 @@ internal/
   model/           domain types; NO k8s imports, so the planner is testable from a YAML snapshot
   cluster/         informer-backed collector, k8s->model conversion, MetricsSource
   constraints/     effective per-pod constraints + explanations; placement feasibility
-  planner/         Strategy interface + greedy bin-packing
+  planner/         Strategy interface + greedy first-fit-decreasing packer
   impact/          Green/Yellow/Red classifier + rationale
   store/           Store interface, sqlite/, migrations/
   api/             rest/ ws/ graph/ agenttools/
@@ -194,6 +195,28 @@ disruption(s) (3 healthy, 1 required).
 The same package holds `Placement`, the feasibility evaluator — taints, node selector, node affinity, resources, pod affinity/anti-affinity across topology domains, and hard topology spread. It lives here rather than in the packer so that the analyzer's explanations and the planner's decisions come from the same code; an explanation that disagrees with the plan is worse than none.
 
 Only **hard** constraints affect feasibility. A `ScheduleAnyway` spread constraint or a preferred affinity is recorded and explained but never reported as a blocker — treating a preference as a blocker would make the planner refuse moves the scheduler allows.
+
+## Planning
+
+`internal/planner` turns a snapshot plus its constraint analysis into an ordered sequence of atomic steps, each one draining a single node. On the demo fabric:
+
+```
+plan: id=c64d1364c6c0 steps=11 nodesBefore=24 nodesAfter=13 reclaims=11
+```
+
+**Greedy first-fit-decreasing**, behind a `Strategy` interface so the OR-Tools comparison in doc §10 stays open. Three choices drive the result:
+
+- **Drain candidates emptiest-first.** The least-loaded node is both cheapest to evacuate and most likely to succeed, so this frees the most nodes for a given amount of disruption.
+- **Place the largest pods first.** Big pods are hardest to fit; placing them last strands them in space the easy pods have already fragmented.
+- **Prefer the *fullest* destination that still fits.** This is what makes it consolidation. A plain first-fit over an arbitrary node order spreads load evenly and frees nothing.
+
+A node is accepted only if **every** movable pod on it finds a home. A partial evacuation frees no node, so a step that cannot complete is never proposed.
+
+The planner is deterministic by construction — the plan ID is a content hash of the steps, so re-planning an unchanged cluster yields the same ID and "has the plan changed?" is a string comparison. It also plans the *ideal* end state regardless of whether a step is safe to run right now; risk is scored separately (M5) and enforced separately (Phase 2), so the plan's shape never depends on the time of day.
+
+Policy inputs are chart values today and become the `ConsolidationPolicy` CRD later: `planner.minNodeAge` (skip fresh nodes so consolidation doesn't fight the autoscaler), `planner.maxSteps`, `planner.excludeNamespaces`. Control-plane nodes are excluded by default.
+
+Ten tests cover it, including the ones that matter most: every proposed move must still be feasible when the plan is *applied in order*, every step must fully empty its target, and no step may drain a node holding a pod the analyzer says cannot be evicted.
 
 ## Kagent
 

--- a/charts/k8s-dencer/ci/orbstack-values.yaml
+++ b/charts/k8s-dencer/ci/orbstack-values.yaml
@@ -7,6 +7,10 @@
 # directly, so `docker build` + `helm upgrade` is the whole loop. Requires a
 # non-:latest tag, which the Makefile supplies from the git SHA.
 planner:
+  # The KWOK fabric is torn down and recreated constantly, so the production
+  # 10m minimum would leave every node ineligible and the demo would show an
+  # empty plan.
+  minNodeAge: 30s
   image:
     registry: ""
     repository: k8s-dencer-planner

--- a/charts/k8s-dencer/templates/planner/deployment.yaml
+++ b/charts/k8s-dencer/templates/planner/deployment.yaml
@@ -57,6 +57,14 @@ spec:
             - name: WATCH_NAMESPACES
               value: {{ join "," . | quote }}
             {{- end }}
+            - name: MIN_NODE_AGE
+              value: {{ .Values.planner.minNodeAge | quote }}
+            - name: MAX_STEPS
+              value: {{ .Values.planner.maxSteps | quote }}
+            {{- with .Values.planner.excludeNamespaces }}
+            - name: EXCLUDE_NAMESPACES
+              value: {{ join "," . | quote }}
+            {{- end }}
             - name: DATABASE_TYPE
               value: {{ .Values.database.type | quote }}
             {{- if eq .Values.database.type "sqlite" }}

--- a/charts/k8s-dencer/values.schema.json
+++ b/charts/k8s-dencer/values.schema.json
@@ -95,6 +95,12 @@
               "type": "array",
               "items": { "type": "string", "minLength": 1 }
             },
+            "minNodeAge": { "$ref": "#/definitions/duration" },
+            "maxSteps": { "type": "integer", "minimum": 0 },
+            "excludeNamespaces": {
+              "type": "array",
+              "items": { "type": "string", "minLength": 1 }
+            },
             "resources": { "$ref": "#/definitions/resources" },
             "podDisruptionBudget": { "$ref": "#/definitions/pdb" }
           }

--- a/charts/k8s-dencer/values.yaml
+++ b/charts/k8s-dencer/values.yaml
@@ -93,6 +93,19 @@ planner:
   # cluster-scoped regardless: restricting them would leave the planner with
   # workloads and nowhere to place them.
   watchNamespaces: []
+
+  # Consolidation policy inputs. These become the ConsolidationPolicy CRD in a
+  # later milestone; they are values for now so the planner is tunable today.
+  #
+  # minNodeAge skips recently created nodes: a node that appeared moments ago
+  # is probably a deliberate scale-up, and draining it immediately would fight
+  # the autoscaler.
+  minNodeAge: 10m
+  # Cap on plan length. 0 means unlimited.
+  maxSteps: 0
+  # Pods in these namespaces are treated as immovable, which makes their nodes
+  # undrainable.
+  excludeNamespaces: []
   resources:
     requests:
       cpu: 50m

--- a/cmd/planner/main.go
+++ b/cmd/planner/main.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"syscall"
@@ -24,6 +25,7 @@ import (
 	"github.com/atedgimo/k8s-dencer/internal/constraints"
 	"github.com/atedgimo/k8s-dencer/internal/httpserver"
 	"github.com/atedgimo/k8s-dencer/internal/model"
+	"github.com/atedgimo/k8s-dencer/internal/planner"
 	"github.com/atedgimo/k8s-dencer/internal/telemetry"
 )
 
@@ -63,6 +65,13 @@ func run(ctx context.Context, log *slog.Logger) error {
 
 	var latest atomic.Pointer[model.ClusterSnapshot]
 	var latestAnalysis atomic.Pointer[constraints.Analysis]
+	var latestPlan atomic.Pointer[model.Plan]
+
+	strategy := planner.Greedy{}
+	planOpts := planner.DefaultOptions()
+	planOpts.MinNodeAge = duration(log, "MIN_NODE_AGE", planOpts.MinNodeAge)
+	planOpts.MaxSteps = intEnv(log, "MAX_STEPS", 0)
+	planOpts.ExcludeNamespaces = splitList(os.Getenv("EXCLUDE_NAMESPACES"))
 
 	health := &httpserver.Health{}
 	mux := http.NewServeMux()
@@ -75,6 +84,12 @@ func run(ctx context.Context, log *slog.Logger) error {
 	}))
 	mux.HandleFunc("GET /debug/constraints", yamlHandler(func() any {
 		if v := latestAnalysis.Load(); v != nil {
+			return v
+		}
+		return nil
+	}))
+	mux.HandleFunc("GET /debug/plan", yamlHandler(func() any {
+		if v := latestPlan.Load(); v != nil {
 			return v
 		}
 		return nil
@@ -102,7 +117,7 @@ func run(ctx context.Context, log *slog.Logger) error {
 	ticker := time.NewTicker(resync)
 	defer ticker.Stop()
 
-	collect(ctx, log, collector, &latest, &latestAnalysis)
+	collect(ctx, log, collector, &latest, &latestAnalysis, &latestPlan, strategy, planOpts)
 
 	for {
 		select {
@@ -113,7 +128,7 @@ func run(ctx context.Context, log *slog.Logger) error {
 		case err := <-serveErr:
 			return err
 		case <-ticker.C:
-			collect(ctx, log, collector, &latest, &latestAnalysis)
+			collect(ctx, log, collector, &latest, &latestAnalysis, &latestPlan, strategy, planOpts)
 		}
 	}
 }
@@ -124,6 +139,9 @@ func collect(
 	c *cluster.Collector,
 	latest *atomic.Pointer[model.ClusterSnapshot],
 	latestAnalysis *atomic.Pointer[constraints.Analysis],
+	latestPlan *atomic.Pointer[model.Plan],
+	strategy planner.Strategy,
+	planOpts planner.Options,
 ) {
 	snap, err := c.Snapshot(ctx)
 	if err != nil {
@@ -182,6 +200,35 @@ func collect(
 		"controllerPinned", cs.ControllerPin,
 		"nodesUndrainable", undrainable,
 	)
+
+	plan, err := strategy.Plan(snap, analysis, planOpts)
+	if err != nil {
+		log.Error("planning failed", "error", err)
+		return
+	}
+	latestPlan.Store(plan)
+
+	log.Info("plan",
+		"id", plan.ID,
+		"strategy", strategy.Name(),
+		"steps", len(plan.Steps),
+		"nodesBefore", plan.NodesBefore,
+		"nodesAfter", plan.NodesAfter,
+		"reclaims", plan.ReclaimedNodes(),
+	)
+}
+
+func intEnv(log *slog.Logger, key string, fallback int) int {
+	raw, ok := os.LookupEnv(key)
+	if !ok || raw == "" {
+		return fallback
+	}
+	v, err := strconv.Atoi(raw)
+	if err != nil {
+		log.Warn("invalid integer, using default", "key", key, "value", raw, "default", fallback)
+		return fallback
+	}
+	return v
 }
 
 // yamlHandler serves whatever load returns, as YAML.

--- a/internal/planner/greedy.go
+++ b/internal/planner/greedy.go
@@ -1,0 +1,223 @@
+package planner
+
+import (
+	"sort"
+	"time"
+
+	"github.com/atedgimo/k8s-dencer/internal/constraints"
+	"github.com/atedgimo/k8s-dencer/internal/model"
+)
+
+// Greedy is a first-fit-decreasing bin-packer.
+//
+// It walks drain candidates emptiest-first and, for each, tries to relocate
+// every movable pod onto the nodes that remain. A node is accepted only if
+// *all* of its pods find a home — a partial evacuation frees nothing, so a
+// step that cannot complete is not proposed at all.
+//
+// Chosen over a constraint solver for the MVP because it is fast enough to
+// re-plan continuously, trivially deterministic, and has no CGO dependency.
+// Architecture doc §10 keeps the OR-Tools comparison open; the Strategy
+// interface is what makes swapping it a contained change.
+type Greedy struct{}
+
+// Name implements Strategy.
+func (Greedy) Name() string { return "greedy-first-fit-decreasing" }
+
+// Plan implements Strategy.
+func (Greedy) Plan(snap *model.ClusterSnapshot, analysis *constraints.Analysis, opts Options) (*model.Plan, error) {
+	now := opts.Now
+	if now.IsZero() {
+		now = snap.TakenAt
+	}
+
+	// The working placement is mutated as steps are accepted, so later steps
+	// see the cluster as earlier steps will have left it. Planning each step
+	// against the original state would produce a set of moves that conflict
+	// with each other.
+	work := constraints.NewPlacement(snap)
+	nodesBefore := occupiedNodes(work)
+
+	candidates := drainCandidates(snap, opts, now)
+	sortNodesForDraining(candidates, work)
+
+	drained := make(map[string]bool, len(candidates))
+	steps := make([]model.PlanStep, 0, len(candidates))
+
+	for _, node := range candidates {
+		if opts.MaxSteps > 0 && len(steps) >= opts.MaxSteps {
+			break
+		}
+		if work.IsEmpty(node.Name) {
+			// Already reclaimable; nothing to do and no step to propose.
+			drained[node.Name] = true
+			continue
+		}
+
+		moves, ok := tryDrain(work, node, drained, analysis, opts)
+		if !ok {
+			continue
+		}
+
+		// Commit only once the whole node is known to be evacuable.
+		for _, m := range moves {
+			pod, found := findPod(work, m.FromNode, m.Namespace, m.Pod)
+			if !found {
+				continue
+			}
+			work.Remove(pod)
+			work.Place(pod, m.ToNode)
+		}
+		drained[node.Name] = true
+
+		steps = append(steps, model.PlanStep{
+			SequenceNumber: len(steps) + 1,
+			TargetNode:     node.Name,
+			Moves:          moves,
+		})
+	}
+
+	for i := range steps {
+		steps[i].ID = stepID(steps[i])
+	}
+
+	return &model.Plan{
+		ID:              planID(Greedy{}.Name(), steps),
+		GeneratedAt:     time.Now().UTC(),
+		SnapshotTakenAt: snap.TakenAt,
+		Status:          model.PlanValid,
+		Steps:           steps,
+		NodesBefore:     nodesBefore,
+		NodesAfter:      nodesBefore - len(steps),
+	}, nil
+}
+
+// tryDrain attempts to relocate every movable pod off node, against a
+// throwaway copy of the working state. Returns the moves only if all of them
+// succeed.
+func tryDrain(
+	work *constraints.Placement,
+	node model.Node,
+	drained map[string]bool,
+	analysis *constraints.Analysis,
+	opts Options,
+) ([]model.Move, bool) {
+	pods := make([]model.Pod, 0)
+	for _, p := range work.Occupants(node.Name) {
+		if !p.IsMovable() {
+			// DaemonSet and terminating pods stay put and do not block the
+			// drain; they simply do not need relocating.
+			continue
+		}
+		if opts.namespaceExcluded(p.Namespace) {
+			return nil, false
+		}
+		// A pod the analyzer says cannot be evicted (a zero-headroom PDB, for
+		// instance) makes the whole node undrainable.
+		if pc, ok := analysis.ForPod(p.Key()); ok && !pc.Movable {
+			return nil, false
+		}
+		pods = append(pods, p)
+	}
+	if len(pods) == 0 {
+		return nil, false
+	}
+
+	sortPodsBySizeDesc(pods)
+
+	trial := work.Clone()
+	moves := make([]model.Move, 0, len(pods))
+
+	for _, p := range pods {
+		target := firstFit(trial, p, node.Name, drained)
+		if target == "" {
+			// One unplaceable pod invalidates the whole step.
+			return nil, false
+		}
+		trial.Remove(p)
+		trial.Place(p, target)
+		moves = append(moves, model.Move{
+			Namespace: p.Namespace,
+			Pod:       p.Name,
+			FromNode:  node.Name,
+			ToNode:    target,
+		})
+	}
+	return moves, true
+}
+
+// firstFit picks a destination for pod, preferring the fullest node that can
+// still take it.
+//
+// Preferring fuller nodes concentrates load instead of spreading it, which is
+// the entire point of consolidation: a plain first-fit over an arbitrary node
+// order tends to leave every node partly used and frees nothing.
+func firstFit(trial *constraints.Placement, pod model.Pod, source string, drained map[string]bool) string {
+	type candidate struct {
+		name string
+		used float64
+	}
+	var options []candidate
+
+	for _, name := range trial.NodeNames() {
+		if name == source || drained[name] {
+			continue
+		}
+		if ok, _ := trial.CanPlace(pod, name); !ok {
+			continue
+		}
+		free := trial.Free(name)
+		options = append(options, candidate{name: name, used: 1 - free.DominantRatio(freeBasis(trial, name))})
+	}
+	if len(options) == 0 {
+		return ""
+	}
+	sort.SliceStable(options, func(i, j int) bool {
+		if options[i].used != options[j].used {
+			return options[i].used > options[j].used
+		}
+		return options[i].name < options[j].name
+	})
+	return options[0].name
+}
+
+// freeBasis returns the node's total allocatable, used as the denominator when
+// scoring how full a node is.
+func freeBasis(trial *constraints.Placement, name string) model.Resources {
+	free := trial.Free(name)
+	used := model.Resources{}
+	for _, p := range trial.Occupants(name) {
+		used = used.Add(p.Requests).Add(model.Resources{Pods: 1})
+	}
+	return free.Add(used)
+}
+
+// drainCandidates returns nodes policy permits draining, in snapshot order.
+func drainCandidates(snap *model.ClusterSnapshot, opts Options, now time.Time) []model.Node {
+	out := make([]model.Node, 0, len(snap.Nodes))
+	for _, n := range snap.Nodes {
+		if !n.Ready {
+			// An unready node's pods are already in trouble; moving them is
+			// the scheduler's problem, not a consolidation decision.
+			continue
+		}
+		if excluded, _ := opts.nodeExcluded(n, now); excluded {
+			continue
+		}
+		out = append(out, n)
+	}
+	return out
+}
+
+func findPod(p *constraints.Placement, nodeName, namespace, name string) (model.Pod, bool) {
+	for _, occupant := range p.Occupants(nodeName) {
+		if occupant.Namespace == namespace && occupant.Name == name {
+			return occupant, true
+		}
+	}
+	return model.Pod{}, false
+}
+
+func stepID(s model.PlanStep) string {
+	return planID("step", []model.PlanStep{s})
+}

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -1,0 +1,181 @@
+// Package planner turns a cluster snapshot into an ordered sequence of
+// consolidation steps.
+//
+// The planner is deliberately deterministic and algorithmic, not
+// LLM-driven: given the same snapshot it must produce the same plan, every
+// time, so that plans are auditable and regressions are catchable by a golden
+// test. The agent layer explains plans; it never makes them.
+//
+// It also plans the *ideal* end state without regard to whether a step is safe
+// to run right now. Risk is scored separately by the impact classifier, and
+// enforced separately by the safety guard. Mixing the two would mean the plan
+// silently changes shape depending on the time of day.
+package planner
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/atedgimo/k8s-dencer/internal/constraints"
+	"github.com/atedgimo/k8s-dencer/internal/model"
+)
+
+// Strategy produces a consolidation plan from observed state.
+//
+// The interface exists so the greedy heuristic can be compared against a
+// constraint solver later (architecture doc §10) without disturbing anything
+// that consumes plans.
+type Strategy interface {
+	// Name identifies the strategy in plan metadata and logs.
+	Name() string
+	// Plan computes a consolidation plan. It must not mutate its inputs and
+	// must be deterministic for a given snapshot and options.
+	Plan(snap *model.ClusterSnapshot, analysis *constraints.Analysis, opts Options) (*model.Plan, error)
+}
+
+// Options constrains what the planner is allowed to propose.
+type Options struct {
+	// MaxSteps caps plan length. Zero means unlimited.
+	MaxSteps int
+
+	// ExcludeNodeLabels excludes a node from being drained if it carries any
+	// of these label keys, whatever the value. Control-plane nodes are
+	// excluded by default: draining the API server out from under the cluster
+	// is not consolidation.
+	ExcludeNodeLabels []string
+
+	// ExcludeNamespaces marks pods in these namespaces immovable, which in
+	// practice makes their nodes undrainable.
+	ExcludeNamespaces []string
+
+	// MinNodeAge skips nodes younger than this. A node that was created
+	// seconds ago is probably being scaled up on purpose, and draining it
+	// immediately would fight the autoscaler.
+	MinNodeAge time.Duration
+
+	// Now is the reference time for MinNodeAge. Zero uses the snapshot time,
+	// which keeps planning reproducible from a fixture.
+	Now time.Time
+}
+
+// DefaultExcludeNodeLabels are the label keys that mark a node as
+// infrastructure rather than a consolidation candidate.
+var DefaultExcludeNodeLabels = []string{
+	"node-role.kubernetes.io/control-plane",
+	"node-role.kubernetes.io/master",
+}
+
+// DefaultOptions returns options safe for any cluster.
+func DefaultOptions() Options {
+	return Options{
+		ExcludeNodeLabels: DefaultExcludeNodeLabels,
+		MinNodeAge:        10 * time.Minute,
+	}
+}
+
+// nodeExcluded reports whether policy forbids draining this node, and why.
+func (o Options) nodeExcluded(n model.Node, now time.Time) (bool, string) {
+	for _, key := range o.ExcludeNodeLabels {
+		if _, ok := n.Labels[key]; ok {
+			return true, fmt.Sprintf("carries excluded label %s", key)
+		}
+	}
+	if o.MinNodeAge > 0 && !n.CreatedAt.IsZero() {
+		if age := now.Sub(n.CreatedAt); age < o.MinNodeAge {
+			return true, fmt.Sprintf("younger than the %s minimum node age", o.MinNodeAge)
+		}
+	}
+	return false, ""
+}
+
+func (o Options) namespaceExcluded(ns string) bool {
+	for _, e := range o.ExcludeNamespaces {
+		if e == ns {
+			return true
+		}
+	}
+	return false
+}
+
+// planID is a stable content hash of the plan's steps.
+//
+// Content-addressed rather than random or time-based so that re-planning an
+// unchanged cluster yields the same ID. That makes "has the plan actually
+// changed?" a string comparison, and keeps golden tests meaningful.
+func planID(strategy string, steps []model.PlanStep) string {
+	h := sha256.New()
+	fmt.Fprintf(h, "%s\n", strategy)
+	for _, s := range steps {
+		fmt.Fprintf(h, "%d|%s|", s.SequenceNumber, s.TargetNode)
+		for _, m := range s.Moves {
+			fmt.Fprintf(h, "%s/%s:%s>%s,", m.Namespace, m.Pod, m.FromNode, m.ToNode)
+		}
+		fmt.Fprint(h, "\n")
+	}
+	return hex.EncodeToString(h.Sum(nil))[:12]
+}
+
+// occupiedNodes counts nodes currently holding at least one movable pod.
+// Nodes holding only DaemonSet pods are already reclaimable and are not
+// counted as occupied.
+func occupiedNodes(p *constraints.Placement) int {
+	n := 0
+	for _, name := range p.NodeNames() {
+		if !p.IsEmpty(name) {
+			n++
+		}
+	}
+	return n
+}
+
+// sortNodesForDraining orders drain candidates emptiest-first.
+//
+// Evacuating the least-loaded node is both the cheapest move and the one most
+// likely to succeed, so taking them in this order frees the most nodes for a
+// given amount of disruption.
+func sortNodesForDraining(nodes []model.Node, p *constraints.Placement) {
+	sort.SliceStable(nodes, func(i, j int) bool {
+		ri := requestedRatio(nodes[i], p)
+		rj := requestedRatio(nodes[j], p)
+		if ri != rj {
+			return ri < rj
+		}
+		// Name tie-break keeps the plan stable across runs.
+		return nodes[i].Name < nodes[j].Name
+	})
+}
+
+func requestedRatio(n model.Node, p *constraints.Placement) float64 {
+	free := p.Free(n.Name)
+	used := n.Allocatable.Sub(free)
+	return used.DominantRatio(n.Allocatable)
+}
+
+// sortPodsBySizeDesc implements the "decreasing" half of first-fit-decreasing.
+// Large pods are hardest to place, so placing them first avoids stranding them
+// after the easy pods have fragmented the remaining space.
+func sortPodsBySizeDesc(pods []model.Pod) {
+	sort.SliceStable(pods, func(i, j int) bool {
+		a, b := pods[i].Requests, pods[j].Requests
+		if a.MilliCPU != b.MilliCPU {
+			return a.MilliCPU > b.MilliCPU
+		}
+		if a.MemoryBytes != b.MemoryBytes {
+			return a.MemoryBytes > b.MemoryBytes
+		}
+		return pods[i].Key() < pods[j].Key()
+	})
+}
+
+// describeMoves renders a step's moves for logs and debugging.
+func describeMoves(moves []model.Move) string {
+	parts := make([]string, 0, len(moves))
+	for _, m := range moves {
+		parts = append(parts, fmt.Sprintf("%s/%s->%s", m.Namespace, m.Pod, m.ToNode))
+	}
+	return strings.Join(parts, " ")
+}

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -1,0 +1,332 @@
+package planner_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/atedgimo/k8s-dencer/internal/constraints"
+	"github.com/atedgimo/k8s-dencer/internal/model"
+	"github.com/atedgimo/k8s-dencer/internal/planner"
+)
+
+func loadFixture(t *testing.T, name string) *model.ClusterSnapshot {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join("..", "..", "test", "fixtures", name+".yaml"))
+	if err != nil {
+		t.Skipf("fixture %s not available: %v", name, err)
+	}
+	var snap model.ClusterSnapshot
+	if err := yaml.Unmarshal(raw, &snap); err != nil {
+		t.Fatalf("parse fixture: %v", err)
+	}
+	return &snap
+}
+
+func planFor(t *testing.T, snap *model.ClusterSnapshot, opts planner.Options) *model.Plan {
+	t.Helper()
+	analysis := constraints.Analyze(snap)
+	p, err := planner.Greedy{}.Plan(snap, analysis, opts)
+	if err != nil {
+		t.Fatalf("plan: %v", err)
+	}
+	return p
+}
+
+// testOptions disables the minimum node age. Fixtures are captured minutes
+// after the fabric is created, so the production default would exclude every
+// node and make these tests silently vacuous.
+func testOptions() planner.Options {
+	o := planner.DefaultOptions()
+	o.MinNodeAge = 0
+	return o
+}
+
+// A plan that changes between runs on identical input cannot be audited, and
+// makes every golden test worthless.
+func TestPlanIsDeterministic(t *testing.T) {
+	snap := loadFixture(t, "a-fragmented")
+
+	first := planFor(t, snap, testOptions())
+	second := planFor(t, snap, testOptions())
+
+	if first.ID != second.ID {
+		t.Errorf("plan ID differs across runs: %s vs %s", first.ID, second.ID)
+	}
+	if len(first.Steps) != len(second.Steps) {
+		t.Fatalf("step count differs: %d vs %d", len(first.Steps), len(second.Steps))
+	}
+	for i := range first.Steps {
+		a, b := first.Steps[i], second.Steps[i]
+		if a.TargetNode != b.TargetNode {
+			t.Errorf("step %d targets %s then %s", i+1, a.TargetNode, b.TargetNode)
+		}
+		if len(a.Moves) != len(b.Moves) {
+			t.Errorf("step %d move count differs", i+1)
+			continue
+		}
+		for j := range a.Moves {
+			if a.Moves[j] != b.Moves[j] {
+				t.Errorf("step %d move %d differs: %+v vs %+v", i+1, j, a.Moves[j], b.Moves[j])
+			}
+		}
+	}
+}
+
+func TestPlanConsolidatesFragmentedCluster(t *testing.T) {
+	snap := loadFixture(t, "a-fragmented")
+	plan := planFor(t, snap, testOptions())
+
+	if len(plan.Steps) == 0 {
+		t.Fatal("a cluster at ~37% requested should be consolidatable")
+	}
+	if plan.NodesAfter >= plan.NodesBefore {
+		t.Errorf("plan frees nothing: before=%d after=%d", plan.NodesBefore, plan.NodesAfter)
+	}
+
+	total, requested := snap.Totals()
+	_ = total
+	// Nothing can pack tighter than the total requested CPU allows.
+	var maxNodeCPU int64
+	for _, n := range snap.Nodes {
+		if n.Allocatable.MilliCPU > maxNodeCPU {
+			maxNodeCPU = n.Allocatable.MilliCPU
+		}
+	}
+	floor := int(requested.MilliCPU / maxNodeCPU)
+	if plan.NodesAfter < floor {
+		t.Errorf("plan claims %d nodes but %dm CPU needs at least %d", plan.NodesAfter, requested.MilliCPU, floor)
+	}
+
+	t.Logf("nodes %d -> %d across %d steps (reclaims %d), floor %d, plan %s",
+		plan.NodesBefore, plan.NodesAfter, len(plan.Steps), plan.ReclaimedNodes(), floor, plan.ID)
+}
+
+// The critical correctness property: applying the plan must yield a cluster
+// the scheduler would actually accept. A plan that looks good but cannot be
+// executed is worse than no plan.
+func TestEveryProposedMoveIsFeasibleWhenApplied(t *testing.T) {
+	for _, fixture := range []string{"a-fragmented", "b-pdb-blocked"} {
+		t.Run(fixture, func(t *testing.T) {
+			snap := loadFixture(t, fixture)
+			plan := planFor(t, snap, testOptions())
+
+			work := constraints.NewPlacement(snap)
+			for _, step := range plan.Steps {
+				for _, m := range step.Moves {
+					pod, ok := findPod(work, m.FromNode, m.Namespace, m.Pod)
+					if !ok {
+						t.Fatalf("step %d moves %s/%s from %s, but it is not there",
+							step.SequenceNumber, m.Namespace, m.Pod, m.FromNode)
+					}
+					work.Remove(pod)
+					if placeable, why := work.CanPlace(pod, m.ToNode); !placeable {
+						t.Errorf("step %d proposes %s/%s -> %s, which is infeasible: %s",
+							step.SequenceNumber, m.Namespace, m.Pod, m.ToNode, why)
+					}
+					work.Place(pod, m.ToNode)
+				}
+			}
+		})
+	}
+}
+
+// A step exists to free a node. If the node still holds movable pods after the
+// step's moves are applied, the step accomplished nothing.
+func TestEveryStepFullyEmptiesItsTargetNode(t *testing.T) {
+	snap := loadFixture(t, "a-fragmented")
+	plan := planFor(t, snap, testOptions())
+
+	work := constraints.NewPlacement(snap)
+	for _, step := range plan.Steps {
+		for _, m := range step.Moves {
+			pod, ok := findPod(work, m.FromNode, m.Namespace, m.Pod)
+			if !ok {
+				continue
+			}
+			work.Remove(pod)
+			work.Place(pod, m.ToNode)
+		}
+		if !work.IsEmpty(step.TargetNode) {
+			remaining := 0
+			for _, p := range work.Occupants(step.TargetNode) {
+				if p.IsMovable() {
+					remaining++
+				}
+			}
+			t.Errorf("step %d targets %s but leaves %d movable pod(s) on it",
+				step.SequenceNumber, step.TargetNode, remaining)
+		}
+	}
+}
+
+// Steps must never target the same node twice, and sequence numbers must run
+// 1..N: the UI addresses steps by number and lets an operator run a subrange.
+func TestStepsAreOrderedAndUnique(t *testing.T) {
+	snap := loadFixture(t, "a-fragmented")
+	plan := planFor(t, snap, testOptions())
+
+	seen := map[string]int{}
+	for i, step := range plan.Steps {
+		if step.SequenceNumber != i+1 {
+			t.Errorf("step at index %d has sequence number %d", i, step.SequenceNumber)
+		}
+		if step.ID == "" {
+			t.Errorf("step %d has no ID", step.SequenceNumber)
+		}
+		if prev, dup := seen[step.TargetNode]; dup {
+			t.Errorf("node %s drained by both step %d and step %d", step.TargetNode, prev, step.SequenceNumber)
+		}
+		seen[step.TargetNode] = step.SequenceNumber
+
+		if len(step.Moves) == 0 {
+			t.Errorf("step %d has no moves", step.SequenceNumber)
+		}
+		for _, m := range step.Moves {
+			if m.FromNode != step.TargetNode {
+				t.Errorf("step %d targets %s but moves a pod off %s", step.SequenceNumber, step.TargetNode, m.FromNode)
+			}
+			if m.ToNode == m.FromNode {
+				t.Errorf("step %d moves %s/%s to its own node", step.SequenceNumber, m.Namespace, m.Pod)
+			}
+		}
+	}
+}
+
+// A pod behind a zero-headroom PDB cannot be evicted, so its node cannot be
+// drained. Proposing it would produce a step guaranteed to fail.
+func TestPlanNeverDrainsANodeHoldingABlockedPod(t *testing.T) {
+	snap := loadFixture(t, "b-pdb-blocked")
+	analysis := constraints.Analyze(snap)
+	plan := planFor(t, snap, testOptions())
+
+	blockedNodes := map[string]string{}
+	for _, pc := range analysis.Pods {
+		if !pc.Movable && pc.NodeName != "" {
+			blockedNodes[pc.NodeName] = pc.Key()
+		}
+	}
+	if len(blockedNodes) == 0 {
+		t.Skip("fixture has no blocked pods")
+	}
+
+	for _, step := range plan.Steps {
+		if pod, blocked := blockedNodes[step.TargetNode]; blocked {
+			t.Errorf("step %d drains %s, which holds unevictable pod %s",
+				step.SequenceNumber, step.TargetNode, pod)
+		}
+	}
+	t.Logf("%d node(s) correctly excluded from draining", len(blockedNodes))
+}
+
+// Control-plane nodes are excluded by default; draining the API server out
+// from under the cluster is not consolidation.
+func TestControlPlaneNodesAreNeverDrained(t *testing.T) {
+	snap := &model.ClusterSnapshot{
+		TakenAt: time.Now(),
+		Nodes: []model.Node{
+			{
+				Name:        "cp",
+				Ready:       true,
+				Labels:      map[string]string{"node-role.kubernetes.io/control-plane": ""},
+				Allocatable: model.Resources{MilliCPU: 8000, MemoryBytes: 1 << 34, Pods: 110},
+			},
+			{
+				Name:        "worker",
+				Ready:       true,
+				Allocatable: model.Resources{MilliCPU: 8000, MemoryBytes: 1 << 34, Pods: 110},
+			},
+		},
+		Pods: []model.Pod{
+			{Namespace: "kube-system", Name: "api", NodeName: "cp", Phase: model.PodRunning,
+				Requests: model.Resources{MilliCPU: 500, MemoryBytes: 1 << 28}},
+		},
+	}
+
+	plan := planFor(t, snap, testOptions())
+	for _, step := range plan.Steps {
+		if step.TargetNode == "cp" {
+			t.Error("control-plane node must never be a drain target")
+		}
+	}
+}
+
+func TestMinNodeAgeSkipsFreshNodes(t *testing.T) {
+	now := time.Now()
+	snap := &model.ClusterSnapshot{
+		TakenAt: now,
+		Nodes: []model.Node{
+			{Name: "fresh", Ready: true, CreatedAt: now.Add(-1 * time.Minute),
+				Allocatable: model.Resources{MilliCPU: 8000, MemoryBytes: 1 << 34, Pods: 110}},
+			{Name: "old", Ready: true, CreatedAt: now.Add(-2 * time.Hour),
+				Allocatable: model.Resources{MilliCPU: 8000, MemoryBytes: 1 << 34, Pods: 110}},
+		},
+		Pods: []model.Pod{
+			{Namespace: "d", Name: "p", NodeName: "fresh", Phase: model.PodRunning,
+				Requests: model.Resources{MilliCPU: 100, MemoryBytes: 1 << 26}},
+		},
+	}
+
+	opts := planner.DefaultOptions()
+	opts.MinNodeAge = 10 * time.Minute
+	opts.Now = now
+
+	plan := planFor(t, snap, opts)
+	for _, step := range plan.Steps {
+		if step.TargetNode == "fresh" {
+			t.Error("a node younger than MinNodeAge must not be drained; it is probably a deliberate scale-up")
+		}
+	}
+}
+
+func TestMaxStepsCapsPlanLength(t *testing.T) {
+	snap := loadFixture(t, "a-fragmented")
+
+	full := planFor(t, snap, testOptions())
+	if len(full.Steps) < 3 {
+		t.Skip("fixture does not produce enough steps to test the cap")
+	}
+
+	opts := testOptions()
+	opts.MaxSteps = 2
+	capped := planFor(t, snap, opts)
+
+	if len(capped.Steps) != 2 {
+		t.Errorf("MaxSteps=2 produced %d steps", len(capped.Steps))
+	}
+	// The capped plan must be a prefix of the full one, or "run steps 1-2"
+	// would mean something different depending on the cap.
+	for i := range capped.Steps {
+		if capped.Steps[i].TargetNode != full.Steps[i].TargetNode {
+			t.Errorf("capped plan diverges at step %d: %s vs %s",
+				i+1, capped.Steps[i].TargetNode, full.Steps[i].TargetNode)
+		}
+	}
+}
+
+func TestEmptyClusterProducesEmptyPlan(t *testing.T) {
+	snap := &model.ClusterSnapshot{TakenAt: time.Now()}
+	plan := planFor(t, snap, testOptions())
+
+	if len(plan.Steps) != 0 {
+		t.Errorf("empty cluster produced %d steps", len(plan.Steps))
+	}
+	if plan.ReclaimedNodes() != 0 {
+		t.Error("empty cluster cannot reclaim nodes")
+	}
+	if plan.ID == "" {
+		t.Error("even an empty plan needs an ID")
+	}
+}
+
+func findPod(p *constraints.Placement, nodeName, namespace, name string) (model.Pod, bool) {
+	for _, occupant := range p.Occupants(nodeName) {
+		if occupant.Namespace == namespace && occupant.Name == name {
+			return occupant, true
+		}
+	}
+	return model.Pod{}, false
+}


### PR DESCRIPTION
The planner now produces plans. On the demo fabric:

```
plan: id=c64d1364c6c0 strategy=greedy-first-fit-decreasing steps=11
      nodesBefore=24 nodesAfter=13 reclaims=11
```

Steps are not yet rated (M5), persisted (M6) or visualised (M7).

## The algorithm

Greedy first-fit-decreasing behind a `Strategy` interface, so the OR-Tools comparison in doc §10 stays open. Three choices drive the result:

- **Drain candidates emptiest-first.** The least-loaded node is both cheapest to evacuate and most likely to succeed, so this frees the most nodes for a given amount of disruption.
- **Place the largest pods first** — the "decreasing" half. Big pods are hardest to fit; placing them last strands them in space the easy pods already fragmented.
- **Prefer the fullest destination that still fits.** This is what makes it consolidation. A plain first-fit over an arbitrary node order spreads load evenly and frees nothing — worth a look during review, since it is the least obvious of the three.

A node is accepted only if **every** movable pod finds a home. Partial evacuation frees no node, so a step that cannot complete is never proposed.

## Determinism is a design property

The plan ID is a content hash of the steps, so re-planning an unchanged cluster yields the same ID and *"has the plan changed?"* becomes a string comparison. Every sort has an explicit tie-break.

The planner also computes the **ideal** end state regardless of whether a step is safe to run right now. Risk is scored separately (M5) and enforced separately (Phase 2), so a plan's shape never depends on the time of day.

## Tests

Ten, including the three properties that actually matter:

- every proposed move must still be feasible when the plan is applied **in order** — planning each step against the original state would produce moves that conflict with each other
- every step must fully empty its target node
- no step may drain a node holding a pod the analyzer says cannot be evicted

Against `a-fragmented` the packer reaches **13 nodes where the arithmetic floor is 11** — a test asserts it never claims to beat that floor, which would indicate a bug rather than brilliance.

## Policy

Chart values now, `ConsolidationPolicy` CRD later: `planner.minNodeAge`, `planner.maxSteps`, `planner.excludeNamespaces`.

Control-plane nodes are excluded by default — draining the API server out from under the cluster is not consolidation. `minNodeAge` defaults to 10m so consolidation does not fight an autoscaler that just scaled up; the orbstack overlay lowers it to 30s, because the KWOK fabric is recreated constantly and the production default would leave every node ineligible and show an empty plan.

## Verified

```
make test    34 tests across model, conversion, constraints, placement, planner
make lint    all chart contract checks pass
live         24 occupied nodes -> 13, 11 steps, 58 moves
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)