### PR TITLE
M8: Kagent agent — Phase 1 complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ Phase 1 (MVP) — visibility and explainability. No execution capability.
 | **M5** | Impact classifier (Green/Yellow/Red + rationale) | **done** |
 | **M6** | Plan store (SQLite) + REST API + graph payload | **done** |
 | **M7** | UI: capacity ribbon, packing canvas, scrubber, constraint inspector | **done** |
-| M8 | Kagent agent: read-only MCP tools + `Agent` CR | next |
+| **M8** | Kagent agent: read-only MCP tools + `Agent` CR | **done** |
 
-Deferred to later phases: Executor, Safety Guard, Scheduler Simulator, `MaintenanceWindow` CRD, Postgres store, multi-agent orchestration.
+**Phase 1 is complete.** Deferred to later phases: Executor, Safety Guard, Scheduler Simulator, `MaintenanceWindow` CRD, Postgres store, multi-agent orchestration.
 
 ### What actually runs today
 
@@ -40,8 +40,9 @@ plan:        id=8bb7900e46db steps=15 nodesBefore=28 nodesAfter=13 reclaims=15
              green=6 yellow=5 red=4
 ```
 
-Plans are rated, explained, persisted and visualised. What remains is the
-Kagent agent, so the same explanations can be asked for in natural language.
+Plans are rated, explained, persisted, visualised, and answerable in natural
+language through a Kagent agent. Nothing in the release can drain, cordon or
+evict.
 
 Three debug endpoints on the planner's health port expose current state as
 YAML: `/debug/snapshot`, `/debug/constraints` and `/debug/plan`.
@@ -74,7 +75,7 @@ internal/
   planner/         Strategy interface + greedy first-fit-decreasing packer
   impact/          Green/Yellow/Red classifier + rationale composition
   store/           Store interface + SQLite implementation and migrations
-  api/             rest/ (+ SSE events), graph/ (Cytoscape payload), agenttools/ (M8)
+  api/             rest/ (+ SSE events), graph/ (Cytoscape payload), agenttools/ (MCP)
 ui/                React + Vite + Cytoscape.js; bundled typefaces
 charts/k8s-dencer/ THE product deliverable — see Chart below
 demo/              POC only: KWOK values + the synthetic topology chart
@@ -298,7 +299,26 @@ They are bundled rather than CDN-fetched because **a cluster may have no route t
 
 Kagent is a **prerequisite**, not installed by this repo. Chart resources are gated behind `kagent.enabled` (default `false`) so the product installs cleanly on clusters without the `kagent.dev` CRDs.
 
-When enabled, the chart creates a `RemoteMCPServer` pointing at the ui-backend's `/mcp` endpoint and an `Agent` CR scoped to explanation only. The MCP tools themselves land in M8, so until then the `RemoteMCPServer` will show `ACCEPTED: False` — expected, and a useful signal for when M8 is actually complete.
+When enabled, the chart creates a `RemoteMCPServer` pointing at the ui-backend's `/mcp` endpoint and an `Agent` CR scoped to explanation only.
+
+### The agent quotes; it never re-derives
+
+Four read-only tools, served over MCP by the ui-backend — no separate image, because the agent itself runs inside Kagent:
+
+| Tool | Answers |
+|---|---|
+| `list_plan_steps` | the plan as a whole — how many nodes it reclaims, how many steps are Red |
+| `explain_step` | why step N is rated as it is, which pods move where |
+| `get_node_constraints` | a node's occupancy, utilisation, and the constraints on its pods |
+| `why_not_drained` | why a node is *not* being drained, naming the responsible constraint |
+
+Every answer is composed from strings the constraint analyzer and impact classifier already produced. A test asserts `explain_step` returns the stored rationale **byte-for-byte** — if the tool paraphrased, the agent and the UI's inspector could describe the same step differently and an operator would have no way to know which to trust.
+
+The surface is read-only by construction, and a test asserts that exactly these four tools exist — no fifth tool can appear without someone deliberately changing that assertion. Asked to drain a node, the agent declines:
+
+> This release of k8s-dencer is read-only by design and does not have the capability to execute actions such as draining nodes.
+
+Verified end to end: the agent calls the tool, receives the classifier's exact words, and answers with them.
 
 ---
 

--- a/cmd/ui-backend/main.go
+++ b/cmd/ui-backend/main.go
@@ -16,6 +16,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/atedgimo/k8s-dencer/internal/api/agenttools"
 	"github.com/atedgimo/k8s-dencer/internal/api/rest"
 	"github.com/atedgimo/k8s-dencer/internal/httpserver"
 	sqlitestore "github.com/atedgimo/k8s-dencer/internal/store/sqlite"
@@ -64,6 +65,13 @@ func run(ctx context.Context, log *slog.Logger) error {
 	mux := http.NewServeMux()
 	health.Register(mux)
 	api.Routes(mux)
+
+	// The Kagent agent reaches the same plan store over MCP. It is mounted on
+	// the ui-backend rather than shipped as its own image because the agent
+	// itself runs inside Kagent — architecture doc §5 — so all we owe it is a
+	// tool endpoint.
+	mux.Handle("/mcp", agenttools.New(db, log, version).Handler())
+	mux.Handle("/mcp/", agenttools.New(db, log, version).Handler())
 
 	// Change detection is a poll of the latest plan ID rather than an event
 	// feed: the planner is a separate process reached only through the shared

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/atedgimo/k8s-dencer
 go 1.26.5
 
 require (
+	github.com/modelcontextprotocol/go-sdk v1.6.1
 	k8s.io/api v0.36.3
 	k8s.io/apimachinery v0.36.3
 	k8s.io/client-go v0.36.3
@@ -25,6 +26,7 @@ require (
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
+	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
@@ -40,12 +42,15 @@ require (
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
+	github.com/segmentio/asm v1.1.3 // indirect
+	github.com/segmentio/encoding v0.5.4 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
+	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/net v0.49.0 // indirect
-	golang.org/x/oauth2 v0.34.0 // indirect
+	golang.org/x/oauth2 v0.35.0 // indirect
 	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/term v0.39.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,8 @@ github.com/go-openapi/swag v0.23.0 h1:vsEVJDUo2hPJ2tu0/Xc+4noaxyEffXNIs3cOULZ+Gr
 github.com/go-openapi/swag v0.23.0/go.mod h1:esZ8ITTYEsH1V2trKHjAN8Ai7xHb8RV+YSZ577vPjgQ=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/google/gnostic-models v0.7.0 h1:qwTtogB15McXDaNqTZdzPJRHvaVJlAl+HVQnLmJEJxo=
 github.com/google/gnostic-models v0.7.0/go.mod h1:whL5G0m6dmc5cPxKc5bdKdEN3UjI7OUGxBlw57miDrQ=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
@@ -42,6 +44,8 @@ github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/jsonschema-go v0.4.3 h1:/DBOLZTfDow7pe2GmaJNhltueGTtDKICi8V8p+DQPd0=
+github.com/google/jsonschema-go v0.4.3/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/pprof v0.0.0-20250403155104-27863c87afa6 h1:BHT72Gu3keYf3ZEu2J0b1vyeLSOYI8bm5wbJM/8yDe8=
 github.com/google/pprof v0.0.0-20250403155104-27863c87afa6/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
@@ -67,6 +71,8 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/modelcontextprotocol/go-sdk v1.6.1 h1:0zOSupjKUxPKSocPT1Wtago+mUHU2/uZ4xSOY0FGReU=
+github.com/modelcontextprotocol/go-sdk v1.6.1/go.mod h1:kzm3kzFL1/+AziGOE0nUs3gvPoNxMCvkxokMkuFapXQ=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -98,6 +104,10 @@ github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/segmentio/asm v1.1.3 h1:WM03sfUOENvvKexOLp+pCqgb/WDjsi7EK8gIsICtzhc=
+github.com/segmentio/asm v1.1.3/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
+github.com/segmentio/encoding v0.5.4 h1:OW1VRern8Nw6ITAtwSZ7Idrl3MXCFwXHPgqESYfvNt0=
+github.com/segmentio/encoding v0.5.4/go.mod h1:HS1ZKa3kSN32ZHVZ7ZLPLXWvOVIiZtyJnO1gPH1sKt0=
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -113,6 +123,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
+github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
+github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
@@ -127,8 +139,8 @@ golang.org/x/mod v0.37.0 h1:vF1DjpVEshcIqoEaauuHebaLk1O1forxjxBaVn884JQ=
 golang.org/x/mod v0.37.0/go.mod h1:m8S8VeM9r4dzDwjrKO0a1sZP3YjeMamRRlD+fmR2Q/0=
 golang.org/x/net v0.49.0 h1:eeHFmOGUTtaaPSGNmjBKpbng9MulQsJURQUAfUwY++o=
 golang.org/x/net v0.49.0/go.mod h1:/ysNB2EvaqvesRkuLAyjI1ycPZlQHM3q01F02UY/MV8=
-golang.org/x/oauth2 v0.34.0 h1:hqK/t4AKgbqWkdkcAeI8XLmbK+4m4G5YeQRrmiotGlw=
-golang.org/x/oauth2 v0.34.0/go.mod h1:lzm5WQJQwKZ3nwavOZ3IS5Aulzxi68dUSgRHujetwEA=
+golang.org/x/oauth2 v0.35.0 h1:Mv2mzuHuZuY2+bkyWXIHMfhNdJAdwW3FuWeCPYN5GVQ=
+golang.org/x/oauth2 v0.35.0/go.mod h1:lzm5WQJQwKZ3nwavOZ3IS5Aulzxi68dUSgRHujetwEA=
 golang.org/x/sync v0.21.0 h1:HLII4xRRTtCRkxYp4HNFF0Js/Og6q2i++KXbg0gHCwM=
 golang.org/x/sync v0.21.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/api/agenttools/agenttools.go
+++ b/internal/api/agenttools/agenttools.go
@@ -1,0 +1,477 @@
+// Package agenttools exposes the plan store to the Kagent agent over MCP.
+//
+// Read-only by construction, and doubly so: Phase 1 has no executor, and even
+// when one exists these tools must not gain a "drain this node" verb. The
+// architecture doc is explicit that the agent explains plans and never makes
+// or executes them — the planner is deterministic precisely so that plans are
+// auditable, and a tool that let the model act would undo that.
+//
+// Every answer is composed from strings the constraint analyzer and impact
+// classifier already produced. The tools quote; they never re-derive. That is
+// what keeps the agent's explanation and the UI's constraint inspector from
+// drifting into two versions of the truth.
+package agenttools
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/atedgimo/k8s-dencer/internal/constraints"
+	"github.com/atedgimo/k8s-dencer/internal/model"
+	"github.com/atedgimo/k8s-dencer/internal/store"
+)
+
+// Server builds the MCP tool surface over a plan store.
+type Server struct {
+	store   store.Store
+	log     *slog.Logger
+	version string
+}
+
+// New returns a tool server.
+func New(s store.Store, log *slog.Logger, version string) *Server {
+	return &Server{store: s, log: log, version: version}
+}
+
+// Handler returns an http.Handler serving MCP over Streamable HTTP.
+//
+// Stateless: each request carries everything needed, so Kagent can reconnect
+// or scale without session affinity. There is no server-to-client request in
+// this surface — the agent asks, we answer — so nothing is lost by it.
+func (s *Server) Handler() *mcp.StreamableHTTPHandler {
+	return mcp.NewStreamableHTTPHandler(
+		func(*http.Request) *mcp.Server { return s.mcpServer() },
+		&mcp.StreamableHTTPOptions{
+			Stateless: true,
+			// Plain JSON rather than SSE: every tool here returns one small
+			// result immediately, so a stream buys nothing and gives proxies
+			// another thing to buffer.
+			JSONResponse: true,
+			Logger:       s.log,
+		},
+	)
+}
+
+func (s *Server) mcpServer() *mcp.Server {
+	srv := mcp.NewServer(&mcp.Implementation{
+		Name:    "k8s-dencer",
+		Version: s.version,
+	}, nil)
+
+	mcp.AddTool(srv, &mcp.Tool{
+		Name: "list_plan_steps",
+		Description: "List the steps in the current node-consolidation plan, with each " +
+			"step's impact rating (Green, Yellow or Red) and the node it drains. " +
+			"Use this to answer questions about the plan as a whole, such as how " +
+			"many nodes it reclaims or how many steps are Red.",
+	}, s.listPlanSteps)
+
+	mcp.AddTool(srv, &mcp.Tool{
+		Name: "explain_step",
+		Description: "Explain one step of the plan: why it is rated Green, Yellow or Red, " +
+			"which pods it moves and where, and the constraints affecting those pods. " +
+			"Use this whenever asked why a specific step has the rating it does.",
+	}, s.explainStep)
+
+	mcp.AddTool(srv, &mcp.Tool{
+		Name: "get_node_constraints",
+		Description: "Describe a node: how full it is, which pods it holds, whether the " +
+			"plan drains it, and the scheduling constraints on its pods. Use this " +
+			"for questions about a specific node.",
+	}, s.getNodeConstraints)
+
+	mcp.AddTool(srv, &mcp.Tool{
+		Name: "why_not_drained",
+		Description: "Explain why a node is NOT being drained by the plan — which pod " +
+			"cannot be evicted or relocated, and the specific constraint responsible. " +
+			"Use this for questions of the form 'why isn't node X being drained?'.",
+	}, s.whyNotDrained)
+
+	return srv
+}
+
+// ---------------------------------------------------------------- list_plan_steps
+
+// ListStepsInput takes no arguments; the current plan is always the subject.
+type ListStepsInput struct{}
+
+// StepSummary is one row of the plan.
+type StepSummary struct {
+	Step       int    `json:"step" jsonschema:"the step's sequence number, 1-based"`
+	TargetNode string `json:"targetNode" jsonschema:"the node this step drains"`
+	Impact     string `json:"impact" jsonschema:"Green, Yellow or Red"`
+	PodsMoved  int    `json:"podsMoved"`
+	// WindowOnly marks steps policy confines to a maintenance window.
+	WindowOnly bool `json:"maintenanceWindowOnly"`
+}
+
+// ListStepsOutput is the plan overview.
+type ListStepsOutput struct {
+	PlanID      string        `json:"planId"`
+	GeneratedAt string        `json:"generatedAt"`
+	NodesBefore int           `json:"nodesOccupiedBefore"`
+	NodesAfter  int           `json:"nodesOccupiedAfter"`
+	Reclaimed   int           `json:"nodesReclaimed"`
+	Green       int           `json:"greenSteps"`
+	Yellow      int           `json:"yellowSteps"`
+	Red         int           `json:"redSteps"`
+	Steps       []StepSummary `json:"steps"`
+	ReadOnly    string        `json:"readOnly"`
+}
+
+func (s *Server) listPlanSteps(ctx context.Context, _ *mcp.CallToolRequest, _ ListStepsInput) (*mcp.CallToolResult, ListStepsOutput, error) {
+	rec, err := s.store.Latest(ctx)
+	if err != nil {
+		return s.fail(err)
+	}
+
+	ratings := rec.Plan.CountByRating()
+	out := ListStepsOutput{
+		PlanID:      rec.Plan.ID,
+		GeneratedAt: rec.Plan.GeneratedAt.Format("2006-01-02 15:04:05 MST"),
+		NodesBefore: rec.Plan.NodesBefore,
+		NodesAfter:  rec.Plan.NodesAfter,
+		Reclaimed:   rec.Plan.ReclaimedNodes(),
+		Green:       ratings[model.ImpactGreen],
+		Yellow:      ratings[model.ImpactYellow],
+		Red:         ratings[model.ImpactRed],
+		ReadOnly:    readOnlyNote,
+	}
+	for _, step := range rec.Plan.Steps {
+		out.Steps = append(out.Steps, StepSummary{
+			Step:       step.SequenceNumber,
+			TargetNode: step.TargetNode,
+			Impact:     string(step.Impact),
+			PodsMoved:  len(step.Moves),
+			WindowOnly: step.RequiresMaintenanceWindow(),
+		})
+	}
+	return nil, out, nil
+}
+
+// ---------------------------------------------------------------- explain_step
+
+// ExplainStepInput identifies a step by its number.
+type ExplainStepInput struct {
+	Step int `json:"step" jsonschema:"the step's sequence number, as shown by list_plan_steps"`
+}
+
+// MoveDetail is one pod relocation.
+type MoveDetail struct {
+	Pod      string `json:"pod"`
+	FromNode string `json:"fromNode"`
+	ToNode   string `json:"toNode"`
+}
+
+// ConstraintDetail is one constraint, in the analyzer's own words.
+type ConstraintDetail struct {
+	Pod  string `json:"pod"`
+	Kind string `json:"kind"`
+	// Blocking marks a constraint that prevents movement outright.
+	Blocking bool `json:"blocking"`
+	// Explanation is the analyzer's canonical text. Quote it; do not rewrite it.
+	Explanation string `json:"explanation"`
+}
+
+// ExplainStepOutput is everything needed to answer "why is step N rated that?".
+type ExplainStepOutput struct {
+	PlanID      string             `json:"planId"`
+	Step        int                `json:"step"`
+	TargetNode  string             `json:"targetNode"`
+	Impact      string             `json:"impact"`
+	WindowOnly  bool               `json:"maintenanceWindowOnly"`
+	Rationale   string             `json:"rationale" jsonschema:"the canonical explanation for this rating; quote it rather than paraphrasing"`
+	Reasons     []string           `json:"contributingFactors"`
+	Moves       []MoveDetail       `json:"moves"`
+	Constraints []ConstraintDetail `json:"podConstraints"`
+	ReadOnly    string             `json:"readOnly"`
+}
+
+func (s *Server) explainStep(ctx context.Context, _ *mcp.CallToolRequest, in ExplainStepInput) (*mcp.CallToolResult, ExplainStepOutput, error) {
+	rec, err := s.store.Latest(ctx)
+	if err != nil {
+		return s.failStep(err)
+	}
+
+	var step *model.PlanStep
+	for i := range rec.Plan.Steps {
+		if rec.Plan.Steps[i].SequenceNumber == in.Step {
+			step = &rec.Plan.Steps[i]
+			break
+		}
+	}
+	if step == nil {
+		return errorResult[ExplainStepOutput](fmt.Sprintf(
+			"Plan %s has no step %d. It has %d steps, numbered 1 to %d.",
+			rec.Plan.ID, in.Step, len(rec.Plan.Steps), len(rec.Plan.Steps)))
+	}
+
+	out := ExplainStepOutput{
+		PlanID:     rec.Plan.ID,
+		Step:       step.SequenceNumber,
+		TargetNode: step.TargetNode,
+		Impact:     string(step.Impact),
+		WindowOnly: step.RequiresMaintenanceWindow(),
+		Rationale:  step.Rationale,
+		ReadOnly:   readOnlyNote,
+	}
+	for _, r := range step.Reasons {
+		out.Reasons = append(out.Reasons, r.Detail)
+	}
+	for _, m := range step.Moves {
+		out.Moves = append(out.Moves, MoveDetail{
+			Pod: m.Namespace + "/" + m.Pod, FromNode: m.FromNode, ToNode: m.ToNode,
+		})
+		if rec.Analysis == nil {
+			continue
+		}
+		if pc, ok := rec.Analysis.ForPod(m.Namespace + "/" + m.Pod); ok {
+			out.Constraints = append(out.Constraints, flatten(pc)...)
+		}
+	}
+	return nil, out, nil
+}
+
+// ---------------------------------------------------------------- get_node_constraints
+
+// NodeInput identifies a node by name.
+type NodeInput struct {
+	Node string `json:"node" jsonschema:"the node's name, for example kwok-node-7"`
+}
+
+// NodeOutput describes a node and its pods.
+type NodeOutput struct {
+	PlanID       string             `json:"planId"`
+	Node         string             `json:"node"`
+	Zone         string             `json:"zone,omitempty"`
+	Ready        bool               `json:"ready"`
+	Cordoned     bool               `json:"cordoned"`
+	CPURequested string             `json:"cpuRequested"`
+	Utilization  string             `json:"utilization"`
+	PodCount     int                `json:"podCount"`
+	DrainedBy    int                `json:"drainedByStep,omitempty" jsonschema:"the step that drains this node, or 0 if the plan leaves it in place"`
+	Impact       string             `json:"drainImpact,omitempty"`
+	Constraints  []ConstraintDetail `json:"podConstraints"`
+	ReadOnly     string             `json:"readOnly"`
+}
+
+func (s *Server) getNodeConstraints(ctx context.Context, _ *mcp.CallToolRequest, in NodeInput) (*mcp.CallToolResult, NodeOutput, error) {
+	rec, err := s.store.Latest(ctx)
+	if err != nil {
+		return s.failNode(err)
+	}
+	node, ok := rec.Snapshot.NodeByName(in.Node)
+	if !ok {
+		return errorResult[NodeOutput](fmt.Sprintf(
+			"No node named %q in this plan's snapshot. %s", in.Node, nodeHint(rec.Snapshot)))
+	}
+
+	requested := rec.Snapshot.RequestedOnNode(node.Name)
+	out := NodeOutput{
+		PlanID:       rec.Plan.ID,
+		Node:         node.Name,
+		Zone:         node.Zone(),
+		Ready:        node.Ready,
+		Cordoned:     node.Unschedulable,
+		CPURequested: fmt.Sprintf("%dm of %dm", requested.MilliCPU, node.Allocatable.MilliCPU),
+		Utilization:  fmt.Sprintf("%.0f%%", requested.DominantRatio(node.Allocatable)*100),
+		PodCount:     len(rec.Snapshot.PodsOnNode(node.Name)),
+		ReadOnly:     readOnlyNote,
+	}
+	for _, step := range rec.Plan.Steps {
+		if step.TargetNode == node.Name {
+			out.DrainedBy = step.SequenceNumber
+			out.Impact = string(step.Impact)
+			break
+		}
+	}
+	if rec.Analysis != nil {
+		for _, pc := range rec.Analysis.ForNode(node.Name) {
+			out.Constraints = append(out.Constraints, flatten(pc)...)
+		}
+	}
+	return nil, out, nil
+}
+
+// ---------------------------------------------------------------- why_not_drained
+
+// WhyNotOutput answers the question directly rather than dumping state.
+type WhyNotOutput struct {
+	PlanID string `json:"planId"`
+	Node   string `json:"node"`
+	// Answer is a complete sentence suitable for quoting back to the operator.
+	Answer    string             `json:"answer"`
+	IsDrained bool               `json:"isDrainedByPlan"`
+	DrainedBy int                `json:"drainedByStep,omitempty"`
+	Blockers  []ConstraintDetail `json:"blockingConstraints"`
+	StuckPods []string           `json:"podsWithNowhereToGo"`
+	ReadOnly  string             `json:"readOnly"`
+}
+
+func (s *Server) whyNotDrained(ctx context.Context, _ *mcp.CallToolRequest, in NodeInput) (*mcp.CallToolResult, WhyNotOutput, error) {
+	rec, err := s.store.Latest(ctx)
+	if err != nil {
+		return s.failWhyNot(err)
+	}
+	node, ok := rec.Snapshot.NodeByName(in.Node)
+	if !ok {
+		return errorResult[WhyNotOutput](fmt.Sprintf(
+			"No node named %q in this plan's snapshot. %s", in.Node, nodeHint(rec.Snapshot)))
+	}
+
+	out := WhyNotOutput{PlanID: rec.Plan.ID, Node: node.Name, ReadOnly: readOnlyNote}
+
+	for _, step := range rec.Plan.Steps {
+		if step.TargetNode == node.Name {
+			out.IsDrained = true
+			out.DrainedBy = step.SequenceNumber
+			out.Answer = fmt.Sprintf(
+				"%s IS being drained, by step %d (rated %s). %s",
+				node.Name, step.SequenceNumber, step.Impact, step.Rationale)
+			return nil, out, nil
+		}
+	}
+
+	// Not a drain target. Work out which of the several possible reasons applies,
+	// most specific first — "it holds an unevictable pod" is a far more useful
+	// answer than "it is not in the plan".
+	if rec.Analysis != nil {
+		drainable, blockers := rec.Analysis.NodeDrainable(node.Name)
+		for _, b := range blockers {
+			out.Blockers = append(out.Blockers, ConstraintDetail{
+				Pod: b.Subject, Kind: string(b.Kind), Blocking: b.Blocking, Explanation: b.Explanation,
+			})
+		}
+		for _, pc := range rec.Analysis.ForNode(node.Name) {
+			if pc.Movable && len(pc.CandidateNodes) == 0 {
+				out.StuckPods = append(out.StuckPods, pc.Key())
+			}
+		}
+		if !drainable && len(out.Blockers) > 0 {
+			out.Answer = fmt.Sprintf(
+				"%s cannot be drained because %d constraint(s) block it. %s",
+				node.Name, len(out.Blockers), out.Blockers[0].Explanation)
+			return nil, out, nil
+		}
+	}
+
+	if node.Unschedulable {
+		out.Answer = fmt.Sprintf(
+			"%s is cordoned, so the planner excludes it as a drain target — its pods "+
+				"cannot be replaced there and nothing new may schedule onto it.", node.Name)
+		return nil, out, nil
+	}
+	if !node.Ready {
+		out.Answer = fmt.Sprintf(
+			"%s is not Ready. The planner skips unready nodes: their pods are already "+
+				"the scheduler's problem, not a consolidation decision.", node.Name)
+		return nil, out, nil
+	}
+	if _, isControlPlane := controlPlaneLabel(node); isControlPlane {
+		out.Answer = fmt.Sprintf(
+			"%s is a control-plane node and is excluded by policy. Draining the API "+
+				"server out from under the cluster is not consolidation.", node.Name)
+		return nil, out, nil
+	}
+	if rec.Snapshot.RequestedOnNode(node.Name).IsZero() {
+		out.Answer = fmt.Sprintf(
+			"%s holds no workload, so there is nothing to drain — it is already "+
+				"reclaimable.", node.Name)
+		return nil, out, nil
+	}
+
+	out.Answer = fmt.Sprintf(
+		"%s is not drained by this plan. It is most likely serving as a destination "+
+			"for pods moved off other nodes, or the planner could not find room for its "+
+			"pods elsewhere. Use get_node_constraints for the detail.", node.Name)
+	return nil, out, nil
+}
+
+// ---------------------------------------------------------------- helpers
+
+const readOnlyNote = "k8s-dencer only plans and explains. It cannot drain, cordon or evict, " +
+	"and has no permission to do so."
+
+func flatten(pc constraints.PodConstraints) []ConstraintDetail {
+	out := make([]ConstraintDetail, 0, len(pc.Constraints))
+	for _, c := range pc.Constraints {
+		out = append(out, ConstraintDetail{
+			Pod:         pc.Key(),
+			Kind:        string(c.Kind),
+			Blocking:    c.Blocking,
+			Explanation: c.Explanation,
+		})
+	}
+	return out
+}
+
+func controlPlaneLabel(n model.Node) (string, bool) {
+	for _, key := range []string{
+		"node-role.kubernetes.io/control-plane",
+		"node-role.kubernetes.io/master",
+	} {
+		if _, ok := n.Labels[key]; ok {
+			return key, true
+		}
+	}
+	return "", false
+}
+
+// nodeHint lists a few real node names, so a model that guessed a name can
+// correct itself instead of guessing again.
+func nodeHint(snap *model.ClusterSnapshot) string {
+	if snap == nil || len(snap.Nodes) == 0 {
+		return "The snapshot contains no nodes."
+	}
+	names := make([]string, 0, len(snap.Nodes))
+	for _, n := range snap.Nodes {
+		names = append(names, n.Name)
+	}
+	sort.Strings(names)
+	if len(names) > 5 {
+		return fmt.Sprintf("Known nodes include: %s (and %d more).",
+			strings.Join(names[:5], ", "), len(names)-5)
+	}
+	return "Known nodes: " + strings.Join(names, ", ") + "."
+}
+
+// errorResult returns a tool-level error rather than a protocol error, so the
+// model sees the explanation and can correct itself instead of the call simply
+// failing.
+func errorResult[T any](msg string) (*mcp.CallToolResult, T, error) {
+	var zero T
+	return &mcp.CallToolResult{
+		IsError: true,
+		Content: []mcp.Content{&mcp.TextContent{Text: msg}},
+	}, zero, nil
+}
+
+func (s *Server) fail(err error) (*mcp.CallToolResult, ListStepsOutput, error) {
+	return errorResult[ListStepsOutput](s.storeMessage(err))
+}
+func (s *Server) failStep(err error) (*mcp.CallToolResult, ExplainStepOutput, error) {
+	return errorResult[ExplainStepOutput](s.storeMessage(err))
+}
+func (s *Server) failNode(err error) (*mcp.CallToolResult, NodeOutput, error) {
+	return errorResult[NodeOutput](s.storeMessage(err))
+}
+func (s *Server) failWhyNot(err error) (*mcp.CallToolResult, WhyNotOutput, error) {
+	return errorResult[WhyNotOutput](s.storeMessage(err))
+}
+
+func (s *Server) storeMessage(err error) string {
+	if errors.Is(err, store.ErrNotFound) {
+		return "No consolidation plan has been produced yet. The planner publishes one " +
+			"once it has read the cluster, usually within a minute of starting."
+	}
+	s.log.Error("agent tool failed", "error", err)
+	return "The plan store could not be read. This is a k8s-dencer fault, not a " +
+		"problem with the question."
+}

--- a/internal/api/agenttools/agenttools_test.go
+++ b/internal/api/agenttools/agenttools_test.go
@@ -1,0 +1,305 @@
+package agenttools_test
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/atedgimo/k8s-dencer/internal/api/agenttools"
+	"github.com/atedgimo/k8s-dencer/internal/constraints"
+	"github.com/atedgimo/k8s-dencer/internal/model"
+	"github.com/atedgimo/k8s-dencer/internal/store"
+	sqlitestore "github.com/atedgimo/k8s-dencer/internal/store/sqlite"
+)
+
+// connect starts the MCP endpoint over HTTP and returns a real MCP client
+// session. Driving the actual protocol rather than calling handlers directly
+// is the point: a protocol mistake here shows up as Kagent silently failing to
+// connect, which a handler-level test would never catch.
+func connect(t *testing.T, records ...store.Record) *mcp.ClientSession {
+	t.Helper()
+
+	db, err := sqlitestore.Open(filepath.Join(t.TempDir(), "agent.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := db.Migrate(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	for _, rec := range records {
+		if _, err := db.Save(context.Background(), rec); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	srv := httptest.NewServer(agenttools.New(db, slog.New(slog.DiscardHandler), "test").Handler())
+	t.Cleanup(srv.Close)
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test", Version: "1"}, nil)
+	session, err := client.Connect(context.Background(),
+		&mcp.StreamableClientTransport{Endpoint: srv.URL}, nil)
+	if err != nil {
+		t.Fatalf("MCP connect: %v", err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+	return session
+}
+
+func call(t *testing.T, s *mcp.ClientSession, name string, args map[string]any) (string, bool) {
+	t.Helper()
+	res, err := s.CallTool(context.Background(), &mcp.CallToolParams{Name: name, Arguments: args})
+	if err != nil {
+		t.Fatalf("call %s: %v", name, err)
+	}
+	var sb strings.Builder
+	for _, c := range res.Content {
+		if tc, ok := c.(*mcp.TextContent); ok {
+			sb.WriteString(tc.Text)
+		}
+	}
+	return sb.String(), res.IsError
+}
+
+func sampleRecord() store.Record {
+	snap := &model.ClusterSnapshot{
+		TakenAt: time.Now().UTC(),
+		Nodes: []model.Node{
+			{Name: "worker-1", Ready: true, Labels: map[string]string{model.LabelZone: "z1"},
+				Allocatable: model.Resources{MilliCPU: 4000, MemoryBytes: 1 << 33, Pods: 110}},
+			{Name: "worker-2", Ready: true, Labels: map[string]string{model.LabelZone: "z2"},
+				Allocatable: model.Resources{MilliCPU: 4000, MemoryBytes: 1 << 33, Pods: 110}},
+			{Name: "control", Ready: true,
+				Labels:      map[string]string{"node-role.kubernetes.io/control-plane": ""},
+				Allocatable: model.Resources{MilliCPU: 4000, MemoryBytes: 1 << 33, Pods: 110}},
+		},
+		Pods: []model.Pod{
+			{Namespace: "app", Name: "orphan", NodeName: "worker-1", Phase: model.PodRunning,
+				Requests: model.Resources{MilliCPU: 500, MemoryBytes: 1 << 28}},
+		},
+	}
+	return store.Record{
+		Plan: &model.Plan{
+			ID: "plan-1", Status: model.PlanValid,
+			GeneratedAt: time.Now().UTC(), SnapshotTakenAt: snap.TakenAt,
+			NodesBefore: 2, NodesAfter: 1,
+			Steps: []model.PlanStep{{
+				ID: "s1", SequenceNumber: 1, TargetNode: "worker-1",
+				Moves:  []model.Move{{Namespace: "app", Pod: "orphan", FromNode: "worker-1", ToNode: "worker-2"}},
+				Impact: model.ImpactRed,
+				Rationale: "Draining worker-1 moves 1 pod(s). Rated Red because: app/orphan has " +
+					"no controller. Evicting it deletes it permanently; nothing will recreate it. " +
+					"Red steps may only execute inside an approved maintenance window.",
+				Reasons: []model.ImpactReason{{Kind: "UnmanagedPod", Subject: "app/orphan",
+					Detail: "app/orphan has no controller."}},
+			}},
+		},
+		Snapshot: snap,
+		Analysis: constraints.Analyze(snap),
+		Strategy: "greedy-first-fit-decreasing",
+	}
+}
+
+// The four tools are a contract with the Agent CR, which names them explicitly
+// in toolNames. A rename that the chart doesn't follow leaves the agent with a
+// tool it cannot call.
+func TestExposesExactlyTheFourDocumentedTools(t *testing.T) {
+	session := connect(t, sampleRecord())
+
+	res, err := session.ListTools(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string]bool{}
+	for _, tool := range res.Tools {
+		got[tool.Name] = true
+		if tool.Description == "" {
+			t.Errorf("tool %s has no description; the model selects tools by description", tool.Name)
+		}
+	}
+	for _, want := range []string{"list_plan_steps", "explain_step", "get_node_constraints", "why_not_drained"} {
+		if !got[want] {
+			t.Errorf("missing tool %s", want)
+		}
+		delete(got, want)
+	}
+	for extra := range got {
+		t.Errorf("unexpected tool %s — the surface must stay read-only and minimal", extra)
+	}
+}
+
+func TestListPlanSteps(t *testing.T) {
+	session := connect(t, sampleRecord())
+
+	out, isErr := call(t, session, "list_plan_steps", nil)
+	if isErr {
+		t.Fatalf("unexpected error: %s", out)
+	}
+	var parsed struct {
+		PlanID    string `json:"planId"`
+		Reclaimed int    `json:"nodesReclaimed"`
+		Red       int    `json:"redSteps"`
+		ReadOnly  string `json:"readOnly"`
+		Steps     []struct {
+			Step       int    `json:"step"`
+			Impact     string `json:"impact"`
+			WindowOnly bool   `json:"maintenanceWindowOnly"`
+		} `json:"steps"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("output is not the structured shape: %v\n%s", err, out)
+	}
+	if parsed.PlanID != "plan-1" || parsed.Reclaimed != 1 || parsed.Red != 1 {
+		t.Errorf("unexpected summary: %+v", parsed)
+	}
+	if len(parsed.Steps) != 1 || !parsed.Steps[0].WindowOnly {
+		t.Errorf("Red step must be flagged maintenance-window-only: %+v", parsed.Steps)
+	}
+	// Every answer states the read-only guarantee, so an operator asking the
+	// agent to drain something is told plainly that it cannot.
+	if !strings.Contains(parsed.ReadOnly, "cannot drain") {
+		t.Errorf("readOnly note missing or reworded: %q", parsed.ReadOnly)
+	}
+}
+
+// The agent must answer with the classifier's exact words. If the tool
+// paraphrased, the agent and the UI's inspector could describe the same step
+// differently and an operator would not know which to trust.
+func TestExplainStepQuotesTheClassifierVerbatim(t *testing.T) {
+	rec := sampleRecord()
+	session := connect(t, rec)
+
+	out, isErr := call(t, session, "explain_step", map[string]any{"step": 1})
+	if isErr {
+		t.Fatalf("unexpected error: %s", out)
+	}
+	var parsed struct {
+		Impact     string `json:"impact"`
+		Rationale  string `json:"rationale"`
+		WindowOnly bool   `json:"maintenanceWindowOnly"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatal(err)
+	}
+	if parsed.Impact != "Red" || !parsed.WindowOnly {
+		t.Errorf("rating lost: %+v", parsed)
+	}
+	if parsed.Rationale != rec.Plan.Steps[0].Rationale {
+		t.Errorf("rationale was altered:\nstored: %q\nserved: %q",
+			rec.Plan.Steps[0].Rationale, parsed.Rationale)
+	}
+}
+
+// A wrong step number should teach the model the valid range rather than
+// failing the call — it can then correct itself in the same conversation.
+func TestUnknownStepReturnsAGuidingError(t *testing.T) {
+	session := connect(t, sampleRecord())
+
+	out, isErr := call(t, session, "explain_step", map[string]any{"step": 99})
+	if !isErr {
+		t.Fatal("expected a tool error for an unknown step")
+	}
+	if !strings.Contains(out, "no step 99") || !strings.Contains(out, "1 to 1") {
+		t.Errorf("error should state the valid range, got: %q", out)
+	}
+}
+
+func TestWhyNotDrainedAnswersEachCase(t *testing.T) {
+	session := connect(t, sampleRecord())
+
+	cases := []struct {
+		node string
+		want string
+	}{
+		{"worker-1", "IS being drained"},
+		{"control", "control-plane"},
+		{"worker-2", ""}, // a destination node; any coherent answer will do
+	}
+	for _, tc := range cases {
+		t.Run(tc.node, func(t *testing.T) {
+			out, isErr := call(t, session, "why_not_drained", map[string]any{"node": tc.node})
+			if isErr {
+				t.Fatalf("unexpected error: %s", out)
+			}
+			var parsed struct {
+				Answer    string `json:"answer"`
+				IsDrained bool   `json:"isDrainedByPlan"`
+			}
+			if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+				t.Fatal(err)
+			}
+			if len(parsed.Answer) < 30 {
+				t.Errorf("answer too thin to be useful: %q", parsed.Answer)
+			}
+			if tc.want != "" && !strings.Contains(parsed.Answer, tc.want) {
+				t.Errorf("answer for %s should mention %q, got: %q", tc.node, tc.want, parsed.Answer)
+			}
+		})
+	}
+}
+
+// A guessed node name is the likeliest model mistake; the error names real
+// nodes so the next attempt can succeed.
+func TestUnknownNodeSuggestsRealNames(t *testing.T) {
+	session := connect(t, sampleRecord())
+
+	out, isErr := call(t, session, "get_node_constraints", map[string]any{"node": "nope"})
+	if !isErr {
+		t.Fatal("expected a tool error for an unknown node")
+	}
+	if !strings.Contains(out, "worker-1") {
+		t.Errorf("error should list known node names, got: %q", out)
+	}
+}
+
+// A fresh install has no plan. The agent should say so in words an operator
+// understands, not surface a database error.
+func TestEmptyStoreExplainsRatherThanFailing(t *testing.T) {
+	session := connect(t)
+
+	out, isErr := call(t, session, "list_plan_steps", nil)
+	if !isErr {
+		t.Fatal("expected a tool error when no plan exists")
+	}
+	if !strings.Contains(out, "No consolidation plan has been produced yet") {
+		t.Errorf("unhelpful empty-store message: %q", out)
+	}
+	if strings.Contains(strings.ToLower(out), "sql") {
+		t.Errorf("internal detail leaked to the model: %q", out)
+	}
+}
+
+func TestGetNodeConstraintsReportsUtilisationAndDrainStep(t *testing.T) {
+	session := connect(t, sampleRecord())
+
+	out, isErr := call(t, session, "get_node_constraints", map[string]any{"node": "worker-1"})
+	if isErr {
+		t.Fatalf("unexpected error: %s", out)
+	}
+	var parsed struct {
+		Node        string `json:"node"`
+		Zone        string `json:"zone"`
+		DrainedBy   int    `json:"drainedByStep"`
+		Impact      string `json:"drainImpact"`
+		Utilization string `json:"utilization"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatal(err)
+	}
+	if parsed.Node != "worker-1" || parsed.Zone != "z1" {
+		t.Errorf("node detail wrong: %+v", parsed)
+	}
+	if parsed.DrainedBy != 1 || parsed.Impact != "Red" {
+		t.Errorf("drain step not linked: %+v", parsed)
+	}
+	if parsed.Utilization == "" {
+		t.Error("utilisation missing")
+	}
+}


### PR DESCRIPTION
The plan is now answerable in natural language. Four read-only MCP tools served by the ui-backend, plus the `Agent` and `RemoteMCPServer` CRs the chart has templated since M0.

```
remotemcpserver.kagent.dev/k8s-dencer  STREAMABLE_HTTP  ACCEPTED: True
agent.kagent.dev/k8s-dencer            Declarative      READY: True
discovered tools: explain_step, get_node_constraints, list_plan_steps, why_not_drained
```

That `ACCEPTED` column has read `False` since M0 because `/mcp` did not exist. **It flipping to `True` is the completion signal for this milestone.**

## Verified end to end against the live cluster

Asked *"why is step 1 rated the way it is?"* — the agent called `explain_step({step: 1})` (visible in the A2A history), received the classifier's exact words, and answered:

> Step 1 is rated Red. This is because it involves moving the pod `dencer-demo/dencer-demo-ledger-0` which belongs to a StatefulSet… The rationale explicitly states that "Red steps may only execute inside an approved maintenance window."

The StatefulSet reasoning came from **our classifier**, not the model's own guesswork.

Asked to drain a node:

> This release of k8s-dencer is read-only by design and does not have the capability to execute actions such as draining nodes.

## The tools quote; they never re-derive

Every answer is composed from strings M3 and M5 already produced, and **a test asserts `explain_step` returns the stored rationale byte-for-byte**. If the tool paraphrased, the agent and the UI's constraint inspector could describe the same step differently and an operator would have no way to know which to trust — that is the whole reason M3 produces the text once.

## Read-only in three places

- Phase 1 has no executor
- a test asserts **exactly these four tools exist** — a fifth cannot appear without someone deliberately changing that assertion
- the tool output states the guarantee, so the model repeats it rather than inventing capability

## Design notes

**No new image.** The agent runs inside Kagent (doc §5), so all we owe it is an endpoint — mounted on ui-backend, which already owns the plan store.

**Stateless Streamable HTTP with JSON responses.** Each call returns one small result, so a stream buys nothing and gives proxies another thing to buffer; statelessness lets Kagent reconnect without session affinity.

**Errors teach rather than fail.** An unknown step number reports the valid range; an unknown node names real ones; an empty store explains the planner hasn't published yet instead of surfacing a database error. Each is a tool-level error the model can act on, not a protocol failure that ends the call.

**Official `modelcontextprotocol/go-sdk`, not hand-rolled JSON-RPC.** Protocol mistakes fail silently as `ACCEPTED: False`, and the tests drive a **real MCP client session over HTTP** rather than calling handlers directly — so a wire-format regression is caught locally instead of in the cluster.

## Verified

```
make test    84 tests; 8 new driving the real MCP protocol
make lint    all chart contract checks pass
live         ACCEPTED: True, 4 tools discovered, agent answers correctly and refuses to act
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)