### PR TITLE
M5: impact classifier (Green/Yellow/Red + rationale)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -276,7 +276,7 @@ demo-down: ## Remove the synthetic topology (deletes the fake nodes)
 .PHONY: scenario
 scenario: ## Switch scenario: make scenario S=b-pdb-blocked
 	@if [ -z "$(S)" ]; then \
-		echo "usage: make scenario S=<a-fragmented|b-pdb-blocked|c-topology-spread|d-anti-affinity|e-tainted-pool>"; \
+		echo "usage: make scenario S=<a-fragmented|b-pdb-blocked|c-topology-spread|d-anti-affinity|e-tainted-pool|f-stateful>"; \
 		exit 1; \
 	fi
 	helm upgrade --install $(DEMO_RELEASE) demo/charts/dencer-demo \

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Phase 1 (MVP) — visibility and explainability. No execution capability.
 | **M2** | Domain model + informer-backed cluster state collector | **done** |
 | **M3** | Constraint analyzer + placement feasibility evaluator | **done** |
 | **M4** | Consolidation planner (greedy first-fit-decreasing) | **done** |
-| M5 | Impact classifier (Green/Yellow/Red + rationale) | next |
-| M6 | Plan store (SQLite) + REST/WS API + graph payload | pending |
+| **M5** | Impact classifier (Green/Yellow/Red + rationale) | **done** |
+| M6 | Plan store (SQLite) + REST/WS API + graph payload | next |
 | M7 | UI: before/after canvas, step timeline scrubber, constraint inspector | pending |
 | M8 | Kagent agent: read-only MCP tools + `Agent` CR | pending |
 
@@ -36,12 +36,12 @@ snapshot:    nodes=31 nodesOccupied=24 pods=117 pdbs=0 pdbsBlocking=0
              cpuRequestedPct=37.0% memRequestedPct=18.8% usageData=false
 constraints: movable=116 blocked=1 stuck=26 antiAffinity=0 spreadBound=1
              controllerPinned=1 nodesUndrainable=1
-plan:        id=c64d1364c6c0 strategy=greedy-first-fit-decreasing steps=11
-             nodesBefore=24 nodesAfter=13 reclaims=11
+plan:        id=8bb7900e46db steps=15 nodesBefore=28 nodesAfter=13 reclaims=15
+             green=6 yellow=5 red=4
 ```
 
-Plans are produced but not yet *rated* — Green/Yellow/Red is M5 — not persisted
-(the plan store is M6), and not visualised (the UI is still a placeholder).
+Plans are rated and explained, but not persisted (the plan store is M6) and not
+visualised (the UI is still a placeholder).
 
 Three debug endpoints on the planner's health port expose current state as
 YAML: `/debug/snapshot`, `/debug/constraints` and `/debug/plan`.
@@ -72,7 +72,7 @@ internal/
   cluster/         informer-backed collector, k8s->model conversion, MetricsSource
   constraints/     effective per-pod constraints + explanations; placement feasibility
   planner/         Strategy interface + greedy first-fit-decreasing packer
-  impact/          Green/Yellow/Red classifier + rationale
+  impact/          Green/Yellow/Red classifier + rationale composition
   store/           Store interface, sqlite/, migrations/
   api/             rest/ ws/ graph/ agenttools/
 ui/                React + Vite + Cytoscape.js
@@ -156,6 +156,7 @@ The base filler workload deploys in **every** scenario, so there is always somet
 | `c-topology-spread` | 6 replicas, `maxSkew: 1` over 3 zones | moves preserve 2-per-zone |
 | `d-anti-affinity` | 5 replicas, required anti-affinity on hostname | each pins a node open; rationale names the rule |
 | `e-tainted-pool` | 3 nodes tainted `dedicated=batch` | pool neither packed into nor drained out of |
+| `f-stateful` | StatefulSet + a bare unmanaged pod | the only scenario producing **Red** steps |
 
 Verified against the live cluster: evicting a `payments` pod is refused with `TooManyRequests`, while `catalog` succeeds — real PDB enforcement on fake nodes.
 
@@ -217,6 +218,30 @@ The planner is deterministic by construction — the plan ID is a content hash o
 Policy inputs are chart values today and become the `ConsolidationPolicy` CRD later: `planner.minNodeAge` (skip fresh nodes so consolidation doesn't fight the autoscaler), `planner.maxSteps`, `planner.excludeNamespaces`. Control-plane nodes are excluded by default.
 
 Ten tests cover it, including the ones that matter most: every proposed move must still be feasible when the plan is *applied in order*, every step must fully empty its target, and no step may drain a node holding a pod the analyzer says cannot be evicted.
+
+## Impact ratings
+
+`internal/impact` rates every step and explains the rating. The rating is **policy, not advice**: doc §5 confines Red steps to an approved maintenance window, and Phase 2's safety guard will enforce that in code rather than trusting UI input validation. So a rating has to be defensible, which is why each one names the specific object and number behind it:
+
+```
+Draining kwok-node-19 moves 1 pod(s). Rated Red because: dencer-demo/dencer-demo-orphan
+has no controller. Evicting it deletes it permanently; nothing will recreate it.
+Red steps may only execute inside an approved maintenance window.
+```
+
+| Rating | Driven by |
+|---|---|
+| **Red** | unmanaged pod (eviction deletes it permanently), StatefulSet pod, PDB at zero headroom, blast radius ≥ `redPodsMoved` |
+| **Yellow** | PDB headroom ≤ `tightPDBHeadroom`, PersistentVolumeClaim, required anti-affinity, hard topology spread, blast radius ≥ `yellowPodsMoved` |
+| **Green** | none of the above |
+
+The worst factor decides, and the rationale **leads with it** — that's the question an operator is actually asking — then lists supporting factors. Anti-affinity and spread rationales quote the analyzer's explanation verbatim rather than re-deriving it, so the two can't drift.
+
+Only **hard** constraints count. A `ScheduleAnyway` spread constraint never affects a rating: flagging a preference the scheduler would happily violate is a false alarm, and false alarms are how a tool gets ignored.
+
+Thresholds are chart values (`planner.impact.*`) because doc §10 is explicit that where PDB headroom stops being acceptable differs per cluster. Defaults are deliberately cautious — an operator who finds them noisy can loosen them; one surprised by an outage they were told was Green will not trust the tool again.
+
+> Red steps only appear under scenario `f-stateful`. The planner already refuses to drain nodes holding unevictable pods, so a zero-headroom PDB never reaches a step — that scenario exists specifically so the Red path is exercised end to end.
 
 ## Kagent
 

--- a/charts/k8s-dencer/templates/planner/deployment.yaml
+++ b/charts/k8s-dencer/templates/planner/deployment.yaml
@@ -65,6 +65,12 @@ spec:
             - name: EXCLUDE_NAMESPACES
               value: {{ join "," . | quote }}
             {{- end }}
+            - name: YELLOW_PODS_MOVED
+              value: {{ .Values.planner.impact.yellowPodsMoved | quote }}
+            - name: RED_PODS_MOVED
+              value: {{ .Values.planner.impact.redPodsMoved | quote }}
+            - name: TIGHT_PDB_HEADROOM
+              value: {{ .Values.planner.impact.tightPDBHeadroom | quote }}
             - name: DATABASE_TYPE
               value: {{ .Values.database.type | quote }}
             {{- if eq .Values.database.type "sqlite" }}

--- a/charts/k8s-dencer/values.schema.json
+++ b/charts/k8s-dencer/values.schema.json
@@ -101,6 +101,14 @@
               "type": "array",
               "items": { "type": "string", "minLength": 1 }
             },
+            "impact": {
+              "type": "object",
+              "properties": {
+                "yellowPodsMoved": { "type": "integer", "minimum": 1 },
+                "redPodsMoved": { "type": "integer", "minimum": 1 },
+                "tightPDBHeadroom": { "type": "integer", "minimum": 0 }
+              }
+            },
             "resources": { "$ref": "#/definitions/resources" },
             "podDisruptionBudget": { "$ref": "#/definitions/pdb" }
           }

--- a/charts/k8s-dencer/values.yaml
+++ b/charts/k8s-dencer/values.yaml
@@ -106,6 +106,20 @@ planner:
   # Pods in these namespaces are treated as immovable, which makes their nodes
   # undrainable.
   excludeNamespaces: []
+
+  # Impact-rating thresholds. Doc §10 is explicit that where PDB headroom stops
+  # being acceptable differs per cluster, so these are tunable rather than
+  # baked in. Defaults are deliberately cautious: an operator who finds them
+  # noisy can loosen them, but one surprised by an outage they were told was
+  # Green will not trust the tool again.
+  impact:
+    # Pods moved in a single step, at or above which the step is Yellow.
+    yellowPodsMoved: 5
+    # Pods moved in a single step, at or above which the step is Red.
+    redPodsMoved: 15
+    # PDB disruption headroom at or below which a covering PDB makes a step
+    # Yellow. Zero headroom is always Red regardless of this value.
+    tightPDBHeadroom: 1
   resources:
     requests:
       cpu: 50m

--- a/cmd/planner/main.go
+++ b/cmd/planner/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/atedgimo/k8s-dencer/internal/cluster"
 	"github.com/atedgimo/k8s-dencer/internal/constraints"
 	"github.com/atedgimo/k8s-dencer/internal/httpserver"
+	"github.com/atedgimo/k8s-dencer/internal/impact"
 	"github.com/atedgimo/k8s-dencer/internal/model"
 	"github.com/atedgimo/k8s-dencer/internal/planner"
 	"github.com/atedgimo/k8s-dencer/internal/telemetry"
@@ -73,6 +74,12 @@ func run(ctx context.Context, log *slog.Logger) error {
 	planOpts.MaxSteps = intEnv(log, "MAX_STEPS", 0)
 	planOpts.ExcludeNamespaces = splitList(os.Getenv("EXCLUDE_NAMESPACES"))
 
+	classifier := impact.New(impact.Thresholds{
+		YellowPodsMoved:  intEnv(log, "YELLOW_PODS_MOVED", 0),
+		RedPodsMoved:     intEnv(log, "RED_PODS_MOVED", 0),
+		TightPDBHeadroom: int32(intEnv(log, "TIGHT_PDB_HEADROOM", 0)),
+	})
+
 	health := &httpserver.Health{}
 	mux := http.NewServeMux()
 	health.Register(mux)
@@ -117,7 +124,7 @@ func run(ctx context.Context, log *slog.Logger) error {
 	ticker := time.NewTicker(resync)
 	defer ticker.Stop()
 
-	collect(ctx, log, collector, &latest, &latestAnalysis, &latestPlan, strategy, planOpts)
+	collect(ctx, log, collector, &latest, &latestAnalysis, &latestPlan, strategy, planOpts, classifier)
 
 	for {
 		select {
@@ -128,7 +135,7 @@ func run(ctx context.Context, log *slog.Logger) error {
 		case err := <-serveErr:
 			return err
 		case <-ticker.C:
-			collect(ctx, log, collector, &latest, &latestAnalysis, &latestPlan, strategy, planOpts)
+			collect(ctx, log, collector, &latest, &latestAnalysis, &latestPlan, strategy, planOpts, classifier)
 		}
 	}
 }
@@ -142,6 +149,7 @@ func collect(
 	latestPlan *atomic.Pointer[model.Plan],
 	strategy planner.Strategy,
 	planOpts planner.Options,
+	classifier impact.Classifier,
 ) {
 	snap, err := c.Snapshot(ctx)
 	if err != nil {
@@ -206,8 +214,12 @@ func collect(
 		log.Error("planning failed", "error", err)
 		return
 	}
+	// Rating happens after planning, never during it: the plan is the ideal
+	// end state, and risk is a separate judgement laid over it.
+	classifier.ClassifyPlan(plan, snap, analysis)
 	latestPlan.Store(plan)
 
+	byRating := plan.CountByRating()
 	log.Info("plan",
 		"id", plan.ID,
 		"strategy", strategy.Name(),
@@ -215,6 +227,9 @@ func collect(
 		"nodesBefore", plan.NodesBefore,
 		"nodesAfter", plan.NodesAfter,
 		"reclaims", plan.ReclaimedNodes(),
+		"green", byRating[model.ImpactGreen],
+		"yellow", byRating[model.ImpactYellow],
+		"red", byRating[model.ImpactRed],
 	)
 }
 

--- a/demo/charts/dencer-demo/templates/NOTES.txt
+++ b/demo/charts/dencer-demo/templates/NOTES.txt
@@ -22,6 +22,11 @@ What this scenario should provoke:
 {{- else if eq .Values.scenario "d-anti-affinity" }}
   cache replicas cannot share a node, so each pins a node open regardless of
   free capacity elsewhere. Ratings should name the anti-affinity rule.
+{{- else if eq .Values.scenario "f-stateful" }}
+  A StatefulSet and a bare unmanaged pod. Both make their steps Red: the
+  StatefulSet replacement cannot start until the old pod fully terminates, and
+  the unmanaged pod is simply deleted by eviction with nothing to recreate it.
+  This is the only scenario that exercises the Red rating end to end.
 {{- else if eq .Values.scenario "e-tainted-pool" }}
   The batch pool is reachable only with the dedicated toleration. General
   workloads must never be packed onto it, and batch pods must never be moved
@@ -33,7 +38,7 @@ Inspect:
   kubectl get pods -n {{ .Release.Namespace }} -o wide
 
 Switch scenario:
-  make scenario S=<a-fragmented|b-pdb-blocked|c-topology-spread|d-anti-affinity|e-tainted-pool>
+  make scenario S=<a-fragmented|b-pdb-blocked|c-topology-spread|d-anti-affinity|e-tainted-pool|f-stateful>
 
 NOTE: these Nodes are fake. No kubelet runs on them and no container in this
 release is ever executed — kwok-controller fabricates the lifecycle. Only the

--- a/demo/charts/dencer-demo/templates/scenario-f-stateful.yaml
+++ b/demo/charts/dencer-demo/templates/scenario-f-stateful.yaml
@@ -1,0 +1,61 @@
+{{- if eq .Values.scenario "f-stateful" }}
+{{/*
+Workloads that make a step Red.
+
+Without this scenario the demo fabric only ever produces Green and Yellow: the
+planner already refuses to drain nodes holding unevictable pods, so a
+zero-headroom PDB never reaches a step, and everything else here is a plain
+Deployment. That would leave the UI's Red state untested and the classifier's
+most consequential rules unexercised end to end.
+
+No volumeClaimTemplates on the StatefulSet: a PVC on a KWOK node would never
+bind, because local-path provisioning waits for a real kubelet that fake nodes
+do not have. The StatefulSet ownership alone is what drives the rating.
+*/}}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ .Release.Name }}-ledger
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "dencer-demo.labels" . | nindent 4 }}
+    dencer.io/role: stateful
+spec:
+  serviceName: {{ .Release.Name }}-ledger
+  replicas: 3
+  selector:
+    matchLabels:
+      app: dencer-ledger
+  template:
+    metadata:
+      labels:
+        app: dencer-ledger
+        dencer.io/synthetic: "true"
+    spec:
+      affinity:
+        {{- include "dencer-demo.nodeAffinity" . | nindent 8 }}
+      {{- include "dencer-demo.tolerations" . | nindent 6 }}
+      containers:
+        {{- include "dencer-demo.container" (dict "ctx" . "cpu" "1" "memory" "2Gi") | nindent 8 }}
+---
+{{/*
+A bare pod with no controller. Evicting it deletes it permanently — nothing
+recreates it — which is the single most consequential thing a consolidation
+step can do and the classifier's highest-severity rule.
+*/}}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ .Release.Name }}-orphan
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "dencer-demo.labels" . | nindent 4 }}
+    app: dencer-orphan
+    dencer.io/role: unmanaged
+spec:
+  affinity:
+    {{- include "dencer-demo.nodeAffinity" . | nindent 4 }}
+  {{- include "dencer-demo.tolerations" . | nindent 2 }}
+  containers:
+    {{- include "dencer-demo.container" (dict "ctx" . "cpu" "1" "memory" "2Gi") | nindent 4 }}
+{{- end }}

--- a/demo/charts/dencer-demo/templates/validate.yaml
+++ b/demo/charts/dencer-demo/templates/validate.yaml
@@ -3,7 +3,7 @@ Fail loudly on an unknown scenario. Without this a typo would silently install
 only the base workload, and the missing constraint would look like a planner
 bug rather than a values mistake.
 */}}
-{{- $valid := list "a-fragmented" "b-pdb-blocked" "c-topology-spread" "d-anti-affinity" "e-tainted-pool" -}}
+{{- $valid := list "a-fragmented" "b-pdb-blocked" "c-topology-spread" "d-anti-affinity" "e-tainted-pool" "f-stateful" -}}
 {{- if not (has .Values.scenario $valid) -}}
 {{- fail (printf "unknown scenario %q; valid scenarios are: %s" .Values.scenario (join ", " $valid)) -}}
 {{- end -}}

--- a/demo/charts/dencer-demo/values.yaml
+++ b/demo/charts/dencer-demo/values.yaml
@@ -9,6 +9,8 @@
 #   c-topology-spread maxSkew 1 across three zones
 #   d-anti-affinity   required pod anti-affinity singletons
 #   e-tainted-pool    dedicated tainted node pool
+#   f-stateful        StatefulSet + an unmanaged pod; the only scenario that
+#                     produces Red-rated steps
 #
 # The base workload is always deployed so every scenario has something to
 # consolidate; the scenario adds the constraint that should change the ratings.

--- a/internal/impact/impact.go
+++ b/internal/impact/impact.go
@@ -1,0 +1,331 @@
+// Package impact rates consolidation steps Green, Yellow or Red and explains
+// the rating.
+//
+// The rating is policy, not advice: architecture doc §5 confines Red steps to
+// an approved maintenance window, and Phase 2's safety guard enforces that in
+// code rather than trusting UI input validation. So a rating has to be
+// defensible — which is why every one carries a rationale naming the specific
+// object and number that drove it.
+//
+// Thresholds are configurable rather than hardcoded. Doc §10 is explicit that
+// where PDB headroom stops being "Green" differs per cluster, and a product
+// that decides that for you will be wrong for most people.
+package impact
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/atedgimo/k8s-dencer/internal/constraints"
+	"github.com/atedgimo/k8s-dencer/internal/model"
+)
+
+// Reason kinds. Stable identifiers: the UI filters on them and the agent
+// reasons over them.
+const (
+	ReasonPDBZeroHeadroom  = "PDBZeroHeadroom"
+	ReasonPDBTightHeadroom = "PDBTightHeadroom"
+	ReasonUnmanagedPod     = "UnmanagedPod"
+	ReasonStatefulWorkload = "StatefulWorkload"
+	ReasonPersistentVolume = "PersistentVolume"
+	ReasonAntiAffinity     = "RequiredAntiAffinity"
+	ReasonTopologySpread   = "HardTopologySpread"
+	ReasonBlastRadius      = "BlastRadius"
+	ReasonBlastRadiusHigh  = "BlastRadiusHigh"
+)
+
+// Thresholds tune where one rating becomes the next.
+type Thresholds struct {
+	// YellowPodsMoved is the pod count above which a step stops being Green
+	// purely on the size of its blast radius.
+	YellowPodsMoved int
+	// RedPodsMoved is the pod count above which a step is Red on size alone.
+	RedPodsMoved int
+	// TightPDBHeadroom is the disruption headroom at or below which a covering
+	// PDB makes a step Yellow. Zero headroom is always Red regardless.
+	TightPDBHeadroom int32
+}
+
+// DefaultThresholds are deliberately cautious. An operator who finds them
+// noisy can loosen them; an operator surprised by an outage they were told was
+// Green will not trust the tool again.
+func DefaultThresholds() Thresholds {
+	return Thresholds{
+		YellowPodsMoved:  5,
+		RedPodsMoved:     15,
+		TightPDBHeadroom: 1,
+	}
+}
+
+// Classifier rates steps against a set of thresholds.
+type Classifier struct {
+	Thresholds Thresholds
+}
+
+// New returns a classifier with the given thresholds, falling back to the
+// defaults for any zero value.
+func New(t Thresholds) Classifier {
+	d := DefaultThresholds()
+	if t.YellowPodsMoved <= 0 {
+		t.YellowPodsMoved = d.YellowPodsMoved
+	}
+	if t.RedPodsMoved <= 0 {
+		t.RedPodsMoved = d.RedPodsMoved
+	}
+	if t.TightPDBHeadroom <= 0 {
+		t.TightPDBHeadroom = d.TightPDBHeadroom
+	}
+	return Classifier{Thresholds: t}
+}
+
+// ClassifyPlan rates every step in place.
+func (c Classifier) ClassifyPlan(plan *model.Plan, snap *model.ClusterSnapshot, analysis *constraints.Analysis) {
+	for i := range plan.Steps {
+		rating, rationale, reasons := c.ClassifyStep(plan.Steps[i], snap, analysis)
+		plan.Steps[i].Impact = rating
+		plan.Steps[i].Rationale = rationale
+		plan.Steps[i].Reasons = reasons
+	}
+}
+
+// ClassifyStep rates a single step and explains the rating.
+func (c Classifier) ClassifyStep(
+	step model.PlanStep,
+	snap *model.ClusterSnapshot,
+	analysis *constraints.Analysis,
+) (model.ImpactRating, string, []model.ImpactReason) {
+	reasons := c.reasonsFor(step, snap, analysis)
+	rating := ratingFor(reasons)
+	return rating, c.rationale(step, rating, reasons), reasons
+}
+
+// severity maps a reason kind to the rating it forces. The step takes the
+// highest severity of any reason found.
+func severity(kind string) model.ImpactRating {
+	switch kind {
+	case ReasonPDBZeroHeadroom, ReasonUnmanagedPod, ReasonStatefulWorkload, ReasonBlastRadiusHigh:
+		return model.ImpactRed
+	case ReasonPDBTightHeadroom, ReasonPersistentVolume, ReasonAntiAffinity,
+		ReasonTopologySpread, ReasonBlastRadius:
+		return model.ImpactYellow
+	default:
+		return model.ImpactGreen
+	}
+}
+
+// ratingFor takes the highest severity of any reason present.
+func ratingFor(reasons []model.ImpactReason) model.ImpactRating {
+	rating := model.ImpactGreen
+	for _, r := range reasons {
+		switch severity(r.Kind) {
+		case model.ImpactRed:
+			return model.ImpactRed
+		case model.ImpactYellow:
+			rating = model.ImpactYellow
+		}
+	}
+	return rating
+}
+
+func (c Classifier) reasonsFor(
+	step model.PlanStep,
+	snap *model.ClusterSnapshot,
+	analysis *constraints.Analysis,
+) []model.ImpactReason {
+	var reasons []model.ImpactReason
+	seen := map[string]bool{}
+
+	add := func(r model.ImpactReason) {
+		key := r.Kind + "|" + r.Subject
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		reasons = append(reasons, r)
+	}
+
+	pdbs := indexPDBs(snap)
+
+	for _, move := range step.Moves {
+		key := move.Namespace + "/" + move.Pod
+		pod, found := findPod(snap, move.Namespace, move.Pod)
+		if !found {
+			continue
+		}
+
+		// A pod with no controller is not recreated after eviction — it is
+		// simply gone. That is the most consequential thing a consolidation
+		// step can do, so it outranks everything else.
+		if pod.Owner == nil {
+			add(model.ImpactReason{
+				Kind:    ReasonUnmanagedPod,
+				Subject: key,
+				Detail: fmt.Sprintf(
+					"%s has no controller. Evicting it deletes it permanently; nothing will recreate it.", key),
+			})
+		} else if pod.Owner.Kind == "StatefulSet" {
+			add(model.ImpactReason{
+				Kind:    ReasonStatefulWorkload,
+				Subject: key,
+				Detail: fmt.Sprintf(
+					"%s belongs to StatefulSet %s. Its replacement keeps the same identity and cannot start until this one has fully terminated, so the workload loses that ordinal for the duration.",
+					key, pod.Owner.Name),
+			})
+		}
+
+		if pod.HasPersistentVol {
+			add(model.ImpactReason{
+				Kind:    ReasonPersistentVolume,
+				Subject: key,
+				Detail: fmt.Sprintf(
+					"%s mounts a PersistentVolumeClaim, which may be bound to its current node's topology and unable to follow it to %s.",
+					key, move.ToNode),
+			})
+		}
+
+		// PDB headroom is the difference between a step that succeeds and one
+		// the API server refuses outright, so it is read per covered pod.
+		for _, pdb := range pdbs[pod.Namespace] {
+			if pdb.Selector.IsEmpty() || !pdb.Selector.Matches(pod.Labels) {
+				continue
+			}
+			switch {
+			case pdb.Blocks():
+				add(model.ImpactReason{
+					Kind:    ReasonPDBZeroHeadroom,
+					Subject: pdb.Key(),
+					Detail: fmt.Sprintf(
+						"PodDisruptionBudget %s allows 0 disruptions (%d healthy, %d required); the API server will refuse to evict %s.",
+						pdb.Key(), pdb.CurrentHealthy, pdb.DesiredHealthy, key),
+				})
+			case pdb.DisruptionsAllowed <= c.Thresholds.TightPDBHeadroom:
+				add(model.ImpactReason{
+					Kind:    ReasonPDBTightHeadroom,
+					Subject: pdb.Key(),
+					Detail: fmt.Sprintf(
+						"PodDisruptionBudget %s has only %d disruption(s) of headroom (%d healthy, %d required), so any concurrent disruption elsewhere will block this step.",
+						pdb.Key(), pdb.DisruptionsAllowed, pdb.CurrentHealthy, pdb.DesiredHealthy),
+				})
+			}
+		}
+
+		// Reuse the analyzer's constraint set rather than re-deriving these:
+		// its explanations are the canonical text, and re-deriving invites the
+		// two to drift.
+		if pc, ok := analysis.ForPod(key); ok {
+			for _, con := range pc.Of(constraints.KindPodAntiAffinity) {
+				add(model.ImpactReason{
+					Kind:    ReasonAntiAffinity,
+					Subject: key,
+					Detail:  con.Explanation,
+				})
+			}
+			for _, con := range pc.Of(constraints.KindTopologySpread) {
+				if !con.Hard {
+					continue
+				}
+				add(model.ImpactReason{
+					Kind:    ReasonTopologySpread,
+					Subject: key,
+					Detail:  con.Explanation,
+				})
+			}
+		}
+	}
+
+	if n := len(step.Moves); n >= c.Thresholds.RedPodsMoved {
+		add(model.ImpactReason{
+			Kind:    ReasonBlastRadiusHigh,
+			Subject: step.TargetNode,
+			Detail: fmt.Sprintf("Moves %d pods at once, at or above the %d-pod red threshold.",
+				n, c.Thresholds.RedPodsMoved),
+		})
+	} else if n >= c.Thresholds.YellowPodsMoved {
+		add(model.ImpactReason{
+			Kind:    ReasonBlastRadius,
+			Subject: step.TargetNode,
+			Detail: fmt.Sprintf("Moves %d pods at once, at or above the %d-pod yellow threshold.",
+				n, c.Thresholds.YellowPodsMoved),
+		})
+	}
+
+	// Stable order so the rationale and the UI list do not reshuffle between
+	// identical runs.
+	sort.SliceStable(reasons, func(i, j int) bool {
+		si, sj := severityRank(reasons[i].Kind), severityRank(reasons[j].Kind)
+		if si != sj {
+			return si > sj
+		}
+		if reasons[i].Kind != reasons[j].Kind {
+			return reasons[i].Kind < reasons[j].Kind
+		}
+		return reasons[i].Subject < reasons[j].Subject
+	})
+	return reasons
+}
+
+func severityRank(kind string) int {
+	switch severity(kind) {
+	case model.ImpactRed:
+		return 2
+	case model.ImpactYellow:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// rationale composes the single canonical explanation for a rating.
+//
+// It leads with the reason that drove the rating, because that is the question
+// an operator is actually asking, then adds the supporting factors. The UI and
+// the Kagent agent both surface this exact string.
+func (c Classifier) rationale(step model.PlanStep, rating model.ImpactRating, reasons []model.ImpactReason) string {
+	pods := len(step.Moves)
+	head := fmt.Sprintf("Draining %s moves %d pod(s).", step.TargetNode, pods)
+
+	if len(reasons) == 0 {
+		return head + " No disruption-budget, stateful, affinity or spread constraints apply, so this step is safe to run at any time."
+	}
+
+	driving := reasons[0]
+	var b strings.Builder
+	b.WriteString(head)
+	b.WriteString(" Rated ")
+	b.WriteString(string(rating))
+	b.WriteString(" because: ")
+	b.WriteString(driving.Detail)
+
+	if len(reasons) > 1 {
+		b.WriteString(" Also: ")
+		rest := make([]string, 0, len(reasons)-1)
+		for _, r := range reasons[1:] {
+			rest = append(rest, strings.TrimSuffix(r.Detail, "."))
+		}
+		b.WriteString(strings.Join(rest, "; "))
+		b.WriteString(".")
+	}
+
+	if rating == model.ImpactRed {
+		b.WriteString(" Red steps may only execute inside an approved maintenance window.")
+	}
+	return b.String()
+}
+
+func indexPDBs(snap *model.ClusterSnapshot) map[string][]model.PodDisruptionBudget {
+	out := make(map[string][]model.PodDisruptionBudget)
+	for _, pdb := range snap.PDBs {
+		out[pdb.Namespace] = append(out[pdb.Namespace], pdb)
+	}
+	return out
+}
+
+func findPod(snap *model.ClusterSnapshot, namespace, name string) (model.Pod, bool) {
+	for _, p := range snap.Pods {
+		if p.Namespace == namespace && p.Name == name {
+			return p, true
+		}
+	}
+	return model.Pod{}, false
+}

--- a/internal/impact/impact_test.go
+++ b/internal/impact/impact_test.go
@@ -1,0 +1,334 @@
+package impact_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/atedgimo/k8s-dencer/internal/constraints"
+	"github.com/atedgimo/k8s-dencer/internal/impact"
+	"github.com/atedgimo/k8s-dencer/internal/model"
+	"github.com/atedgimo/k8s-dencer/internal/planner"
+)
+
+func snapshotWith(pods []model.Pod, pdbs []model.PodDisruptionBudget) *model.ClusterSnapshot {
+	return &model.ClusterSnapshot{
+		Nodes: []model.Node{
+			{Name: "a", Ready: true, Allocatable: model.Resources{MilliCPU: 8000, MemoryBytes: 1 << 34, Pods: 110}},
+			{Name: "b", Ready: true, Allocatable: model.Resources{MilliCPU: 8000, MemoryBytes: 1 << 34, Pods: 110}},
+		},
+		Pods: pods,
+		PDBs: pdbs,
+	}
+}
+
+func stepMoving(pods ...model.Pod) model.PlanStep {
+	step := model.PlanStep{SequenceNumber: 1, TargetNode: "a"}
+	for _, p := range pods {
+		step.Moves = append(step.Moves, model.Move{
+			Namespace: p.Namespace, Pod: p.Name, FromNode: "a", ToNode: "b",
+		})
+	}
+	return step
+}
+
+func classify(t *testing.T, snap *model.ClusterSnapshot, step model.PlanStep, th impact.Thresholds) (model.ImpactRating, string, []model.ImpactReason) {
+	t.Helper()
+	return impact.New(th).ClassifyStep(step, snap, constraints.Analyze(snap))
+}
+
+func deploymentPod(name string) model.Pod {
+	return model.Pod{
+		Namespace: "app", Name: name, NodeName: "a", Phase: model.PodRunning,
+		Labels:   map[string]string{"app": "web"},
+		Requests: model.Resources{MilliCPU: 100, MemoryBytes: 1 << 26},
+		Owner:    &model.OwnerRef{Kind: "Deployment", Name: "web"},
+	}
+}
+
+func TestUnconstrainedStepIsGreen(t *testing.T) {
+	pod := deploymentPod("web-1")
+	snap := snapshotWith([]model.Pod{pod}, nil)
+
+	rating, rationale, reasons := classify(t, snap, stepMoving(pod), impact.DefaultThresholds())
+
+	if rating != model.ImpactGreen {
+		t.Errorf("rating = %s, want Green (reasons: %+v)", rating, reasons)
+	}
+	if len(reasons) != 0 {
+		t.Errorf("expected no reasons, got %+v", reasons)
+	}
+	if !strings.Contains(rationale, "safe to run at any time") {
+		t.Errorf("Green rationale should say so plainly, got: %q", rationale)
+	}
+}
+
+// A pod with no controller is deleted permanently by eviction. Nothing about a
+// consolidation step is more consequential.
+func TestUnmanagedPodIsRed(t *testing.T) {
+	pod := deploymentPod("orphan")
+	pod.Owner = nil
+	snap := snapshotWith([]model.Pod{pod}, nil)
+
+	rating, rationale, reasons := classify(t, snap, stepMoving(pod), impact.DefaultThresholds())
+
+	if rating != model.ImpactRed {
+		t.Fatalf("rating = %s, want Red", rating)
+	}
+	if reasons[0].Kind != impact.ReasonUnmanagedPod {
+		t.Errorf("driving reason = %s, want %s", reasons[0].Kind, impact.ReasonUnmanagedPod)
+	}
+	if !strings.Contains(rationale, "nothing will recreate it") {
+		t.Errorf("rationale must explain the consequence, got: %q", rationale)
+	}
+	if !strings.Contains(rationale, "maintenance window") {
+		t.Error("Red rationale must state the maintenance-window restriction")
+	}
+}
+
+func TestStatefulSetPodIsRed(t *testing.T) {
+	pod := deploymentPod("db-0")
+	pod.Owner = &model.OwnerRef{Kind: "StatefulSet", Name: "db"}
+	snap := snapshotWith([]model.Pod{pod}, nil)
+
+	rating, rationale, _ := classify(t, snap, stepMoving(pod), impact.DefaultThresholds())
+
+	if rating != model.ImpactRed {
+		t.Errorf("rating = %s, want Red", rating)
+	}
+	if !strings.Contains(rationale, "StatefulSet db") {
+		t.Errorf("rationale must name the StatefulSet, got: %q", rationale)
+	}
+}
+
+// The distinction the whole product rests on: a PDB with no headroom is Red,
+// the same PDB with headroom is not.
+func TestPDBHeadroomDrivesTheRating(t *testing.T) {
+	pod := deploymentPod("web-1")
+	selector := &model.LabelSelector{MatchLabels: map[string]string{"app": "web"}}
+
+	cases := []struct {
+		name       string
+		allowed    int32
+		want       model.ImpactRating
+		wantReason string
+	}{
+		{"zero headroom is Red", 0, model.ImpactRed, impact.ReasonPDBZeroHeadroom},
+		{"one disruption is tight, Yellow", 1, model.ImpactYellow, impact.ReasonPDBTightHeadroom},
+		{"comfortable headroom is Green", 5, model.ImpactGreen, ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			snap := snapshotWith([]model.Pod{pod}, []model.PodDisruptionBudget{{
+				Namespace: "app", Name: "web", Selector: selector,
+				DisruptionsAllowed: tc.allowed, CurrentHealthy: 3, DesiredHealthy: 3, ExpectedPods: 3,
+			}})
+
+			rating, rationale, reasons := classify(t, snap, stepMoving(pod), impact.DefaultThresholds())
+
+			if rating != tc.want {
+				t.Errorf("rating = %s, want %s (reasons %+v)", rating, tc.want, reasons)
+			}
+			if tc.wantReason == "" {
+				return
+			}
+			if reasons[0].Kind != tc.wantReason {
+				t.Errorf("driving reason = %s, want %s", reasons[0].Kind, tc.wantReason)
+			}
+			if !strings.Contains(rationale, "app/web") {
+				t.Errorf("rationale must name the PDB, got: %q", rationale)
+			}
+		})
+	}
+}
+
+// Doc §10: where headroom stops being acceptable differs per cluster, so the
+// boundary has to move with configuration rather than be baked in.
+func TestTightHeadroomThresholdIsTunable(t *testing.T) {
+	pod := deploymentPod("web-1")
+	snap := snapshotWith([]model.Pod{pod}, []model.PodDisruptionBudget{{
+		Namespace: "app", Name: "web",
+		Selector:           &model.LabelSelector{MatchLabels: map[string]string{"app": "web"}},
+		DisruptionsAllowed: 3, CurrentHealthy: 6, DesiredHealthy: 3,
+	}})
+
+	if rating, _, _ := classify(t, snap, stepMoving(pod), impact.DefaultThresholds()); rating != model.ImpactGreen {
+		t.Errorf("3 disruptions of headroom should be Green by default, got %s", rating)
+	}
+
+	strict := impact.Thresholds{TightPDBHeadroom: 5}
+	if rating, _, _ := classify(t, snap, stepMoving(pod), strict); rating != model.ImpactYellow {
+		t.Errorf("with TightPDBHeadroom=5 the same step should be Yellow, got %s", rating)
+	}
+}
+
+func TestBlastRadiusThresholds(t *testing.T) {
+	makePods := func(n int) []model.Pod {
+		var pods []model.Pod
+		for i := 0; i < n; i++ {
+			pods = append(pods, deploymentPod("web-"+string(rune('a'+i))))
+		}
+		return pods
+	}
+
+	cases := []struct {
+		pods int
+		want model.ImpactRating
+	}{
+		{2, model.ImpactGreen},
+		{5, model.ImpactYellow},
+		{15, model.ImpactRed},
+	}
+	for _, tc := range cases {
+		pods := makePods(tc.pods)
+		snap := snapshotWith(pods, nil)
+		rating, _, reasons := classify(t, snap, stepMoving(pods...), impact.DefaultThresholds())
+		if rating != tc.want {
+			t.Errorf("%d pods rated %s, want %s (reasons %+v)", tc.pods, rating, tc.want, reasons)
+		}
+	}
+}
+
+func TestAntiAffinityAndSpreadAreYellow(t *testing.T) {
+	anti := deploymentPod("cache-1")
+	anti.PodAffinity = &model.PodAffinity{RequiredAntiAffinity: []model.PodAffinityTerm{{
+		TopologyKey:   model.LabelHostname,
+		LabelSelector: &model.LabelSelector{MatchLabels: map[string]string{"app": "web"}},
+	}}}
+
+	snap := snapshotWith([]model.Pod{anti}, nil)
+	rating, rationale, reasons := classify(t, snap, stepMoving(anti), impact.DefaultThresholds())
+	if rating != model.ImpactYellow {
+		t.Errorf("required anti-affinity should be Yellow, got %s", rating)
+	}
+	if reasons[0].Kind != impact.ReasonAntiAffinity {
+		t.Errorf("driving reason = %s", reasons[0].Kind)
+	}
+	// The rationale must quote the analyzer's text, not invent its own.
+	if !strings.Contains(rationale, "anti-affinity") {
+		t.Errorf("rationale should carry the analyzer's explanation, got: %q", rationale)
+	}
+}
+
+// A ScheduleAnyway spread constraint is a preference. Rating a step Yellow for
+// a preference the scheduler would happily violate is a false alarm, and false
+// alarms are how a tool gets ignored.
+func TestSoftTopologySpreadDoesNotAffectRating(t *testing.T) {
+	pod := deploymentPod("web-1")
+	pod.TopologySpread = []model.TopologySpreadConstraint{{
+		MaxSkew: 1, TopologyKey: model.LabelZone, WhenUnsatisfiable: model.ScheduleAnyway,
+	}}
+	snap := snapshotWith([]model.Pod{pod}, nil)
+
+	rating, _, reasons := classify(t, snap, stepMoving(pod), impact.DefaultThresholds())
+	if rating != model.ImpactGreen {
+		t.Errorf("soft spread should not change the rating, got %s (%+v)", rating, reasons)
+	}
+}
+
+func TestPersistentVolumeIsYellow(t *testing.T) {
+	pod := deploymentPod("web-1")
+	pod.HasPersistentVol = true
+	snap := snapshotWith([]model.Pod{pod}, nil)
+
+	rating, rationale, _ := classify(t, snap, stepMoving(pod), impact.DefaultThresholds())
+	if rating != model.ImpactYellow {
+		t.Errorf("rating = %s, want Yellow", rating)
+	}
+	if !strings.Contains(rationale, "PersistentVolumeClaim") {
+		t.Errorf("rationale should name the volume concern, got: %q", rationale)
+	}
+}
+
+// The worst factor decides, and it must be the one the rationale leads with —
+// that is the question an operator is actually asking.
+func TestHighestSeverityWinsAndLeadsTheRationale(t *testing.T) {
+	orphan := deploymentPod("orphan")
+	orphan.Owner = nil
+	orphan.HasPersistentVol = true
+
+	snap := snapshotWith([]model.Pod{orphan}, nil)
+	rating, rationale, reasons := classify(t, snap, stepMoving(orphan), impact.DefaultThresholds())
+
+	if rating != model.ImpactRed {
+		t.Fatalf("rating = %s, want Red", rating)
+	}
+	if reasons[0].Kind != impact.ReasonUnmanagedPod {
+		t.Errorf("Red reason must sort first, got %s", reasons[0].Kind)
+	}
+	if !strings.Contains(rationale, "Also:") {
+		t.Error("supporting reasons should still be reported")
+	}
+	if strings.Index(rationale, "no controller") > strings.Index(rationale, "Also:") {
+		t.Error("the driving reason must come before the supporting ones")
+	}
+}
+
+func TestRatingIsDeterministic(t *testing.T) {
+	pod := deploymentPod("web-1")
+	pod.HasPersistentVol = true
+	pod.PodAffinity = &model.PodAffinity{RequiredAntiAffinity: []model.PodAffinityTerm{{
+		TopologyKey:   model.LabelHostname,
+		LabelSelector: &model.LabelSelector{MatchLabels: map[string]string{"app": "web"}},
+	}}}
+	snap := snapshotWith([]model.Pod{pod}, nil)
+
+	_, first, _ := classify(t, snap, stepMoving(pod), impact.DefaultThresholds())
+	_, second, _ := classify(t, snap, stepMoving(pod), impact.DefaultThresholds())
+	if first != second {
+		t.Errorf("rationale differs across runs:\n%q\n%q", first, second)
+	}
+}
+
+func TestZeroThresholdsFallBackToDefaults(t *testing.T) {
+	c := impact.New(impact.Thresholds{})
+	want := impact.DefaultThresholds()
+	if c.Thresholds != want {
+		t.Errorf("zero thresholds = %+v, want defaults %+v", c.Thresholds, want)
+	}
+}
+
+// End to end over a real captured cluster: every step must be rated and
+// explained, with no blank rationale reaching the UI or the agent.
+func TestClassifyPlanOverFixture(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join("..", "..", "test", "fixtures", "b-pdb-blocked.yaml"))
+	if err != nil {
+		t.Skipf("fixture unavailable: %v", err)
+	}
+	var snap model.ClusterSnapshot
+	if err := yaml.Unmarshal(raw, &snap); err != nil {
+		t.Fatal(err)
+	}
+
+	analysis := constraints.Analyze(&snap)
+	opts := planner.DefaultOptions()
+	opts.MinNodeAge = 0
+	plan, err := planner.Greedy{}.Plan(&snap, analysis, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	impact.New(impact.Thresholds{}).ClassifyPlan(plan, &snap, analysis)
+
+	counts := plan.CountByRating()
+	for _, step := range plan.Steps {
+		if step.Impact == "" {
+			t.Errorf("step %d has no rating", step.SequenceNumber)
+		}
+		if len(strings.TrimSpace(step.Rationale)) < 40 {
+			t.Errorf("step %d rationale is too thin to be useful: %q", step.SequenceNumber, step.Rationale)
+		}
+		if step.Impact == model.ImpactRed && !step.RequiresMaintenanceWindow() {
+			t.Errorf("step %d is Red but not window-confined", step.SequenceNumber)
+		}
+	}
+	t.Logf("%d steps: %d Green, %d Yellow, %d Red",
+		len(plan.Steps), counts[model.ImpactGreen], counts[model.ImpactYellow], counts[model.ImpactRed])
+	if len(plan.Steps) > 0 {
+		t.Logf("example: %s", plan.Steps[0].Rationale)
+	}
+}


### PR DESCRIPTION
Every step is now rated and explained:

```
plan: id=8bb7900e46db steps=15 nodesBefore=28 nodesAfter=13 reclaims=15
      green=6 yellow=5 red=4
```

```
Draining kwok-node-19 moves 1 pod(s). Rated Red because:
dencer-demo/dencer-demo-orphan has no controller. Evicting it deletes it
permanently; nothing will recreate it. Red steps may only execute inside an
approved maintenance window.
```

## The rating is policy, not advice

Doc §5 confines Red steps to an approved maintenance window, and Phase 2's safety guard will enforce that **in code** rather than trusting UI input validation. So a rating has to be defensible — hence every one names the specific object and number behind it.

| Rating | Driven by |
|---|---|
| **Red** | unmanaged pod (eviction deletes it permanently), StatefulSet pod, PDB at zero headroom, blast radius ≥ red threshold |
| **Yellow** | PDB headroom ≤ tight threshold, PersistentVolumeClaim, required anti-affinity, hard topology spread, blast radius ≥ yellow threshold |
| **Green** | none of the above |

Worst factor wins, and the rationale **leads with it** — that is the question an operator is actually asking — then lists supporting factors.

Anti-affinity and spread rationales **quote the analyzer's explanation verbatim** rather than re-deriving it, so the constraint inspector and the rating can never disagree.

Only hard constraints count. A `ScheduleAnyway` spread never affects a rating: flagging a preference the scheduler would happily violate is a false alarm, and false alarms are how a tool gets ignored.

## Thresholds are configuration, not constants

Doc §10 is explicit that where PDB headroom stops being acceptable differs per cluster, so `planner.impact.{yellowPodsMoved,redPodsMoved,tightPDBHeadroom}` are chart values. Defaults are deliberately cautious — an operator who finds them noisy can loosen them, but one surprised by an outage they were told was Green will not trust the tool again.

## A gap this surfaced: the fabric could not produce Red at all

Running the classifier over the existing scenarios gave **10 Green, 4 Yellow, 0 Red** — and the Yellows were purely blast radius. The planner already refuses to drain nodes holding unevictable pods, so a zero-headroom PDB never reaches a step, and every other workload was a plain Deployment.

That would have left the classifier's most consequential rules, and M7's Red UI state, untested end to end. Added scenario **`f-stateful`** (a StatefulSet plus a bare unmanaged pod), which now yields `green=6 yellow=5 red=4` live.

The StatefulSet deliberately has **no** `volumeClaimTemplates`: a PVC on a KWOK node never binds, because local-path provisioning waits for a real kubelet that fake nodes do not have. StatefulSet ownership alone drives the rating.

## Verified

```
make test    47 tests; 13 new covering each rule, threshold tuning,
             severity ordering and rationale quality
make lint    all chart contract checks pass
live         green=6 yellow=5 red=4 under f-stateful
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)