### PR TITLE
M7: UI — capacity ribbon, packing canvas, scrubber, constraint inspector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,18 @@ DEMO_NAMESPACE     ?= dencer-demo
 DEMO_RELEASE       ?= dencer-demo
 SCENARIO           ?= a-fragmented
 
-# A dirty suffix keeps uncommitted builds from reusing a clean tag, and the
-# changing tag is what makes `helm upgrade` roll pods without a manual restart.
+# The tag must change whenever the *content* changes, not just the commit.
+# A plain "-dirty" suffix is the same string for every uncommitted state, so
+# two different builds at one SHA share a tag: the podspec does not change,
+# helm upgrade reports success, and the pod quietly keeps the old image. The
+# suffix therefore hashes the working tree — tracked diffs and untracked file
+# contents both — so each distinct state gets its own tag and pods actually roll.
 GIT_SHA     := $(shell git rev-parse --short HEAD 2>/dev/null || echo nogit)
-GIT_DIRTY   := $(shell test -n "$$(git status --porcelain 2>/dev/null)" && echo -dirty || true)
+DIRTY_HASH  := $(shell { git diff HEAD 2>/dev/null; \
+                         git ls-files --others --exclude-standard -z 2>/dev/null \
+                           | xargs -0 shasum 2>/dev/null; } | shasum | cut -c1-8)
+GIT_DIRTY   := $(shell test -n "$$(git status --porcelain 2>/dev/null)" \
+                 && echo "-dirty.$(DIRTY_HASH)" || true)
 IMAGE_TAG   ?= $(GIT_SHA)$(GIT_DIRTY)
 
 IMAGE_PREFIX ?= k8s-dencer

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Phase 1 (MVP) — visibility and explainability. No execution capability.
 | **M4** | Consolidation planner (greedy first-fit-decreasing) | **done** |
 | **M5** | Impact classifier (Green/Yellow/Red + rationale) | **done** |
 | **M6** | Plan store (SQLite) + REST API + graph payload | **done** |
-| M7 | UI: before/after canvas, step timeline scrubber, constraint inspector | next |
-| M8 | Kagent agent: read-only MCP tools + `Agent` CR | pending |
+| **M7** | UI: capacity ribbon, packing canvas, scrubber, constraint inspector | **done** |
+| M8 | Kagent agent: read-only MCP tools + `Agent` CR | next |
 
 Deferred to later phases: Executor, Safety Guard, Scheduler Simulator, `MaintenanceWindow` CRD, Postgres store, multi-agent orchestration.
 
@@ -40,8 +40,8 @@ plan:        id=8bb7900e46db steps=15 nodesBefore=28 nodesAfter=13 reclaims=15
              green=6 yellow=5 red=4
 ```
 
-Plans are rated, explained and persisted. They are not yet visualised — the UI
-is still a placeholder, and the graph payload it will consume is already served.
+Plans are rated, explained, persisted and visualised. What remains is the
+Kagent agent, so the same explanations can be asked for in natural language.
 
 Three debug endpoints on the planner's health port expose current state as
 YAML: `/debug/snapshot`, `/debug/constraints` and `/debug/plan`.
@@ -75,7 +75,7 @@ internal/
   impact/          Green/Yellow/Red classifier + rationale composition
   store/           Store interface + SQLite implementation and migrations
   api/             rest/ (+ SSE events), graph/ (Cytoscape payload), agenttools/ (M8)
-ui/                React + Vite + Cytoscape.js
+ui/                React + Vite + Cytoscape.js; bundled typefaces
 charts/k8s-dencer/ THE product deliverable — see Chart below
 demo/              POC only: KWOK values + the synthetic topology chart
 build/             Dockerfile.go (parameterised by COMPONENT) + Dockerfile.ui
@@ -269,6 +269,30 @@ GET /api/v1/events                                   live plan changes (SSE)
 Live updates use **Server-Sent Events rather than WebSockets**: the traffic is strictly one-way since the API is read-only, `EventSource` reconnects on its own, and it needs no dependency and no protocol upgrade. The stream sends current state on connect, so a client joining a stable cluster isn't left blank.
 
 The graph payload is shaped for Cytoscape's compound-node model — cluster nodes are parents, pods are children — and every pod carries **both** its current node and where the plan would move it, so the frontend can build the before/after view and animate the step scrubber from a single request.
+
+## The UI
+
+```bash
+make ui     # port-forwards and prints the URLs
+```
+
+**The capacity ribbon is the page's argument.** One bar per node, ordered fullest-first, filled to requested CPU — the long tail of barely-used bars *is* the case for consolidating. Dragging the scrubber drains them in place. A big number over a small label was the first draft; it states a conclusion where the evidence should be, so the only display-size figure now sits inside a sentence that gives it meaning.
+
+**One morphing canvas, not two before/after panes.** Scrubbing shows the same comparison plus every intermediate state, and makes the causality visible — this pod leaves, so this node empties. Two half-width panes of 30 nodes would be unreadable, and the ribbon already does the at-a-glance job.
+
+**Cytoscape's own layouts are not used.** Positions are computed: node boxes on a grid, pods in a sub-grid inside them. A force layout says nothing about packing and jitters on every relayout; deterministic positions are also what make the animation possible. Node boxes are plain nodes rather than compound parents, because a compound parent collapses to nothing when emptied — exactly the node an operator most wants to see.
+
+### Accessibility is load-bearing here, not a checkbox
+
+The data-viz palette validator reports **`#d03b3b` ↔ `#0ca30c` at CVD ΔE 4.1 for deuteranopia**, against a floor of 8. Red and Green are the same colour to a large minority of readers — for a Green/Yellow/Red product that is the central design constraint, not a footnote.
+
+So nothing encodes a rating by colour alone: every chip carries a distinct glyph (●▲■ — different silhouettes, not just fills) **and** the word; scrubber ticks use the glyphs; blocked pods are diamonds. Node utilisation uses the sequential blue ramp — one hue, light→dark — validated against this page plane.
+
+### Typefaces are bundled, not fetched
+
+Archivo for structure and every figure, IBM Plex Sans for prose, IBM Plex Mono for machine identifiers (a node name is an identifier and shouldn't read as a word). Latin subsets only — the full packages ship Cyrillic, Greek and Vietnamese, 3.3MB of assets for a UI with no text in any of them.
+
+They are bundled rather than CDN-fetched because **a cluster may have no route to the internet**, and type that silently falls back to `system-ui` in an air-gapped install is not designed type. It also means no third-party request from an operator's browser.
 
 ## Kagent
 

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -8,6 +8,11 @@
       "name": "k8s-dencer-ui",
       "version": "0.1.0",
       "dependencies": {
+        "@fontsource-variable/archivo": "^5.3.0",
+        "@fontsource-variable/ibm-plex-sans": "^5.3.0",
+        "@fontsource/ibm-plex-mono": "^5.3.0",
+        "@types/cytoscape": "^3.21.9",
+        "cytoscape": "^3.34.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -743,6 +748,33 @@
         "node": ">=18"
       }
     },
+    "node_modules/@fontsource-variable/archivo": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/archivo/-/archivo-5.3.0.tgz",
+      "integrity": "sha512-HogK8FJelrD1o7TlZlkIVtHgc20bO5PZRWE7mUeUTdMN055alznQV6/00J00IBeu8FQAH4s3zW9UJNvKExXf+g==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource-variable/ibm-plex-sans": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/ibm-plex-sans/-/ibm-plex-sans-5.3.0.tgz",
+      "integrity": "sha512-agG8tXFEo0hD9+J7npa4vbbWult52eMLVaQ6WQRlhs/iCAojrMAoejru85W9HTVXHfyUj96KM7gp/KGAS87XaQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/ibm-plex-mono": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource/ibm-plex-mono/-/ibm-plex-mono-5.3.0.tgz",
+      "integrity": "sha512-eTgnZjZEGk1QtD3ZstF+Vclo2HLAni8YMy34/DxllwZvyz1lR/1RF/xTiAquOBO7MvqBx8D2Ig2WCPMVfdZu7Q==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1234,6 +1266,12 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/cytoscape": {
+      "version": "3.21.9",
+      "resolved": "https://registry.npmjs.org/@types/cytoscape/-/cytoscape-3.21.9.tgz",
+      "integrity": "sha512-JyrG4tllI6jvuISPjHK9j2Xv/LTbnLekLke5otGStjFluIyA9JjgnvgZrSBsp8cEDpiTjwgZUZwpPv8TSBcoLw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -1371,6 +1409,15 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cytoscape": {
+      "version": "3.34.0",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.0.tgz",
+      "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",

--- a/ui/package.json
+++ b/ui/package.json
@@ -10,6 +10,11 @@
     "typecheck": "tsc -b --noEmit"
   },
   "dependencies": {
+    "@fontsource-variable/archivo": "^5.3.0",
+    "@fontsource-variable/ibm-plex-sans": "^5.3.0",
+    "@fontsource/ibm-plex-mono": "^5.3.0",
+    "@types/cytoscape": "^3.21.9",
+    "cytoscape": "^3.34.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,94 +1,155 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
+import CapacityRibbon from "./components/CapacityRibbon";
+import Inspector, { Selection } from "./components/Inspector";
+import PlanCanvas from "./components/PlanCanvas";
+import Scrubber from "./components/Scrubber";
+import StatTiles from "./components/StatTiles";
+import StepList from "./components/StepList";
 import { runtimeConfig } from "./runtime-config";
+import { usePlan } from "./usePlan";
 
-interface VersionInfo {
-  version: string;
-  database: string;
-}
-
-type Status =
-  | { state: "loading" }
-  | { state: "ok"; info: VersionInfo }
-  | { state: "error"; message: string };
-
-/**
- * M0 placeholder. It deliberately calls the backend rather than rendering a
- * static page: that makes deploying the chart a real end-to-end check of
- * frontend -> nginx proxy -> ui-backend Service wiring.
- *
- * The graph canvas, step timeline and constraint inspector land in M7.
- */
 export default function App() {
-  const { apiBaseUrl, kagentUrl } = runtimeConfig();
-  const [status, setStatus] = useState<Status>({ state: "loading" });
+  const state = usePlan();
+  const { kagentUrl } = runtimeConfig();
 
+  const [step, setStep] = useState(0);
+  const [playing, setPlaying] = useState(false);
+  const [selectedStep, setSelectedStep] = useState<number | null>(null);
+  const [selection, setSelection] = useState<Selection>(null);
+
+  const planId = state.status === "ready" ? state.plan.plan.id : null;
+
+  // A new plan invalidates the scrubber position: step 7 of the old plan is
+  // not step 7 of the new one.
   useEffect(() => {
-    const controller = new AbortController();
+    setStep(0);
+    setPlaying(false);
+    setSelectedStep(null);
+    setSelection(null);
+  }, [planId]);
 
-    fetch(`${apiBaseUrl}/api/v1/version`, { signal: controller.signal })
-      .then(async (res) => {
-        if (!res.ok) {
-          throw new Error(`backend returned ${res.status}`);
-        }
-        return (await res.json()) as VersionInfo;
-      })
-      .then((info) => setStatus({ state: "ok", info }))
-      .catch((err: unknown) => {
-        if (controller.signal.aborted) return;
-        setStatus({
-          state: "error",
-          message: err instanceof Error ? err.message : String(err),
-        });
-      });
+  const handleSelectPod = useCallback((key: string | null) => {
+    setSelection(key ? { kind: "pod", key } : null);
+  }, []);
 
-    return () => controller.abort();
-  }, [apiBaseUrl]);
+  const handleSelectNode = useCallback((name: string | null) => {
+    setSelection(name ? { kind: "node", name } : null);
+  }, []);
+
+  const handleSelectStep = useCallback((seq: number | null) => {
+    setSelectedStep(seq);
+    // Selecting a step moves the canvas to the moment just before it runs, so
+    // the highlighted pods are still on the node being drained.
+    if (seq != null) {
+      setPlaying(false);
+      setStep(seq - 1);
+    }
+  }, []);
 
   return (
-    <main className="shell">
-      <header className="header">
-        <div>
+    <div className="shell">
+      <header className="topbar">
+        <div className="brand">
           <h1>k8s-dencer</h1>
-          <p className="tagline">Node consolidation planning, explained.</p>
+          <span className="tagline">Capacity plan</span>
         </div>
-        {kagentUrl && (
-          <a className="link" href={kagentUrl} target="_blank" rel="noreferrer">
-            Ask the agent →
-          </a>
-        )}
+        <div className="topbar-right">
+          <span className="badge" title="This release plans and explains. It never drains, cordons or evicts.">
+            Plans only
+          </span>
+          {kagentUrl && (
+            <a className="link" href={kagentUrl} target="_blank" rel="noreferrer">
+              Ask the agent →
+            </a>
+          )}
+        </div>
       </header>
 
-      <section className="panel">
-        <h2>Backend</h2>
-        {status.state === "loading" && <p className="muted">Connecting…</p>}
-        {status.state === "ok" && (
-          <dl className="facts">
-            <dt>Status</dt>
-            <dd>
-              <span className="dot dot-ok" aria-hidden="true" />
-              Connected
-            </dd>
-            <dt>Version</dt>
-            <dd>{status.info.version}</dd>
-            <dt>Plan store</dt>
-            <dd>{status.info.database}</dd>
-          </dl>
-        )}
-        {status.state === "error" && (
-          <p className="error">
-            <span className="dot dot-err" aria-hidden="true" />
-            Cannot reach ui-backend: {status.message}
-          </p>
-        )}
-      </section>
+      {state.status === "loading" && <Placeholder title="Reading the cluster…" />}
 
-      <section className="panel">
-        <h2>Milestone</h2>
-        <p className="muted">
-          M0 — delivery skeleton. The relationship graph, step timeline and
-          constraint inspector arrive in M7.
-        </p>
-      </section>
-    </main>
+      {state.status === "empty" && (
+        <Placeholder
+          title="No plan yet"
+          detail="The planner publishes one once it has read the cluster. This takes a few seconds after install."
+        />
+      )}
+
+      {state.status === "error" && (
+        <Placeholder title="Cannot reach the planner" detail={state.message} tone="error" />
+      )}
+
+      {state.status === "ready" && (
+        <>
+          <CapacityRibbon
+            graph={state.graph}
+            steps={state.plan.plan.steps}
+            step={step}
+            onSelectNode={handleSelectNode}
+          />
+          <StatTiles stats={state.graph.stats} />
+
+          <main className="workspace">
+            <PlanCanvas
+              graph={state.graph}
+              steps={state.plan.plan.steps}
+              step={step}
+              selectedStep={selectedStep}
+              onSelectStep={handleSelectStep}
+              onSelectPod={handleSelectPod}
+              onSelectNode={handleSelectNode}
+            />
+            <div className="sidebar">
+              <StepList
+                steps={state.plan.plan.steps}
+                appliedThrough={step}
+                selected={selectedStep}
+                onSelect={handleSelectStep}
+              />
+              <Inspector
+                planId={state.plan.plan.id}
+                graph={state.graph}
+                steps={state.plan.plan.steps}
+                selection={selection}
+                onClose={() => setSelection(null)}
+                onSelectStep={handleSelectStep}
+              />
+            </div>
+          </main>
+
+          <Scrubber
+            steps={state.plan.plan.steps}
+            step={step}
+            onStep={setStep}
+            playing={playing}
+            onPlayingChange={setPlaying}
+          />
+
+          <footer className="statusbar">
+            <span>
+              plan <code>{state.plan.plan.id}</code>
+            </span>
+            <span>{state.plan.strategy}</span>
+            <span>{new Date(state.plan.plan.generatedAt).toLocaleTimeString()}</span>
+          </footer>
+        </>
+      )}
+    </div>
+  );
+}
+
+function Placeholder({
+  title,
+  detail,
+  tone = "muted",
+}: {
+  title: string;
+  detail?: string;
+  tone?: "muted" | "error";
+}) {
+  return (
+    <div className={`placeholder placeholder-${tone}`}>
+      <h2>{title}</h2>
+      {detail && <p>{detail}</p>}
+    </div>
   );
 }

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -1,0 +1,200 @@
+import { runtimeConfig } from "./runtime-config";
+
+export type Impact = "Green" | "Yellow" | "Red";
+
+export interface Move {
+  namespace: string;
+  pod: string;
+  fromNode: string;
+  toNode: string;
+}
+
+export interface ImpactReason {
+  kind: string;
+  subject?: string;
+  detail?: string;
+}
+
+export interface PlanStep {
+  id: string;
+  sequenceNumber: number;
+  targetNode?: string;
+  moves: Move[];
+  impact: Impact;
+  rationale: string;
+  reasons?: ImpactReason[];
+}
+
+export interface Plan {
+  id: string;
+  generatedAt: string;
+  snapshotTakenAt: string;
+  status: string;
+  steps: PlanStep[];
+  nodesBefore: number;
+  nodesAfter: number;
+}
+
+export interface PlanResponse {
+  plan: Plan;
+  strategy: string;
+  storedAt: string;
+  ratings: Record<Impact, number>;
+  readOnly: boolean;
+}
+
+export interface GraphData {
+  id: string;
+  parent?: string;
+  source?: string;
+  target?: string;
+  kind: "node" | "pod" | "edge";
+  label: string;
+
+  zone?: string;
+  ready?: boolean;
+  cordoned?: boolean;
+  cpuAllocatable?: number;
+  cpuRequested?: number;
+  memAllocatable?: number;
+  memRequested?: number;
+  utilization?: number;
+  drained?: boolean;
+  drainStep?: number;
+
+  namespace?: string;
+  cpuRequest?: number;
+  memRequest?: number;
+  ownerKind?: string;
+  ownerName?: string;
+  movable?: boolean;
+  targetNode?: string;
+  moveStep?: number;
+  blocked?: boolean;
+
+  relation?: "move" | "pdb" | "anti-affinity";
+  impact?: string;
+}
+
+export interface GraphElement {
+  group: "nodes" | "edges";
+  data: GraphData;
+}
+
+export interface GraphStats {
+  nodesBefore: number;
+  nodesAfter: number;
+  reclaimed: number;
+  steps: number;
+  ratings: Record<Impact, number>;
+  podsMoved: number;
+  cpuReclaimedMilli: number;
+  memoryReclaimedBytes: number;
+}
+
+export interface GraphPayload {
+  planId: string;
+  elements: GraphElement[];
+  stats: GraphStats;
+}
+
+export interface PodConstraint {
+  kind: string;
+  subject?: string;
+  hard: boolean;
+  blocking: boolean;
+  explanation: string;
+}
+
+export interface PodConstraints {
+  namespace: string;
+  name: string;
+  nodeName?: string;
+  movable: boolean;
+  constraints: PodConstraint[];
+  candidateNodes: string[] | null;
+}
+
+export interface StepDetail {
+  planId: string;
+  step: PlanStep;
+  constraints: PodConstraints[];
+}
+
+const base = () => runtimeConfig().apiBaseUrl;
+
+/** ApiError distinguishes "nothing planned yet" from a real failure — a fresh
+ *  install legitimately has no plan, and the UI must not show that as broken. */
+export class ApiError extends Error {
+  constructor(
+    readonly status: number,
+    message: string,
+  ) {
+    super(message);
+  }
+  get isEmpty() {
+    return this.status === 404;
+  }
+}
+
+async function get<T>(path: string, signal?: AbortSignal): Promise<T> {
+  const res = await fetch(`${base()}${path}`, { signal });
+  if (!res.ok) {
+    let detail = res.statusText;
+    try {
+      const body = (await res.json()) as { error?: string };
+      if (body.error) detail = body.error;
+    } catch {
+      /* non-JSON error body */
+    }
+    throw new ApiError(res.status, detail);
+  }
+  return (await res.json()) as T;
+}
+
+export const api = {
+  latestPlan: (signal?: AbortSignal) => get<PlanResponse>("/api/v1/plans/latest", signal),
+  graph: (planId: string, signal?: AbortSignal) =>
+    get<GraphPayload>(`/api/v1/plans/${planId}/graph`, signal),
+  step: (planId: string, seq: number, signal?: AbortSignal) =>
+    get<StepDetail>(`/api/v1/plans/${planId}/steps/${seq}`, signal),
+};
+
+/** Subscribes to plan changes. Returns an unsubscribe function.
+ *
+ *  EventSource reconnects on its own, so there is no retry logic here. */
+export function subscribePlans(onChange: (planId: string) => void): () => void {
+  const source = new EventSource(`${base()}/api/v1/events`);
+  const handler = (e: MessageEvent) => {
+    try {
+      const data = JSON.parse(e.data) as { planId?: string };
+      if (data.planId) onChange(data.planId);
+    } catch {
+      /* ignore malformed frames */
+    }
+  };
+  source.addEventListener("plan", handler as EventListener);
+  return () => {
+    source.removeEventListener("plan", handler as EventListener);
+    source.close();
+  };
+}
+
+export function formatCPU(milli: number): string {
+  if (milli >= 1000) {
+    const cores = milli / 1000;
+    return `${cores % 1 === 0 ? cores : cores.toFixed(1)}`;
+  }
+  return `${milli}m`;
+}
+
+export function formatBytes(bytes: number): string {
+  const units = ["B", "KiB", "MiB", "GiB", "TiB"];
+  let v = bytes;
+  let i = 0;
+  while (v >= 1024 && i < units.length - 1) {
+    v /= 1024;
+    i++;
+  }
+  return `${v % 1 === 0 ? v : v.toFixed(1)} ${units[i]}`;
+}

--- a/ui/src/components/CapacityRibbon.tsx
+++ b/ui/src/components/CapacityRibbon.tsx
@@ -1,0 +1,134 @@
+import { useMemo } from "react";
+import { GraphPayload, PlanStep } from "../api";
+
+interface Props {
+  graph: GraphPayload;
+  steps: PlanStep[];
+  step: number;
+  onSelectNode: (name: string) => void;
+}
+
+/**
+ * The capacity ribbon — the page's thesis.
+ *
+ * One cell per node, ordered fullest to emptiest, each cell's fill showing how
+ * much of that machine is actually requested. The argument the product exists
+ * to make is visible in a single glance: a long tail of barely-used cells, and
+ * a shorter block of full ones once the plan has run.
+ *
+ * This is deliberately not a big number with a small label. "15 nodes
+ * reclaimed" is a conclusion; the ribbon is the evidence, and it also does the
+ * work a side-by-side before/after pane would do, in one strip, leaving the
+ * canvas its full width for detail.
+ */
+export default function CapacityRibbon({ graph, steps, step, onSelectNode }: Props) {
+  const cells = useMemo(() => buildCells(graph, steps, step), [graph, steps, step]);
+
+  const live = cells.filter((c) => !c.drained && c.load > 0).length;
+  const idle = cells.filter((c) => !c.drained && c.load === 0).length;
+  const reclaimed = cells.filter((c) => c.drained).length;
+
+  return (
+    <section className="ribbon" aria-label="Cluster capacity by node">
+      <div className="ribbon-lede">
+        <p className="ribbon-claim">
+          <span className="ribbon-figure">{live}</span>
+          <span className="ribbon-claim-text">
+            machines carry the workload
+            {reclaimed > 0 && (
+              <>
+                {" "}
+                once <strong>{reclaimed}</strong> more are drained
+              </>
+            )}
+          </span>
+        </p>
+        <p className="ribbon-sub">
+          {idle > 0 && `${idle} already empty · `}
+          each bar is one node, filled to its requested CPU
+        </p>
+      </div>
+
+      <ol className="ribbon-track">
+        {cells.map((c) => (
+          <li key={c.name}>
+            <button
+              type="button"
+              className={`cell${c.drained ? " cell-drained" : ""}${c.load === 0 ? " cell-idle" : ""}`}
+              onClick={() => onSelectNode(c.name)}
+              title={`${c.name} — ${Math.round(c.fill * 100)}% requested${c.drained ? " · drained by this plan" : ""}`}
+              aria-label={`${c.name}, ${Math.round(c.fill * 100)} percent requested${c.drained ? ", drained by this plan" : ""}`}
+            >
+              <span className="cell-fill" style={{ height: `${Math.max(c.fill * 100, c.load > 0 ? 4 : 0)}%` }} />
+            </button>
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}
+
+interface Cell {
+  name: string;
+  fill: number;
+  load: number;
+  drained: boolean;
+}
+
+/**
+ * Cells keep a fixed order — fullest first, as the cluster stands today — and
+ * never re-sort while scrubbing. A bar that jumped position as it drained
+ * would read as motion carrying meaning it does not have; holding position
+ * makes the drain itself the only thing moving.
+ */
+function buildCells(graph: GraphPayload, steps: PlanStep[], step: number): Cell[] {
+  const capacity = new Map<string, number>();
+  const baseline = new Map<string, number>();
+  const drainStep = new Map<string, number>();
+
+  for (const el of graph.elements) {
+    const d = el.data;
+    if (d.kind !== "node") continue;
+    capacity.set(d.label, d.cpuAllocatable ?? 0);
+    baseline.set(d.label, 0);
+    if (d.drainStep) drainStep.set(d.label, d.drainStep);
+  }
+
+  const host = new Map<string, string>();
+  const request = new Map<string, number>();
+  for (const el of graph.elements) {
+    const d = el.data;
+    if (d.kind !== "pod" || !d.parent) continue;
+    const key = `${d.namespace}/${d.label}`;
+    host.set(key, d.parent.replace(/^node:/, ""));
+    request.set(key, d.cpuRequest ?? 0);
+  }
+  for (const s of steps) {
+    if (s.sequenceNumber > step) break;
+    for (const m of s.moves) host.set(`${m.namespace}/${m.pod}`, m.toNode);
+  }
+
+  for (const [key, node] of host) {
+    baseline.set(node, (baseline.get(node) ?? 0) + (request.get(key) ?? 0));
+  }
+
+  const cells: Cell[] = [];
+  for (const [name, cap] of capacity) {
+    const load = baseline.get(name) ?? 0;
+    const drained = (drainStep.get(name) ?? 0) > 0 && (drainStep.get(name) ?? 0) <= step;
+    cells.push({ name, load, fill: cap > 0 ? Math.min(load / cap, 1) : 0, drained });
+  }
+
+  // Ordered once, by how full each node is *today*, then held.
+  const initial = new Map<string, number>();
+  for (const el of graph.elements) {
+    if (el.data.kind !== "node") continue;
+    const cap = el.data.cpuAllocatable ?? 0;
+    initial.set(el.data.label, cap > 0 ? (el.data.cpuRequested ?? 0) / cap : 0);
+  }
+  cells.sort((a, b) => {
+    const d = (initial.get(b.name) ?? 0) - (initial.get(a.name) ?? 0);
+    return d !== 0 ? d : a.name.localeCompare(b.name, undefined, { numeric: true });
+  });
+  return cells;
+}

--- a/ui/src/components/Impact.tsx
+++ b/ui/src/components/Impact.tsx
@@ -1,0 +1,53 @@
+import { Impact } from "../api";
+
+/**
+ * Rating chip.
+ *
+ * The palette validator reports critical <-> good at CVD deltaE 4.1 for
+ * deuteranopia, against a floor of 8 — Red and Green are the same colour to a
+ * large minority of readers. So a rating is never colour alone: each carries a
+ * distinct glyph *and* the word. The glyphs differ in silhouette (disc,
+ * triangle, square), not just fill, so they survive greyscale and low
+ * resolution too.
+ */
+const GLYPH: Record<Impact, string> = {
+  Green: "●",
+  Yellow: "▲",
+  Red: "■",
+};
+
+const DESCRIPTION: Record<Impact, string> = {
+  Green: "Safe to run at any time",
+  Yellow: "Executable on request, flagged",
+  Red: "Maintenance window only",
+};
+
+export function ImpactChip({ impact, compact = false }: { impact: Impact; compact?: boolean }) {
+  return (
+    <span
+      className={`chip chip-${impact.toLowerCase()}${compact ? " chip-compact" : ""}`}
+      title={DESCRIPTION[impact]}
+    >
+      <span aria-hidden="true" className="chip-glyph">
+        {GLYPH[impact]}
+      </span>
+      <span className="chip-label">{impact}</span>
+    </span>
+  );
+}
+
+export function ImpactLegend({ counts }: { counts: Record<Impact, number> }) {
+  const order: Impact[] = ["Green", "Yellow", "Red"];
+  return (
+    <div className="legend" aria-label="Steps by impact rating">
+      {order.map((impact) => (
+        <div className="legend-item" key={impact}>
+          <ImpactChip impact={impact} compact />
+          <span className="legend-count">{counts[impact] ?? 0}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export { GLYPH as impactGlyph, DESCRIPTION as impactDescription };

--- a/ui/src/components/Inspector.tsx
+++ b/ui/src/components/Inspector.tsx
@@ -1,0 +1,193 @@
+import { GraphPayload, PlanStep, formatBytes, formatCPU } from "../api";
+import { usePodConstraints } from "../useConstraints";
+import { ImpactChip } from "./Impact";
+
+export type Selection =
+  | { kind: "pod"; key: string }
+  | { kind: "node"; name: string }
+  | null;
+
+interface Props {
+  planId: string;
+  graph: GraphPayload;
+  steps: PlanStep[];
+  selection: Selection;
+  onClose: () => void;
+  onSelectStep: (seq: number) => void;
+}
+
+/**
+ * Constraint inspector.
+ *
+ * Every explanation shown here is the string the constraint analyzer produced,
+ * rendered verbatim. The UI deliberately does not paraphrase or re-derive
+ * them: the Kagent agent answers from the same text, and an inspector that
+ * worded things differently would leave an operator unsure which to believe.
+ */
+export default function Inspector({
+  planId,
+  graph,
+  steps,
+  selection,
+  onClose,
+  onSelectStep,
+}: Props) {
+  if (!selection) return null;
+
+  return (
+    <section className="inspector" aria-label="Constraint inspector">
+      <header className="inspector-header">
+        <h2>{selection.kind === "pod" ? "Pod" : "Node"}</h2>
+        <button type="button" className="inspector-close" onClick={onClose} aria-label="Close inspector">
+          ✕
+        </button>
+      </header>
+      {selection.kind === "pod" ? (
+        <PodPanel planId={planId} podKey={selection.key} />
+      ) : (
+        <NodePanel graph={graph} steps={steps} name={selection.name} onSelectStep={onSelectStep} />
+      )}
+    </section>
+  );
+}
+
+function PodPanel({ planId, podKey }: { planId: string; podKey: string }) {
+  const state = usePodConstraints(planId, podKey);
+
+  return (
+    <div className="inspector-body">
+      <div className="inspector-title">{podKey}</div>
+
+      {state.status === "loading" && <p className="muted">Loading constraints…</p>}
+      {state.status === "missing" && (
+        <p className="muted">This pod is not part of the displayed plan's snapshot.</p>
+      )}
+      {state.status === "error" && <p className="error-text">{state.message}</p>}
+
+      {state.status === "ready" && (
+        <>
+          <dl className="facts">
+            <dt>Node</dt>
+            <dd>{state.constraints.nodeName || "unscheduled"}</dd>
+            <dt>Movable</dt>
+            <dd>
+              {state.constraints.movable ? (
+                "Yes"
+              ) : (
+                <span className="flag-blocked">✕ Blocked</span>
+              )}
+            </dd>
+            <dt>Can move to</dt>
+            <dd>
+              {state.constraints.movable
+                ? `${state.constraints.candidateNodes?.length ?? 0} node(s)`
+                : "—"}
+            </dd>
+          </dl>
+
+          <h3 className="inspector-subhead">
+            Effective constraints
+            <span className="inspector-count">{state.constraints.constraints.length}</span>
+          </h3>
+
+          <ul className="constraint-list">
+            {state.constraints.constraints.map((c, i) => (
+              <li key={`${c.kind}-${c.subject ?? i}`} className={c.blocking ? "constraint blocking" : "constraint"}>
+                <div className="constraint-head">
+                  {/* Blocking status carries a glyph as well as colour. */}
+                  <span className="constraint-kind">
+                    {c.blocking && <span aria-hidden="true">✕ </span>}
+                    {c.kind}
+                  </span>
+                  <span className={`constraint-tag${c.hard ? " hard" : ""}`}>
+                    {c.hard ? "hard" : "preference"}
+                  </span>
+                </div>
+                {c.subject && <div className="constraint-subject">{c.subject}</div>}
+                <p className="constraint-text">{c.explanation}</p>
+              </li>
+            ))}
+            {state.constraints.constraints.length === 0 && (
+              <li className="muted">No constraints apply to this pod.</li>
+            )}
+          </ul>
+        </>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Node detail is derived from the graph payload already in memory rather than
+ * fetched. Everything shown — occupancy, utilisation, which step drains it —
+ * is in the payload, so a round trip would only add latency.
+ */
+function NodePanel({
+  graph,
+  steps,
+  name,
+  onSelectStep,
+}: {
+  graph: GraphPayload;
+  steps: PlanStep[];
+  name: string;
+  onSelectStep: (seq: number) => void;
+}) {
+  const node = graph.elements.find((e) => e.data.kind === "node" && e.data.label === name)?.data;
+  const pods = graph.elements.filter(
+    (e) => e.data.kind === "pod" && e.data.parent === `node:${name}`,
+  );
+  const drainStep = node?.drainStep ?? 0;
+  const step = steps.find((s) => s.sequenceNumber === drainStep);
+  const blocked = pods.filter((p) => p.data.blocked);
+
+  if (!node) return <div className="inspector-body muted">Node not found in this plan.</div>;
+
+  const util = node.cpuAllocatable ? (node.cpuRequested ?? 0) / node.cpuAllocatable : 0;
+
+  return (
+    <div className="inspector-body">
+      <div className="inspector-title">{name}</div>
+
+      <dl className="facts">
+        <dt>Zone</dt>
+        <dd>{node.zone || "—"}</dd>
+        <dt>CPU</dt>
+        <dd>
+          {formatCPU(node.cpuRequested ?? 0)} / {formatCPU(node.cpuAllocatable ?? 0)} cores (
+          {Math.round(util * 100)}%)
+        </dd>
+        <dt>Memory</dt>
+        <dd>
+          {formatBytes(node.memRequested ?? 0)} / {formatBytes(node.memAllocatable ?? 0)}
+        </dd>
+        <dt>Pods</dt>
+        <dd>{pods.length}</dd>
+      </dl>
+
+      {drainStep > 0 && step ? (
+        <div className="inspector-callout">
+          <div className="callout-head">
+            <span>Drained by step {drainStep}</span>
+            <ImpactChip impact={step.impact} compact />
+          </div>
+          <p className="constraint-text">{step.rationale}</p>
+          <button type="button" className="linkish" onClick={() => onSelectStep(drainStep)}>
+            Show this step →
+          </button>
+        </div>
+      ) : (
+        <div className="inspector-callout">
+          <div className="callout-head">
+            <span>Not drained by this plan</span>
+          </div>
+          <p className="constraint-text">
+            {blocked.length > 0
+              ? `${blocked.length} pod(s) here cannot be evicted, so the node cannot be emptied. Select a pod to see why.`
+              : "This node is either a destination for other pods, excluded by policy, or already reclaimable."}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/PlanCanvas.tsx
+++ b/ui/src/components/PlanCanvas.tsx
@@ -1,0 +1,292 @@
+import { useEffect, useMemo, useRef } from "react";
+import cytoscape, { Core, ElementDefinition } from "cytoscape";
+import { GraphPayload, PlanStep } from "../api";
+import {
+  Model,
+  NODE_HEADER,
+  POD_SIZE,
+  computeLayout,
+  gridColumns,
+  peakOccupancy,
+  placementAtStep,
+  toModel,
+} from "../layout";
+
+interface Props {
+  graph: GraphPayload;
+  steps: PlanStep[];
+  /** 0 shows the cluster as it is now; N shows it after step N. */
+  step: number;
+  selectedStep: number | null;
+  onSelectStep: (seq: number | null) => void;
+  onSelectPod: (podKey: string | null) => void;
+  onSelectNode: (name: string | null) => void;
+}
+
+const css = (name: string) =>
+  getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+
+/**
+ * The packing canvas.
+ *
+ * Rather than two static before/after panes, one canvas morphs between them
+ * under the scrubber. That shows the same comparison plus every intermediate
+ * state, and makes the causal story — this pod leaves, so this node empties —
+ * visible instead of inferred.
+ */
+export default function PlanCanvas({
+  graph,
+  steps,
+  step,
+  selectedStep,
+  onSelectStep,
+  onSelectPod,
+  onSelectNode,
+}: Props) {
+  const container = useRef<HTMLDivElement>(null);
+  const cyRef = useRef<Core | null>(null);
+
+  const model: Model = useMemo(() => toModel(graph), [graph]);
+  const peak = useMemo(() => peakOccupancy(model, steps), [model, steps]);
+  const columns = useMemo(() => gridColumns(model.nodes.length), [model.nodes.length]);
+
+  // Build the graph once per plan. Steps only move things, so rebuilding on
+  // every scrubber tick would throw away the animation entirely.
+  useEffect(() => {
+    if (!container.current) return;
+
+    const placement = placementAtStep(model, steps, 0);
+    const laid = computeLayout(model, placement, peak, columns);
+
+    const elements: ElementDefinition[] = [];
+    for (const node of model.nodes) {
+      const pos = laid.nodes.get(node.id)!;
+      elements.push({
+        group: "nodes",
+        data: {
+          id: node.id,
+          kind: "node",
+          label: node.name,
+          zone: node.zone ?? "",
+          drainStep: node.drainStep,
+          w: laid.nodeWidth,
+          h: laid.nodeHeight,
+        },
+        position: { ...pos },
+        selectable: false,
+        grabbable: false,
+      });
+    }
+    for (const pod of model.pods) {
+      const pos = laid.pods.get(pod.id)!;
+      elements.push({
+        group: "nodes",
+        data: {
+          id: pod.id,
+          kind: "pod",
+          key: pod.key,
+          label: pod.label,
+          blocked: pod.blocked,
+          movable: pod.movable,
+          owner: pod.ownerKind ?? "",
+        },
+        position: { ...pos },
+        selectable: false,
+        grabbable: false,
+      });
+    }
+
+    const cy = cytoscape({
+      container: container.current,
+      elements,
+      layout: { name: "preset" },
+      style: styleSheet(),
+      minZoom: 0.15,
+      maxZoom: 3,
+      wheelSensitivity: 0.2,
+      // Boxes and pods are positioned deliberately; letting a drag move them
+      // would destroy the packing picture the layout exists to convey.
+      autoungrabify: true,
+      boxSelectionEnabled: false,
+    });
+    cyRef.current = cy;
+
+    cy.on("tap", "node[kind = 'node']", (e) => {
+      const drain = e.target.data("drainStep") as number;
+      onSelectNode(e.target.data("label") as string);
+      onSelectStep(drain > 0 ? drain : null);
+    });
+    cy.on("tap", "node[kind = 'pod']", (e) => {
+      onSelectPod(e.target.data("key") as string);
+    });
+    cy.on("tap", (e) => {
+      if (e.target === cy) {
+        onSelectStep(null);
+        onSelectPod(null);
+        onSelectNode(null);
+      }
+    });
+
+    cy.fit(undefined, 30);
+
+    return () => {
+      cy.destroy();
+      cyRef.current = null;
+    };
+  }, [model, steps, peak, columns, onSelectStep, onSelectPod, onSelectNode]);
+
+  // Animate to the requested step.
+  useEffect(() => {
+    const cy = cyRef.current;
+    if (!cy) return;
+
+    const placement = placementAtStep(model, steps, step);
+    const laid = computeLayout(model, placement, peak, columns);
+    const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+    cy.batch(() => {
+      for (const node of model.nodes) {
+        const el = cy.getElementById(node.id);
+        if (el.empty()) continue;
+        const drained = node.drainStep > 0 && node.drainStep <= step;
+        el.data("emptied", laid.emptied.has(node.name));
+        el.data("drained", drained);
+        el.data("load", laid.nodeLoad.get(node.name) ?? 0);
+        el.data(
+          "fill",
+          node.cpuAllocatable > 0
+            ? (laid.nodeLoad.get(node.name) ?? 0) / node.cpuAllocatable
+            : 0,
+        );
+      }
+      for (const pod of model.pods) {
+        const el = cy.getElementById(pod.id);
+        if (el.empty()) continue;
+        const target = laid.pods.get(pod.id);
+        if (!target) continue;
+        if (reduceMotion) {
+          el.position(target);
+        } else {
+          el.stop().animate({ position: target }, { duration: 420, easing: "ease-in-out-cubic" });
+        }
+      }
+    });
+  }, [model, steps, step, peak, columns]);
+
+  // Highlight whichever step is selected.
+  useEffect(() => {
+    const cy = cyRef.current;
+    if (!cy) return;
+    cy.batch(() => {
+      cy.nodes().removeClass("highlight dim");
+      if (selectedStep == null) return;
+      const target = steps.find((s) => s.sequenceNumber === selectedStep);
+      if (!target) return;
+
+      const involved = new Set<string>();
+      if (target.targetNode) involved.add(`node:${target.targetNode}`);
+      for (const m of target.moves) {
+        involved.add(`pod:${m.namespace}/${m.pod}`);
+        involved.add(`node:${m.toNode}`);
+      }
+      cy.nodes().forEach((n) => {
+        n.addClass(involved.has(n.id()) ? "highlight" : "dim");
+      });
+    });
+  }, [selectedStep, steps]);
+
+  return <div className="canvas" ref={container} role="img" aria-label="Cluster packing" />;
+}
+
+/**
+ * Node fill encodes utilisation on the sequential blue ramp — one hue,
+ * light to dark, per the palette's rule for magnitude.
+ *
+ * Impact ratings are never encoded by colour alone here: a drained node also
+ * gets a distinct border style per rating (solid / dashed / double), because
+ * the validator puts Red and Green at CVD deltaE 4.1, which is indistinguishable
+ * for deuteranopia.
+ */
+function styleSheet(): cytoscape.StylesheetJson {
+  const seq = [css("--seq-100"), css("--seq-250"), css("--seq-400"), css("--seq-550"), css("--seq-700")];
+  const surface = css("--surface");
+  const raised = css("--surface-raised");
+  const border = css("--border-strong");
+  const muted = css("--text-muted");
+  const text = css("--text-secondary");
+
+  return [
+    {
+      selector: "node[kind = 'node']",
+      style: {
+        shape: "round-rectangle",
+        width: "data(w)",
+        height: "data(h)",
+        "background-color": surface,
+        "background-opacity": 1,
+        "border-width": 1,
+        "border-color": border,
+        label: "data(label)",
+        "text-valign": "top",
+        "text-halign": "center",
+        "text-margin-y": NODE_HEADER - 6,
+        "font-size": 8,
+        color: muted,
+        "font-family": css("--font-mono") || "monospace",
+        "z-index": 1,
+      },
+    },
+    // Utilisation, five steps of one hue. Bucketed rather than continuous so
+    // the difference between two nodes is actually readable.
+    { selector: "node[kind = 'node'][fill >= 0.01]", style: { "border-color": seq[0], "border-width": 2 } },
+    { selector: "node[kind = 'node'][fill >= 0.25]", style: { "border-color": seq[1] } },
+    { selector: "node[kind = 'node'][fill >= 0.5]", style: { "border-color": seq[2] } },
+    { selector: "node[kind = 'node'][fill >= 0.75]", style: { "border-color": seq[3] } },
+    { selector: "node[kind = 'node'][fill >= 0.95]", style: { "border-color": seq[4] } },
+    {
+      selector: "node[kind = 'node'][?drained]",
+      style: {
+        "background-opacity": 0.25,
+        "border-style": "dashed",
+        "border-color": muted,
+        color: muted,
+      },
+    },
+    {
+      selector: "node[kind = 'pod']",
+      style: {
+        shape: "round-rectangle",
+        width: POD_SIZE,
+        height: POD_SIZE,
+        "background-color": raised,
+        "border-width": 1,
+        "border-color": border,
+        "z-index": 10,
+      },
+    },
+    {
+      selector: "node[kind = 'pod'][?movable]",
+      style: { "background-color": css("--seq-400"), "background-opacity": 0.55 },
+    },
+    // A blocked pod is why a node cannot be emptied, so it is marked by shape
+    // as well as colour.
+    {
+      selector: "node[kind = 'pod'][?blocked]",
+      style: {
+        shape: "diamond",
+        "background-color": css("--impact-red"),
+        "background-opacity": 0.9,
+        "border-color": css("--impact-red"),
+      },
+    },
+    { selector: ".dim", style: { opacity: 0.18 } },
+    {
+      selector: "node[kind = 'pod'].highlight",
+      style: { "border-width": 2, "border-color": css("--text-primary"), "z-index": 30 },
+    },
+    {
+      selector: "node[kind = 'node'].highlight",
+      style: { "border-width": 3, "border-color": css("--text-primary"), color: text },
+    },
+  ] as cytoscape.StylesheetJson;
+}

--- a/ui/src/components/Scrubber.tsx
+++ b/ui/src/components/Scrubber.tsx
@@ -1,0 +1,115 @@
+import { useEffect, useRef } from "react";
+import { PlanStep } from "../api";
+import { impactGlyph } from "./Impact";
+
+interface Props {
+  steps: PlanStep[];
+  step: number;
+  onStep: (n: number) => void;
+  playing: boolean;
+  onPlayingChange: (playing: boolean) => void;
+}
+
+/**
+ * Timeline scrubber.
+ *
+ * Position 0 is the cluster as it stands; the maximum is the fully
+ * consolidated end state. Dragging between them is the before/after
+ * comparison, with every intermediate state available — which a pair of static
+ * panes cannot show.
+ *
+ * A native range input carries the keyboard and screen-reader behaviour for
+ * free; a custom-drawn track would have to reimplement all of it and would
+ * still be worse.
+ */
+export default function Scrubber({ steps, step, onStep, playing, onPlayingChange }: Props) {
+  const max = steps.length;
+  const timer = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!playing) return;
+    if (step >= max) {
+      onPlayingChange(false);
+      return;
+    }
+    timer.current = window.setTimeout(() => onStep(step + 1), 620);
+    return () => {
+      if (timer.current) window.clearTimeout(timer.current);
+    };
+  }, [playing, step, max, onStep, onPlayingChange]);
+
+  const current = steps.find((s) => s.sequenceNumber === step);
+
+  return (
+    <section className="scrubber" aria-label="Step timeline">
+      <button
+        type="button"
+        className="scrub-btn"
+        onClick={() => onPlayingChange(!playing)}
+        aria-label={playing ? "Pause" : "Play through the plan"}
+        disabled={max === 0}
+      >
+        {playing ? "❚❚" : "▶"}
+      </button>
+      <button
+        type="button"
+        className="scrub-btn"
+        onClick={() => {
+          onPlayingChange(false);
+          onStep(0);
+        }}
+        aria-label="Back to the current cluster"
+        disabled={step === 0}
+      >
+        ↺
+      </button>
+
+      <div className="scrub-track">
+        <input
+          type="range"
+          min={0}
+          max={max}
+          step={1}
+          value={step}
+          aria-label="Consolidation step"
+          aria-valuetext={
+            step === 0 ? "Cluster as it is now" : `After step ${step} of ${max}`
+          }
+          onChange={(e) => {
+            onPlayingChange(false);
+            onStep(Number(e.target.value));
+          }}
+        />
+        {/* Rating ticks. Glyphs rather than coloured dots, because Red and
+            Green are indistinguishable under deuteranopia. */}
+        <div className="scrub-ticks" aria-hidden="true">
+          {steps.map((s) => (
+            <span
+              key={s.id}
+              className={`tick tick-${s.impact.toLowerCase()}${s.sequenceNumber <= step ? " tick-done" : ""}`}
+              style={{ left: `${(s.sequenceNumber / Math.max(max, 1)) * 100}%` }}
+            >
+              {impactGlyph[s.impact]}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      <div className="scrub-readout">
+        {step === 0 ? (
+          <>
+            <strong>Now</strong>
+            <span className="scrub-sub">drag to preview the plan</span>
+          </>
+        ) : (
+          <>
+            <strong>
+              Step {step} of {max}
+            </strong>
+            <span className="scrub-sub">{current?.targetNode ?? ""}</span>
+          </>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/ui/src/components/StatTiles.tsx
+++ b/ui/src/components/StatTiles.tsx
@@ -1,0 +1,39 @@
+import { GraphStats, formatBytes, formatCPU } from "../api";
+import { ImpactLegend } from "./Impact";
+
+/**
+ * Supporting figures.
+ *
+ * These sit *under* the capacity ribbon and stay deliberately small. The
+ * ribbon is the argument; these are the receipts. Promoting one of them to a
+ * display-size hero would put a conclusion where the evidence should be.
+ *
+ * Figures are Archivo with tabular numerals, because this is a row of numbers
+ * that should align — the rule against tabular figures applies to large
+ * standalone values, which none of these are any more.
+ */
+export default function StatTiles({ stats }: { stats: GraphStats }) {
+  return (
+    <section className="figures" aria-label="Plan summary">
+      <Figure label="CPU freed" value={formatCPU(stats.cpuReclaimedMilli)} unit="cores" />
+      <Figure label="Memory freed" value={formatBytes(stats.memoryReclaimedBytes)} />
+      <Figure label="Pods moved" value={String(stats.podsMoved)} unit={`in ${stats.steps} steps`} />
+      <div className="figure figure-legend">
+        <span className="figure-label">Steps by impact</span>
+        <ImpactLegend counts={stats.ratings} />
+      </div>
+    </section>
+  );
+}
+
+function Figure({ label, value, unit }: { label: string; value: string; unit?: string }) {
+  return (
+    <div className="figure">
+      <span className="figure-label">{label}</span>
+      <span className="figure-value">
+        {value}
+        {unit && <span className="figure-unit">{unit}</span>}
+      </span>
+    </div>
+  );
+}

--- a/ui/src/components/StepList.tsx
+++ b/ui/src/components/StepList.tsx
@@ -1,0 +1,58 @@
+import { PlanStep } from "../api";
+import { ImpactChip } from "./Impact";
+
+interface Props {
+  steps: PlanStep[];
+  /** How far the scrubber has advanced; steps at or below this are applied. */
+  appliedThrough: number;
+  selected: number | null;
+  onSelect: (seq: number | null) => void;
+}
+
+/**
+ * The numbered, impact-rated step list.
+ *
+ * Selecting a step highlights it on the canvas, and clicking a node on the
+ * canvas selects its step here — the same relationship read from either
+ * direction, so an operator can start from "what does step 7 do?" or from
+ * "why is this node going away?".
+ */
+export default function StepList({ steps, appliedThrough, selected, onSelect }: Props) {
+  return (
+    <aside className="steps" aria-label="Consolidation steps">
+      <header className="steps-header">
+        <h2>Steps</h2>
+        <span className="steps-count">{steps.length}</span>
+      </header>
+
+      <ol className="step-list">
+        {steps.map((step) => {
+          const applied = step.sequenceNumber <= appliedThrough;
+          const isSelected = selected === step.sequenceNumber;
+          return (
+            <li key={step.id}>
+              <button
+                type="button"
+                className={`step${isSelected ? " step-selected" : ""}${applied ? " step-applied" : ""}`}
+                aria-current={isSelected ? "step" : undefined}
+                onClick={() => onSelect(isSelected ? null : step.sequenceNumber)}
+              >
+                <span className="step-seq">{step.sequenceNumber}</span>
+                <span className="step-body">
+                  <span className="step-title">
+                    <span className="step-node">{step.targetNode}</span>
+                    <ImpactChip impact={step.impact} compact />
+                  </span>
+                  <span className="step-meta">
+                    {step.moves.length} pod{step.moves.length === 1 ? "" : "s"} to move
+                  </span>
+                  {isSelected && <span className="step-rationale">{step.rationale}</span>}
+                </span>
+              </button>
+            </li>
+          );
+        })}
+      </ol>
+    </aside>
+  );
+}

--- a/ui/src/fonts.css
+++ b/ui/src/fonts.css
@@ -1,0 +1,67 @@
+/*
+ * Bundled typefaces, latin subsets only.
+ *
+ * Faces are declared by hand rather than importing the packages' index.css,
+ * which pulls in Cyrillic, Greek and Vietnamese subsets as well — 3.3MB of
+ * assets for a UI that ships no text in any of them. Latin-only takes it to a
+ * fraction of that.
+ *
+ * Bundled rather than fetched from a CDN: a cluster may have no route to the
+ * internet, and type that silently falls back to system-ui in an air-gapped
+ * environment is not a designed UI. It also means no third-party request from
+ * an operator's browser.
+ *
+ * font-display: swap — the page is readable immediately and reflows once, which
+ * beats a blank screen while an instrument loads.
+ */
+
+/* Archivo — structure, headings, every figure. Industrial grotesque with
+   strong lining numerals; the signage of load planning rather than the default
+   UI sans. */
+@font-face {
+  font-family: "Archivo Variable";
+  font-style: normal;
+  font-display: swap;
+  font-weight: 100 900;
+  src: url("@fontsource-variable/archivo/files/archivo-latin-wght-normal.woff2") format("woff2-variations");
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
+    U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191,
+    U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+/* IBM Plex Sans — prose. Engineering provenance, and deliberately not Inter. */
+@font-face {
+  font-family: "IBM Plex Sans Variable";
+  font-style: normal;
+  font-display: swap;
+  font-weight: 100 700;
+  src: url("@fontsource-variable/ibm-plex-sans/files/ibm-plex-sans-latin-wght-normal.woff2") format("woff2-variations");
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
+    U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191,
+    U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+/* IBM Plex Mono — machine identifiers. Node names and pod keys are machine
+   identifiers and should look like it; setting them in the prose face makes
+   them read as words. */
+@font-face {
+  font-family: "IBM Plex Mono";
+  font-style: normal;
+  font-display: swap;
+  font-weight: 400;
+  src: url("@fontsource/ibm-plex-mono/files/ibm-plex-mono-latin-400-normal.woff2") format("woff2");
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
+    U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191,
+    U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+@font-face {
+  font-family: "IBM Plex Mono";
+  font-style: normal;
+  font-display: swap;
+  font-weight: 500;
+  src: url("@fontsource/ibm-plex-mono/files/ibm-plex-mono-latin-500-normal.woff2") format("woff2");
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
+    U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191,
+    U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1,141 +1,792 @@
+@import "./theme.css";
+
 /*
- * Dark-first token set. M7 builds the real design system on these; keeping the
- * names stable now avoids a rename pass later.
+ * Type roles, applied consistently:
+ *   Archivo    structure, every figure, section headings
+ *   Plex Sans  prose — rationales, explanations, descriptions
+ *   Plex Mono  machine identifiers — node names, pod keys, plan IDs
+ *
+ * Section headings use weight and size contrast rather than uppercase letter-
+ * spaced eyebrows. Tracked-out caps are the generic dashboard tell, and they
+ * are harder to read at the sizes they always get used at.
  */
-:root {
-  --bg: #0e1116;
-  --surface: #161b22;
-  --border: #262c36;
-  --text: #e6edf3;
-  --text-muted: #8b949e;
-  --accent: #4f9cf9;
-  --ok: #3fb950;
-  --err: #f85149;
-
-  --radius: 10px;
-  --gap: 1rem;
-
-  color-scheme: dark light;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    --bg: #ffffff;
-    --surface: #f6f8fa;
-    --border: #d8dee4;
-    --text: #1f2328;
-    --text-muted: #59636e;
-    --accent: #0969da;
-    --ok: #1a7f37;
-    --err: #cf222e;
-  }
-}
-
-* {
-  box-sizing: border-box;
-}
-
-body {
-  margin: 0;
-  background: var(--bg);
-  color: var(--text);
-  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
-  line-height: 1.5;
-}
 
 .shell {
-  max-width: 60rem;
-  margin: 0 auto;
-  padding: 2.5rem 1.25rem;
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
+  display: grid;
+  grid-template-rows: auto auto auto 1fr auto auto;
+  height: 100%;
+  max-height: 100%;
+  overflow: hidden;
 }
 
-.header {
+/* ---------------------------------------------------------------- topbar */
+
+.topbar {
   display: flex;
-  flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
-  gap: var(--gap);
+  gap: 1rem;
+  padding: 0.65rem 1.25rem;
+  border-bottom: 1px solid var(--border);
+  background: var(--surface);
 }
 
-h1 {
+.brand {
+  display: flex;
+  align-items: baseline;
+  gap: 0.7rem;
+  min-width: 0;
+}
+
+.brand h1 {
   margin: 0;
-  font-size: 1.6rem;
-  letter-spacing: -0.02em;
-}
-
-h2 {
-  margin: 0 0 0.75rem;
-  font-size: 0.8rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--text-muted);
+  font-family: var(--font-display);
+  font-size: 1rem;
+  font-weight: 700;
+  letter-spacing: -0.015em;
 }
 
 .tagline {
-  margin: 0.25rem 0 0;
+  font-family: var(--font-display);
+  font-weight: 500;
   color: var(--text-muted);
+  font-size: 0.8rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.topbar-right {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.badge {
+  font-family: var(--font-display);
+  font-weight: 600;
+  padding: 0.12rem 0.5rem;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  font-size: 0.72rem;
+  color: var(--text-secondary);
+  white-space: nowrap;
 }
 
 .link {
   color: var(--accent);
   text-decoration: none;
+  font-size: 0.85rem;
   font-weight: 500;
+  white-space: nowrap;
 }
 
 .link:hover {
   text-decoration: underline;
 }
 
-.panel {
+/* ----------------------------------------------------- capacity ribbon */
+
+.ribbon {
+  display: grid;
+  grid-template-columns: minmax(16rem, 26rem) 1fr;
+  gap: 1.75rem;
+  align-items: end;
+  padding: 1.1rem 1.25rem 0.9rem;
   background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 1.25rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.ribbon-lede {
+  min-width: 0;
+}
+
+.ribbon-claim {
+  margin: 0;
+  display: flex;
+  align-items: baseline;
+  gap: 0.6rem;
+}
+
+/* The one display-size figure on the page, and it sits inside a sentence
+   rather than floating above a caption — the number means nothing without the
+   clause that follows it. */
+.ribbon-figure {
+  font-family: var(--font-display);
+  font-size: 3.25rem;
+  font-weight: 700;
+  line-height: 0.9;
+  letter-spacing: -0.04em;
+  font-variant-numeric: lining-nums;
+}
+
+.ribbon-claim-text {
+  font-family: var(--font-display);
+  font-size: 0.95rem;
+  font-weight: 500;
+  line-height: 1.25;
+  color: var(--text-secondary);
+}
+
+.ribbon-claim-text strong {
+  color: var(--text-primary);
+  font-weight: 700;
+}
+
+.ribbon-sub {
+  margin: 0.45rem 0 0;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.ribbon-track {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  align-items: flex-end;
+  gap: 2px;
+  height: 4.25rem;
+  min-width: 0;
+}
+
+.ribbon-track li {
+  flex: 1 1 0;
+  min-width: 3px;
+  height: 100%;
+}
+
+.cell {
+  display: block;
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  border: none;
+  border-radius: 1px;
+  background: var(--surface-sunken);
+  position: relative;
+  overflow: hidden;
+  transition: opacity 260ms ease;
+}
+
+.cell:hover {
+  outline: 1px solid var(--text-muted);
+}
+
+.cell-fill {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: var(--seq-400);
+  transition: height 380ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* A drained cell keeps its slot and empties, rather than disappearing: the gap
+   it leaves is the point. */
+.cell-drained {
+  opacity: 0.32;
+}
+
+.cell-drained .cell-fill {
+  background: var(--text-muted);
+}
+
+.cell-idle .cell-fill {
+  background: var(--border-strong);
+}
+
+/* ---------------------------------------------------------------- figures */
+
+.figures {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 2rem;
+  padding: 0.6rem 1.25rem;
+  background: var(--surface-sunken);
+  border-bottom: 1px solid var(--border);
+}
+
+.figure {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  min-width: 0;
+}
+
+.figure-label {
+  font-family: var(--font-display);
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--text-muted);
+}
+
+/* Tabular figures here because this is a row of numbers that should align.
+   The rule against them applies to large standalone values. */
+.figure-value {
+  font-family: var(--font-display);
+  font-size: 0.95rem;
+  font-weight: 650;
+  font-variant-numeric: tabular-nums;
+  display: flex;
+  align-items: baseline;
+  gap: 0.3rem;
+}
+
+.figure-unit {
+  font-size: 0.72rem;
+  font-weight: 500;
+  color: var(--text-muted);
+}
+
+.figure-legend {
+  margin-left: auto;
+}
+
+/* ---------------------------------------------------------------- chips */
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.05rem 0.4rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid currentColor;
+  font-family: var(--font-display);
+  font-size: 0.7rem;
+  font-weight: 600;
+  line-height: 1.6;
+  white-space: nowrap;
+}
+
+.chip-glyph {
+  font-size: 0.65em;
+  line-height: 1;
+}
+
+.chip-green {
+  color: var(--impact-green);
+}
+.chip-yellow {
+  color: var(--impact-yellow);
+}
+.chip-red {
+  color: var(--impact-red);
+}
+
+.legend {
+  display: flex;
+  gap: 0.55rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.legend-count {
+  font-family: var(--font-display);
+  font-size: 0.85rem;
+  font-weight: 650;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ------------------------------------------------------------- workspace */
+
+.workspace {
+  display: grid;
+  grid-template-columns: 1fr minmax(290px, 25rem);
+  min-height: 0;
+  overflow: hidden;
+}
+
+.canvas {
+  min-height: 0;
+  background: var(--page);
+}
+
+/* ----------------------------------------------------------------- steps */
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  min-width: 0;
+  border-left: 1px solid var(--border);
+}
+
+.steps {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  flex: 1 1 auto;
+  background: var(--surface);
+}
+
+.steps-header,
+.inspector-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.6rem 1rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.steps-header h2,
+.inspector-header h2 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 0.85rem;
+  font-weight: 650;
+  color: var(--text-primary);
+}
+
+.steps-count {
+  font-family: var(--font-display);
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.step-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  overflow-y: auto;
+  min-height: 0;
+  flex: 1;
+}
+
+.step {
+  display: flex;
+  gap: 0.7rem;
+  width: 100%;
+  padding: 0.55rem 1rem;
+  background: none;
+  border: none;
+  border-bottom: 1px solid var(--border);
+  border-left: 2px solid transparent;
+  text-align: left;
+}
+
+.step:hover {
+  background: var(--surface-raised);
+}
+
+.step-selected {
+  background: var(--surface-raised);
+  border-left-color: var(--accent);
+}
+
+.step-applied .step-seq,
+.step-applied .step-node {
+  color: var(--text-muted);
+}
+
+/* Step numbers are a real sequence — the steps must run in order — so the
+   numbering encodes something true rather than decorating the list. */
+.step-seq {
+  flex: 0 0 1.5rem;
+  font-family: var(--font-display);
+  font-variant-numeric: tabular-nums;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  padding-top: 0.12rem;
+}
+
+.step-body {
+  min-width: 0;
+  flex: 1;
+}
+
+.step-title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  justify-content: space-between;
+}
+
+.step-node {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.step-meta {
+  display: block;
+  font-size: 0.74rem;
+  color: var(--text-muted);
+  margin-top: 0.1rem;
+}
+
+.step-rationale {
+  display: block;
+  margin-top: 0.45rem;
+  font-size: 0.78rem;
+  line-height: 1.5;
+  color: var(--text-secondary);
+  border-left: 2px solid var(--border-strong);
+  padding-left: 0.6rem;
+}
+
+/* -------------------------------------------------------------- scrubber */
+
+.scrubber {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  padding: 0.6rem 1.25rem;
+  border-top: 1px solid var(--border);
+  background: var(--surface);
+}
+
+.scrub-btn {
+  flex: 0 0 auto;
+  width: 1.9rem;
+  height: 1.9rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-strong);
+  background: var(--surface-raised);
+  font-size: 0.7rem;
+  display: grid;
+  place-items: center;
+}
+
+.scrub-btn:hover:not(:disabled) {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.scrub-btn:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+
+.scrub-track {
+  position: relative;
+  flex: 1;
+  min-width: 0;
+  padding-bottom: 0.85rem;
+}
+
+.scrub-track input[type="range"] {
+  width: 100%;
+  accent-color: var(--accent);
+  margin: 0;
+}
+
+.scrub-ticks {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 0.85rem;
+  pointer-events: none;
+}
+
+.tick {
+  position: absolute;
+  transform: translateX(-50%);
+  font-size: 0.5rem;
+  line-height: 1;
+  opacity: 0.4;
+}
+
+.tick-done {
+  opacity: 1;
+}
+
+.tick-green {
+  color: var(--impact-green);
+}
+.tick-yellow {
+  color: var(--impact-yellow);
+}
+.tick-red {
+  color: var(--impact-red);
+}
+
+.scrub-readout {
+  flex: 0 0 auto;
+  min-width: 9.5rem;
+  text-align: right;
+  font-family: var(--font-display);
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.scrub-sub {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  font-weight: 400;
+  color: var(--text-muted);
+}
+
+/* ------------------------------------------------------------- inspector */
+
+.inspector {
+  flex: 0 0 auto;
+  max-height: 55%;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  border-top: 1px solid var(--border-strong);
+  background: var(--surface-raised);
+}
+
+.inspector-close {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  padding: 0.1rem 0.3rem;
+  border-radius: var(--radius-sm);
+}
+
+.inspector-close:hover {
+  color: var(--text-primary);
+  background: var(--surface);
+}
+
+.inspector-body {
+  overflow-y: auto;
+  min-height: 0;
+  padding: 0.7rem 1rem 1rem;
+}
+
+.inspector-title {
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  font-weight: 500;
+  word-break: break-all;
+  margin-bottom: 0.6rem;
 }
 
 .facts {
   display: grid;
   grid-template-columns: auto 1fr;
-  gap: 0.4rem 1.25rem;
-  margin: 0;
+  gap: 0.22rem 0.9rem;
+  margin: 0 0 0.85rem;
+  font-size: 0.78rem;
 }
 
 .facts dt {
+  font-family: var(--font-display);
+  font-weight: 500;
   color: var(--text-muted);
 }
 
 .facts dd {
   margin: 0;
+  color: var(--text-secondary);
   font-variant-numeric: tabular-nums;
 }
 
-.muted {
-  margin: 0;
+.flag-blocked {
+  color: var(--impact-red);
+  font-weight: 600;
+}
+
+.inspector-subhead {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin: 0 0 0.45rem;
+  font-family: var(--font-display);
+  font-size: 0.8rem;
+  font-weight: 650;
+  color: var(--text-primary);
+}
+
+.inspector-count {
+  font-variant-numeric: tabular-nums;
+  font-weight: 500;
   color: var(--text-muted);
 }
 
-.error {
+.constraint-list {
+  list-style: none;
   margin: 0;
-  color: var(--err);
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 }
 
-/* Status is never conveyed by colour alone: the dot is paired with a label. */
-.dot {
-  display: inline-block;
-  width: 0.5rem;
-  height: 0.5rem;
-  border-radius: 50%;
-  margin-right: 0.5rem;
-  vertical-align: middle;
+.constraint {
+  border: 1px solid var(--border);
+  border-left: 2px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  padding: 0.45rem 0.6rem;
+  background: var(--surface);
 }
 
-.dot-ok {
-  background: var(--ok);
+.constraint.blocking {
+  border-left-color: var(--impact-red);
 }
 
-.dot-err {
-  background: var(--err);
+.constraint-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.constraint-kind {
+  font-family: var(--font-display);
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+
+.constraint.blocking .constraint-kind {
+  color: var(--impact-red);
+}
+
+.constraint-tag {
+  font-family: var(--font-display);
+  font-size: 0.66rem;
+  font-weight: 500;
+  color: var(--text-muted);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 0 0.3rem;
+}
+
+.constraint-tag.hard {
+  color: var(--text-secondary);
+  border-color: var(--border-strong);
+}
+
+.constraint-subject {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  color: var(--text-muted);
+  margin-top: 0.12rem;
+  word-break: break-all;
+}
+
+/* The analyzer's exact words — the Kagent agent answers from this same text,
+   and two wordings would leave an operator unsure which to trust. */
+.constraint-text {
+  margin: 0.3rem 0 0;
+  font-size: 0.78rem;
+  line-height: 1.5;
+  color: var(--text-secondary);
+}
+
+.inspector-callout {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 0.55rem 0.65rem;
+  background: var(--surface);
+}
+
+.callout-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-family: var(--font-display);
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.linkish {
+  margin-top: 0.45rem;
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--accent);
+  font-size: 0.78rem;
+  font-weight: 500;
+}
+
+.linkish:hover {
+  text-decoration: underline;
+}
+
+.muted {
+  color: var(--text-muted);
+  font-size: 0.78rem;
+  margin: 0;
+}
+
+.error-text {
+  color: var(--impact-red);
+  font-size: 0.78rem;
+  margin: 0;
+}
+
+/* ------------------------------------------------------------- statusbar */
+
+.statusbar {
+  display: flex;
+  gap: 1.25rem;
+  padding: 0.35rem 1.25rem;
+  border-top: 1px solid var(--border);
+  background: var(--surface-sunken);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--text-muted);
+}
+
+/* ----------------------------------------------------------- placeholder */
+
+.placeholder {
+  grid-row: 2 / -1;
+  display: grid;
+  place-content: center;
+  text-align: center;
+  gap: 0.5rem;
+  padding: 3rem;
+}
+
+.placeholder h2 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 1.05rem;
+  font-weight: 650;
+}
+
+.placeholder p {
+  margin: 0;
+  max-width: 32rem;
+  color: var(--text-secondary);
+  font-size: 0.88rem;
+}
+
+.placeholder-error h2 {
+  color: var(--impact-red);
+}
+
+@media (max-width: 1000px) {
+  .ribbon {
+    grid-template-columns: 1fr;
+    gap: 0.85rem;
+    align-items: start;
+  }
+  .ribbon-track {
+    height: 3rem;
+  }
+}
+
+@media (max-width: 900px) {
+  .workspace {
+    grid-template-columns: 1fr;
+    grid-template-rows: 1fr auto;
+  }
+  .sidebar {
+    border-left: none;
+    border-top: 1px solid var(--border);
+    max-height: 45vh;
+  }
 }

--- a/ui/src/layout.ts
+++ b/ui/src/layout.ts
@@ -1,0 +1,212 @@
+import { GraphPayload, PlanStep } from "./api";
+
+/**
+ * Deterministic packing layout.
+ *
+ * Cytoscape's own layouts are not used. Node consolidation is a *packing*
+ * picture — "which pods sit in which box, and how full is each box" — and an
+ * organic force layout communicates none of that while jittering on every
+ * relayout. Positions are computed here instead: node boxes on a fixed grid,
+ * pods in a sub-grid inside each box. That makes the picture stable between
+ * renders and, more importantly, makes the step scrubber possible: morphing
+ * between two steps is just animating each pod to a new computed position.
+ *
+ * Node boxes are plain nodes rather than Cytoscape compound parents, because a
+ * compound parent auto-sizes to its children and would collapse to nothing the
+ * moment a node is drained — exactly the node the operator most wants to see.
+ */
+
+export const POD_SIZE = 22;
+export const POD_GAP = 4;
+export const POD_COLS = 4;
+export const NODE_HEADER = 26;
+export const NODE_PAD = 8;
+export const NODE_GAP_X = 34;
+export const NODE_GAP_Y = 30;
+
+export interface PodInfo {
+  id: string;
+  key: string;
+  label: string;
+  namespace: string;
+  cpuRequest: number;
+  memRequest: number;
+  ownerKind?: string;
+  ownerName?: string;
+  movable: boolean;
+  blocked: boolean;
+  homeNode: string;
+}
+
+export interface NodeInfo {
+  id: string;
+  name: string;
+  zone?: string;
+  cpuAllocatable: number;
+  memAllocatable: number;
+  cordoned: boolean;
+  ready: boolean;
+  drainStep: number;
+}
+
+export interface Positioned {
+  nodes: Map<string, { x: number; y: number }>;
+  pods: Map<string, { x: number; y: number }>;
+  nodeWidth: number;
+  nodeHeight: number;
+  /** Requested milliCPU per node at this step, for the utilisation fill. */
+  nodeLoad: Map<string, number>;
+  /** Nodes that are empty of movable pods at this step. */
+  emptied: Set<string>;
+}
+
+export interface Model {
+  nodes: NodeInfo[];
+  pods: PodInfo[];
+}
+
+/** Extracts the domain model from the graph payload. */
+export function toModel(graph: GraphPayload): Model {
+  const nodes: NodeInfo[] = [];
+  const pods: PodInfo[] = [];
+
+  for (const el of graph.elements) {
+    const d = el.data;
+    if (d.kind === "node") {
+      nodes.push({
+        id: d.id,
+        name: d.label,
+        zone: d.zone,
+        cpuAllocatable: d.cpuAllocatable ?? 0,
+        memAllocatable: d.memAllocatable ?? 0,
+        cordoned: d.cordoned ?? false,
+        ready: d.ready ?? false,
+        drainStep: d.drainStep ?? 0,
+      });
+    } else if (d.kind === "pod" && d.parent) {
+      pods.push({
+        id: d.id,
+        key: `${d.namespace}/${d.label}`,
+        label: d.label,
+        namespace: d.namespace ?? "",
+        cpuRequest: d.cpuRequest ?? 0,
+        memRequest: d.memRequest ?? 0,
+        ownerKind: d.ownerKind,
+        ownerName: d.ownerName,
+        movable: d.movable ?? false,
+        blocked: d.blocked ?? false,
+        homeNode: d.parent.replace(/^node:/, ""),
+      });
+    }
+  }
+
+  nodes.sort((a, b) => collate(a.name, b.name));
+  pods.sort((a, b) => collate(a.key, b.key));
+  return { nodes, pods };
+}
+
+/**
+ * Where each pod lives after steps 1..step have been applied.
+ *
+ * Steps are applied in order rather than indexed, because a pod can be moved
+ * by one step onto a node that a later step drains again.
+ */
+export function placementAtStep(model: Model, steps: PlanStep[], step: number): Map<string, string> {
+  const placement = new Map<string, string>();
+  for (const pod of model.pods) placement.set(pod.key, pod.homeNode);
+
+  for (const s of steps) {
+    if (s.sequenceNumber > step) break;
+    for (const m of s.moves) {
+      placement.set(`${m.namespace}/${m.pod}`, m.toNode);
+    }
+  }
+  return placement;
+}
+
+/**
+ * Computes positions for one step.
+ *
+ * Every node box is the same size, sized to the busiest node across the whole
+ * plan rather than to the current step. A box that resized as pods left it
+ * would make the grid reflow on every scrubber tick, and the reflow would read
+ * as motion that means nothing.
+ */
+export function computeLayout(
+  model: Model,
+  placement: Map<string, string>,
+  maxPodsPerNode: number,
+  columns: number,
+): Positioned {
+  const rows = Math.max(2, Math.ceil(maxPodsPerNode / POD_COLS));
+  const innerWidth = POD_COLS * POD_SIZE + (POD_COLS - 1) * POD_GAP;
+  const innerHeight = rows * POD_SIZE + (rows - 1) * POD_GAP;
+  const nodeWidth = innerWidth + NODE_PAD * 2;
+  const nodeHeight = innerHeight + NODE_HEADER + NODE_PAD;
+
+  const nodes = new Map<string, { x: number; y: number }>();
+  const pods = new Map<string, { x: number; y: number }>();
+  const nodeLoad = new Map<string, number>();
+  const emptied = new Set<string>();
+
+  const occupants = new Map<string, PodInfo[]>();
+  for (const n of model.nodes) occupants.set(n.name, []);
+  for (const pod of model.pods) {
+    const host = placement.get(pod.key) ?? pod.homeNode;
+    const list = occupants.get(host);
+    if (list) list.push(pod);
+  }
+
+  model.nodes.forEach((node, i) => {
+    const col = i % columns;
+    const row = Math.floor(i / columns);
+    const cx = col * (nodeWidth + NODE_GAP_X);
+    const cy = row * (nodeHeight + NODE_GAP_Y);
+    nodes.set(node.id, { x: cx, y: cy });
+
+    const here = occupants.get(node.name) ?? [];
+    let load = 0;
+    let movable = 0;
+    here.forEach((pod, j) => {
+      load += pod.cpuRequest;
+      if (pod.movable) movable++;
+      const pc = j % POD_COLS;
+      const pr = Math.floor(j / POD_COLS);
+      pods.set(pod.id, {
+        // Positions are centres in Cytoscape, so offset by half the box and
+        // half the cell to land on the grid.
+        x: cx - nodeWidth / 2 + NODE_PAD + POD_SIZE / 2 + pc * (POD_SIZE + POD_GAP),
+        y: cy - nodeHeight / 2 + NODE_HEADER + POD_SIZE / 2 + pr * (POD_SIZE + POD_GAP),
+      });
+    });
+    nodeLoad.set(node.name, load);
+    if (movable === 0) emptied.add(node.name);
+  });
+
+  return { nodes, pods, nodeWidth, nodeHeight, nodeLoad, emptied };
+}
+
+/** The busiest a node ever gets across every step, so boxes never resize. */
+export function peakOccupancy(model: Model, steps: PlanStep[]): number {
+  let peak = 1;
+  for (let step = 0; step <= steps.length; step++) {
+    const placement = placementAtStep(model, steps, step);
+    const counts = new Map<string, number>();
+    for (const pod of model.pods) {
+      const host = placement.get(pod.key) ?? pod.homeNode;
+      counts.set(host, (counts.get(host) ?? 0) + 1);
+    }
+    for (const c of counts.values()) peak = Math.max(peak, c);
+  }
+  return peak;
+}
+
+/** Grid columns chosen to keep the whole cluster roughly square. */
+export function gridColumns(nodeCount: number): number {
+  return Math.max(1, Math.ceil(Math.sqrt(nodeCount * 1.4)));
+}
+
+/** Sorts names so node-2 comes before node-10. */
+function collate(a: string, b: string): number {
+  return a.localeCompare(b, undefined, { numeric: true, sensitivity: "base" });
+}

--- a/ui/src/theme.css
+++ b/ui/src/theme.css
@@ -1,0 +1,141 @@
+/*
+ * Design tokens.
+ *
+ * Direction: a capacity instrument, not a control panel. The product's job is
+ * to argue that the cluster is running more machines than it needs — and to
+ * never touch anything. Everything here serves reading a load plan: industrial
+ * grotesque numerals, machine identifiers in mono, and a quiet slate plane so
+ * the capacity ribbon and the packing canvas are the only things that shout.
+ *
+ * Typefaces are bundled, not fetched. A Kubernetes cluster may have no route
+ * to the internet, and a UI whose type silently falls back to system-ui in an
+ * air-gapped environment is not a designed UI.
+ *
+ * Colour is the one place boldness is NOT spent. The status trio and the
+ * sequential ramp come from the validated data-viz palette and are re-run
+ * against this page plane (#0f1319: sequential ordinal ramp passes all checks;
+ * status trio clears 3:1). An invented accent would collide with the status
+ * hues, so structure and type carry the identity instead.
+ *
+ * The validator puts critical <-> good at CVD deltaE 4.1 for deuteranopia:
+ * Red and Green are the same colour to a large minority of readers. Nothing in
+ * this UI encodes a rating by colour alone.
+ */
+
+@import "./fonts.css";
+
+:root {
+  color-scheme: dark;
+
+  /* Plane and surfaces. The plane is cooler than the chart surfaces on
+     purpose — instrument housing against instrument face. */
+  --page: #0f1319;
+  --surface: #161b23;
+  --surface-raised: #1d232c;
+  --surface-sunken: #0b0e13;
+  --border: rgba(255, 255, 255, 0.08);
+  --border-strong: #2b333f;
+
+  --text-primary: #f2f4f7;
+  --text-secondary: #b6bdc9;
+  --text-muted: #7c8698;
+
+  /* Status palette — fixed, never themed, never colour-alone. */
+  --impact-green: #0ca30c;
+  --impact-yellow: #fab219;
+  --impact-red: #d03b3b;
+
+  /* Sequential ramp (blue), one hue light→dark, for utilisation magnitude. */
+  --seq-100: #cde2fb;
+  --seq-250: #86b6ef;
+  --seq-400: #3987e5;
+  --seq-550: #1c5cab;
+  --seq-700: #0d366b;
+
+  --accent: #3987e5;
+
+  /* Type. Archivo carries structure and every figure; Plex Sans carries prose;
+     Plex Mono carries machine identifiers, which should look like machine
+     identifiers. */
+  --font-display: "Archivo Variable", system-ui, sans-serif;
+  --font-body: "IBM Plex Sans Variable", system-ui, sans-serif;
+  --font-mono: "IBM Plex Mono", ui-monospace, monospace;
+
+  --radius: 4px;
+  --radius-sm: 3px;
+}
+
+@media (prefers-color-scheme: light) {
+  :root:not([data-theme="dark"]) {
+    color-scheme: light;
+    --page: #eceef1;
+    --surface: #fcfcfb;
+    --surface-raised: #ffffff;
+    --surface-sunken: #e3e6ea;
+    --border: rgba(11, 11, 11, 0.1);
+    --border-strong: #c3c2b7;
+    --text-primary: #0b0b0b;
+    --text-secondary: #52514e;
+    --text-muted: #767c88;
+    --seq-400: #2a78d6;
+    --accent: #2a78d6;
+  }
+}
+
+:root[data-theme="light"] {
+  color-scheme: light;
+  --page: #eceef1;
+  --surface: #fcfcfb;
+  --surface-raised: #ffffff;
+  --surface-sunken: #e3e6ea;
+  --border: rgba(11, 11, 11, 0.1);
+  --border-strong: #c3c2b7;
+  --text-primary: #0b0b0b;
+  --text-secondary: #52514e;
+  --text-muted: #767c88;
+  --seq-400: #2a78d6;
+  --accent: #2a78d6;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  background: var(--page);
+  color: var(--text-primary);
+  font-family: var(--font-body);
+  font-size: 14px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+
+button {
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+}
+
+/* Keyboard focus must stay visible everywhere; the ring is deliberately loud. */
+:where(a, button, input, [tabindex]):focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+/* The scrubber animation explains a causal sequence, but it is not worth
+   making anyone unwell. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/ui/src/useConstraints.ts
+++ b/ui/src/useConstraints.ts
@@ -1,0 +1,73 @@
+import { useEffect, useState } from "react";
+import { ApiError, PodConstraints } from "./api";
+import { runtimeConfig } from "./runtime-config";
+
+export type ConstraintsState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "missing" }
+  | { status: "error"; message: string }
+  | { status: "ready"; constraints: PodConstraints };
+
+/**
+ * Loads one pod's effective constraint set from the plan that is on screen.
+ *
+ * Deliberately scoped to the displayed plan rather than live cluster state:
+ * the explanations must describe the same moment the canvas is drawing, or the
+ * inspector would contradict the plan beside it.
+ */
+export function usePodConstraints(planId: string | null, podKey: string | null): ConstraintsState {
+  const [state, setState] = useState<ConstraintsState>({ status: "idle" });
+
+  useEffect(() => {
+    if (!planId || !podKey) {
+      setState({ status: "idle" });
+      return;
+    }
+    const [namespace, name] = splitKey(podKey);
+    if (!namespace || !name) {
+      setState({ status: "missing" });
+      return;
+    }
+
+    const controller = new AbortController();
+    setState({ status: "loading" });
+
+    (async () => {
+      try {
+        const res = await fetch(
+          `${runtimeConfig().apiBaseUrl}/api/v1/plans/${encodeURIComponent(planId)}/constraints/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}`,
+          { signal: controller.signal },
+        );
+        if (res.status === 404) {
+          setState({ status: "missing" });
+          return;
+        }
+        if (!res.ok) {
+          throw new ApiError(res.status, res.statusText);
+        }
+        const constraints = (await res.json()) as PodConstraints;
+        if (!controller.signal.aborted) {
+          setState({ status: "ready", constraints });
+        }
+      } catch (err) {
+        if (controller.signal.aborted) return;
+        setState({
+          status: "error",
+          message: err instanceof Error ? err.message : String(err),
+        });
+      }
+    })();
+
+    return () => controller.abort();
+  }, [planId, podKey]);
+
+  return state;
+}
+
+/** Pod keys are "namespace/name"; a name never contains a slash. */
+function splitKey(key: string): [string, string] {
+  const i = key.indexOf("/");
+  if (i < 0) return ["", ""];
+  return [key.slice(0, i), key.slice(i + 1)];
+}

--- a/ui/src/usePlan.ts
+++ b/ui/src/usePlan.ts
@@ -1,0 +1,56 @@
+import { useCallback, useEffect, useState } from "react";
+import { ApiError, GraphPayload, PlanResponse, api, subscribePlans } from "./api";
+
+export type PlanState =
+  | { status: "loading" }
+  | { status: "empty" }
+  | { status: "error"; message: string }
+  | { status: "ready"; plan: PlanResponse; graph: GraphPayload };
+
+/**
+ * Loads the latest plan and its graph, and reloads when the planner publishes
+ * a new one.
+ *
+ * The plan and graph are fetched together and swapped together: rendering a
+ * graph against a different plan's steps would put the scrubber out of step
+ * with the canvas, which is worse than a moment of staleness.
+ */
+export function usePlan(): PlanState & { reload: () => void } {
+  const [state, setState] = useState<PlanState>({ status: "loading" });
+  const [nonce, setNonce] = useState(0);
+
+  const reload = useCallback(() => setNonce((n) => n + 1), []);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    (async () => {
+      try {
+        const plan = await api.latestPlan(controller.signal);
+        const graph = await api.graph(plan.plan.id, controller.signal);
+        if (!controller.signal.aborted) {
+          setState({ status: "ready", plan, graph });
+        }
+      } catch (err) {
+        if (controller.signal.aborted) return;
+        if (err instanceof ApiError && err.isEmpty) {
+          // No plan yet is a normal state for a fresh install, not a fault.
+          setState({ status: "empty" });
+          return;
+        }
+        setState({
+          status: "error",
+          message: err instanceof Error ? err.message : String(err),
+        });
+      }
+    })();
+
+    return () => controller.abort();
+  }, [nonce]);
+
+  useEffect(() => {
+    return subscribePlans(() => reload());
+  }, [reload]);
+
+  return { ...state, reload };
+}

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -5,7 +5,10 @@ export default defineConfig({
   plugins: [react()],
   build: {
     outDir: "dist",
-    sourcemap: true,
+    // Off for the shipped bundle: 2.3MB of maps go into the container image
+    // and nothing there consumes them. Build locally with `--sourcemap` when
+    // debugging a deployed bundle.
+    sourcemap: false,
   },
   server: {
     port: 5173,


### PR DESCRIPTION
The plan is now visible.

## The capacity ribbon is the argument

One bar per node, ordered fullest-first, filled to requested CPU. The long tail of barely-used bars **is** the case for consolidating; dragging the scrubber drains them in place.

The first draft led with *"15 nodes reclaimed"* as a big number over a small label. That states a conclusion where the evidence should be — and it is the templated answer. The only display-size figure now sits inside a sentence: *"**13** machines carry the workload once **15** more are drained."*

## One morphing canvas, not two panes

Scrubbing shows the same before/after comparison plus every intermediate state, and makes the causality visible — this pod leaves, so this node empties. Two half-width panes of 30 nodes would be unreadable, and the ribbon already does the at-a-glance job.

**Cytoscape's own layouts are not used.** Positions are computed: node boxes on a grid, pods in a sub-grid inside them. A force layout says nothing about packing and jitters on every relayout; deterministic positions are also what make the animation possible.

Node boxes are plain nodes rather than compound parents — a compound parent auto-sizes to its children and would collapse to nothing when emptied, which is exactly the node an operator most wants to see.

## Accessibility drove the encoding

The palette validator reports **`#d03b3b` ↔ `#0ca30c` at CVD ΔE 4.1 for deuteranopia**, against a floor of 8. Red and Green are the same colour to a large minority of readers — for a Green/Yellow/Red product that is the central design constraint, not a footnote.

Nothing encodes a rating by colour alone: every chip carries a distinct glyph (●▲■, different silhouettes) **and** the word; scrubber ticks use the glyphs; blocked pods are diamonds. Utilisation uses the sequential blue ramp, one hue light→dark, re-validated against this page plane (ordinal ramp passes all four checks; status trio clears 3:1).

## The inspector quotes, never paraphrases

Explanations render exactly as the analyzer produced them. The Kagent agent will answer from those same strings, and an inspector that reworded them would leave an operator with two versions of the truth and no way to choose.

## Typefaces bundled, latin-only

Archivo for structure and figures, IBM Plex Sans for prose, IBM Plex Mono for machine identifiers (a node name is an identifier and shouldn't read as a word).

Bundled rather than CDN-fetched because **a cluster may have no route to the internet**, and type that silently falls back to `system-ui` in an air-gapped install is not designed type. Latin subsets only: the full packages ship Cyrillic, Greek and Vietnamese — 3.3MB of assets for a UI with no text in any of them, now **732KB**.

## Two build-loop defects fixed

- **`IMAGE_TAG` was `<sha>-dirty` for every uncommitted state**, so two builds at one commit shared a tag: the podspec didn't change, `helm upgrade` reported success, and the pod quietly kept the old image. This bit me during development. The suffix now hashes the working tree; verified the hash changes when a file does.
- Vite was emitting **2.3MB of sourcemaps into the container image**, which nothing there consumes.

## Verified

```
make test    68 tests pass
make lint    all chart contract checks pass
live         plan 29 -> 13 nodes, 16 steps, green=7 yellow=4 red=5
```

Incidentally validated by a manual `kubectl drain` experiment on the fabric: with 3 nodes cordoned, the planner correctly excluded them as targets and still produced a valid plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)