### PR TITLE
M9: authentication and authorization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -219,6 +219,26 @@ status: ## Show what is running
 logs: ## Tail the planner log
 	kubectl logs -n $(NAMESPACE) -l app.kubernetes.io/component=planner -f --tail=50
 
+# Tier 3 of the auth story: a plain bearer token, for the POC and for CI. The
+# production path is OIDC single sign-on (auth.oidc.*), where the API server
+# validates an ID token from an issuer it already trusts.
+TOKEN_SA       ?= dencer-operator
+TOKEN_DURATION ?= 8h
+
+.PHONY: token
+token: ## Mint an operator token for the UI (paste it when prompted)
+	@kubectl get serviceaccount $(TOKEN_SA) -n $(NAMESPACE) >/dev/null 2>&1 \
+		|| kubectl create serviceaccount $(TOKEN_SA) -n $(NAMESPACE) >/dev/null
+	@# Granting the operator role, not the viewer role, so the same token keeps
+	@# working when the executor lands in M10 and the UI gains a run button.
+	@kubectl get rolebinding $(TOKEN_SA) -n $(NAMESPACE) >/dev/null 2>&1 \
+		|| kubectl create rolebinding $(TOKEN_SA) -n $(NAMESPACE) \
+			--clusterrole=$(RELEASE)-consolidation-operator \
+			--serviceaccount=$(NAMESPACE):$(TOKEN_SA) >/dev/null
+	@echo "# ServiceAccount $(NAMESPACE)/$(TOKEN_SA), valid $(TOKEN_DURATION)." >&2
+	@echo "# Paste this into the UI's sign-in field." >&2
+	@kubectl create token $(TOKEN_SA) -n $(NAMESPACE) --duration=$(TOKEN_DURATION)
+
 .PHONY: undeploy
 undeploy: ## Remove the product release
 	-helm uninstall $(RELEASE) --namespace $(NAMESPACE)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 k8s-dencer continuously analyzes your Kubernetes cluster's constraints (PDBs, topology spread, affinity, taints) and builds a node consolidation plan — broken into discrete, impact-rated steps you can inspect and run on your own terms, on request or during a maintenance window. Nothing executes without explicit approval.
 
-**Phase 1 is read-only by construction.** It plans and explains; it never cordons, drains or evicts. The ServiceAccount is not granted `pods/eviction`, and `make lint` fails the build if any values profile ever grants it.
+**Still read-only.** It plans and explains; it never cordons, drains or evicts. No ServiceAccount is granted `pods/eviction`, and `make lint` fails the build if any values profile ever grants it. The executor arrives in M10 — with its own ServiceAccount, behind the authorization gate that M9 has already shipped.
 
 Full design: [docs/k8s-consolidation-agent-architecture.md](docs/k8s-consolidation-agent-architecture.md)
 
@@ -24,7 +24,22 @@ Phase 1 (MVP) — visibility and explainability. No execution capability.
 | **M7** | UI: capacity ribbon, packing canvas, scrubber, constraint inspector | **done** |
 | **M8** | Kagent agent: read-only MCP tools + `Agent` CR | **done** |
 
-**Phase 1 is complete.** Deferred to later phases: Executor, Safety Guard, Scheduler Simulator, `MaintenanceWindow` CRD, Postgres store, multi-agent orchestration.
+**Phase 1 is complete.**
+
+Phase 2 — on-request execution. Authentication lands first, deliberately: a
+window in which an execute endpoint exists unauthenticated is worse than either
+state on its own.
+
+| Milestone | Scope | State |
+|---|---|---|
+| **M9** | AuthN/AuthZ via TokenReview + SubjectAccessReview; OIDC SSO; NetworkPolicy on by default | **done** |
+| **M10** | Executor + Safety Guard, own ServiceAccount, `pods/eviction` | planned |
+| **M11** | UI rebuild: packing view, motion, action-first header | planned |
+| **M12** | Execution controls, live run, OIDC sign-in flow, plan pinning | planned |
+| **M13** | End-to-end on KWOK incl. real SSO against Dex | planned |
+
+Deferred beyond Phase 2: `MaintenanceWindow` CRD and scheduled execution,
+Postgres store, multi-agent orchestration.
 
 ### What actually runs today
 
@@ -55,6 +70,7 @@ YAML: `/debug/snapshot`, `/debug/constraints` and `/debug/plan`.
 
 ```bash
 make demo     # KWOK fabric + 30-node topology + build images + install the chart
+make token    # mint an operator token — the UI asks for one
 make ui       # port-forward and print the URLs
 make down     # remove all three releases
 ```
@@ -75,6 +91,7 @@ internal/
   planner/         Strategy interface + greedy first-fit-decreasing packer
   impact/          Green/Yellow/Red classifier + rationale composition
   store/           Store interface + SQLite implementation and migrations
+  auth/            TokenReview authn + SubjectAccessReview authz; no credential store of our own
   api/             rest/ (+ SSE events), graph/ (Cytoscape payload), agenttools/ (MCP)
 ui/                React + Vite + Cytoscape.js; bundled typefaces
 charts/k8s-dencer/ THE product deliverable — see Chart below
@@ -125,11 +142,133 @@ Runs `helm lint` and `kubeconform --strict` across every profile, then asserts t
 4. **no profile grants `pods/eviction`**
 5. `database.type=sqlite` with `uiBackend.replicaCount=2` is rejected by `values.schema.json`
 6. the packaged chart excludes the `ci/` fixtures
+7. **no profile disables authentication**
+8. `system:auth-delegator` is bound to ui-backend and to nothing else
+9. the consolidation-operator ClusterRole ships **unbound**
+10. a NetworkPolicy is present by default, and restricts ingress only
+11. `auth.oidc.enabled=true` without an issuer and client ID is rejected
 
 ### Known constraints
 
 - **SQLite is single-writer.** `uiBackend.replicaCount` is pinned to 1 and enforced by the schema; the planner is co-scheduled with ui-backend via a `requiredDuringScheduling` podAffinity, because a ReadWriteOnce claim only permits multiple pods on the same node. Both constraints disappear when the Postgres store lands.
 - **PDBs use `maxUnavailable`, never `minAvailable`.** A `minAvailable` PDB on a single-replica Deployment makes its own pod undrainable — the exact pathology this product exists to detect.
+
+---
+
+## Authentication
+
+k8s-dencer owns **no credential store**. A caller presents a token,
+[ui-backend](internal/auth/authenticator.go) validates it with a `TokenReview`,
+and permission is decided by a
+[`SubjectAccessReview`](internal/auth/authorizer.go). So "who may read the plan"
+and "who may drain a node" are ordinary RoleBindings that compose with whatever
+your cluster already uses, audit flows through the API server, and there is no
+user database to breach.
+
+On by default (`auth.enabled`). Two unbound ClusterRoles ship with the chart —
+bind whichever you need:
+
+| ClusterRole | Grants |
+|---|---|
+| `<release>-viewer` | `get plans.dencer.io` |
+| `<release>-consolidation-operator` | the above, plus `create consolidations.dencer.io` |
+
+Neither resource is a CRD, and neither ever will be: RBAC and
+SubjectAccessReview match on strings, so a permission can be granted against a
+resource name that has no API behind it. metrics-server relies on the same
+property.
+
+### Three ways to authenticate
+
+All three converge on the same `SubjectAccessReview` — authentication is
+pluggable, authorization is one code path.
+
+**1. OIDC single sign-on** — the recommended deployment. When your API server
+runs with `--oidc-issuer-url`, an ID token from that issuer **is already a
+Kubernetes credential**, so `TokenReview` validates it for us and returns the
+user's IdP groups. SSO therefore costs a redirect flow in the browser and
+nothing on the server: no session store, no user database, no client secret.
+
+```yaml
+auth:
+  oidc:
+    enabled: true
+    issuerUrl: https://login.example.com/realms/platform   # the SAME issuer the API server trusts
+    clientId: k8s-dencer                                   # public client, Authorization Code + PKCE
+```
+
+```bash
+kubectl create rolebinding dencer-operators -n k8s-dencer \
+  --clusterrole=k8s-dencer-consolidation-operator --group=oidc:platform-sre
+```
+
+Unavailable on clusters whose API server cannot validate a third-party token —
+EKS with IAM auth, GKE with Google auth. Use an auth proxy there.
+
+**2. Auth proxy** — oauth2-proxy, Ingress auth or a service mesh terminates SSO
+and asserts the identity in a header. We skip `TokenReview` and go straight to
+`SubjectAccessReview`, which accepts `spec.user` and `spec.groups` directly, so
+we can ask "may *this* person do this" without ever holding their token.
+
+Off by default, and **while it is off the headers are ignored, not merely
+unused** — a request carrying `X-Forwarded-User` is anonymous, not an
+administrator. Turning it on means anything that can reach ui-backend can claim
+to be anyone, so `networkPolicy.enabled` is what makes the proxy unbypassable.
+
+**3. Bearer token** — for the POC and CI.
+
+```bash
+make token     # mints one and prints it; paste into the UI
+```
+
+### Notes worth knowing
+
+- **Token expiry cannot break a run.** From M10, authorization happens once at
+  enqueue and the executor then works under its own ServiceAccount, so a
+  15-minute ID token can authorize a 40-minute consolidation. The authenticated
+  username and groups are recorded on the run and on every audit event.
+- **A 403 tells you how to fix it** — it names the exact verb, group and
+  resource, and quotes the `kubectl create rolebinding` that grants them.
+- **Authentication is cached for 30s; authorization never is.** A revoked
+  RoleBinding must stop working immediately.
+- **`/api/v1/authinfo` is served openly.** A client cannot sign in without
+  knowing where to sign in, and the answer is an issuer URL and a public client
+  ID. [A test](internal/api/rest/guarded_test.go) fails if any *other* route is
+  registered without a guard — which is what will stop an execute endpoint
+  shipping unauthenticated in M10.
+- **Do not assume your NetworkPolicy is enforced.** A CNI that does not
+  implement NetworkPolicy accepts the object and silently ignores it — there is
+  no warning and no event. k3s's default CNI is one of these, so on the OrbStack
+  POC cluster the policy provides *zero* protection: a pod in `default` reaches
+  ui-backend with a 200. Verify on your own cluster before relying on it, and
+  note that `auth.trustedProxy` is only safe where it *is* enforced.
+
+  ```bash
+  kubectl run probe --rm -i --restart=Never -n default --image=curlimages/curl:8.11.1 \
+    --command -- curl -s -o /dev/null -w '%{http_code}\n' \
+    http://<release>-ui-backend.<ns>.svc:8080/api/v1/authinfo   # 000 = enforced, 200 = not
+  ```
+
+- **The MCP surface can be token-guarded, and on an unenforced CNI it should
+  be.** Verified against Kagent 0.9.12: `RemoteMCPServer.headersFrom` presents a
+  bearer token and all four tools are discovered through it. Off by default only
+  because the secret is yours to create and rotate — the chart will not mint a
+  non-expiring ServiceAccount token on your behalf.
+
+  ```bash
+  kubectl create serviceaccount dencer-agent -n k8s-dencer
+  kubectl create rolebinding dencer-agent -n k8s-dencer \
+    --clusterrole=k8s-dencer-viewer --serviceaccount=k8s-dencer:dencer-agent
+  kubectl create secret generic dencer-mcp-token -n kagent \
+    --from-literal=authorization="Bearer $(kubectl create token dencer-agent -n k8s-dencer --duration=720h)"
+  helm upgrade ... --set auth.mcpRequireToken=true \
+    --set kagent.authSecret.name=dencer-mcp-token
+  ```
+
+  The value must be the whole header — Kagent substitutes it verbatim. The
+  surface is read-only either way, and a test fails if a fifth tool appears.
+- **The UI signs in by pasting a token.** The OIDC redirect flow lands in M12,
+  because M11 rebuilds the header and building the login twice would be waste.
 
 ---
 
@@ -255,6 +394,7 @@ Plans live in SQLite on the chart's PVC, not in a CRD. Doc §6 makes the case: a
 ### Endpoints
 
 ```
+GET /api/v1/authinfo                                 how to sign in — the only open route
 GET /api/v1/version
 GET /api/v1/plans                                    list, newest first
 GET /api/v1/plans/{id|latest}                        full plan
@@ -265,9 +405,15 @@ GET /api/v1/plans/{id}/constraints[/{ns}/{pod}]      constraint analysis
 GET /api/v1/events                                   live plan changes (SSE)
 ```
 
-`latest` is an alias, so the UI can deep-link without knowing an ID. **There is no mutating route** — not even a disabled one, because a "not implemented" execute endpoint is an invitation. A test asserts none exists.
+Everything but `authinfo` requires `get plans.dencer.io` — see
+[Authentication](#authentication). `latest` is an alias, so the UI can deep-link
+without knowing an ID. **There is no mutating route** — not even a disabled one,
+because a "not implemented" execute endpoint is an invitation. A test asserts
+none exists.
 
-Live updates use **Server-Sent Events rather than WebSockets**: the traffic is strictly one-way since the API is read-only, `EventSource` reconnects on its own, and it needs no dependency and no protocol upgrade. The stream sends current state on connect, so a client joining a stable cluster isn't left blank.
+Live updates use **Server-Sent Events rather than WebSockets**: the traffic is strictly one-way since the API is read-only, and it needs no dependency and no protocol upgrade. The stream sends current state on connect, so a client joining a stable cluster isn't left blank.
+
+The frontend consumes that stream with **`fetch` rather than `EventSource`**, which costs us the reconnect logic `EventSource` gives away. `EventSource` cannot send an `Authorization` header, and the alternative — putting the token in the query string — would write a working credential into every access log between the browser and the backend.
 
 The graph payload is shaped for Cytoscape's compound-node model — cluster nodes are parents, pods are children — and every pod carries **both** its current node and where the plan would move it, so the frontend can build the before/after view and animate the step scrubber from a single request.
 

--- a/charts/k8s-dencer/ci/production-values.yaml
+++ b/charts/k8s-dencer/ci/production-values.yaml
@@ -77,6 +77,17 @@ ingress:
 networkPolicy:
   enabled: true
 
+# The recommended deployment: SSO through the issuer the API server already
+# trusts, so an ID token from it is a Kubernetes credential and permission is
+# an ordinary RoleBinding against an IdP group.
+auth:
+  enabled: true
+  anonymousRead: false
+  oidc:
+    enabled: true
+    issuerUrl: https://login.example.com/realms/platform
+    clientId: k8s-dencer
+
 serviceMonitor:
   enabled: true
   labels:

--- a/charts/k8s-dencer/templates/NOTES.txt
+++ b/charts/k8s-dencer/templates/NOTES.txt
@@ -16,9 +16,54 @@ Reach the UI:
 {{- end }}
 
 Verify the read-only guarantee:
+{{- range $component := list "planner" "ui-backend" }}
   kubectl auth can-i create pods/eviction \
-    --as=system:serviceaccount:{{ .Release.Namespace }}:{{ include "k8s-dencer.serviceAccountName" . }}
-  # must print: no
+    --as=system:serviceaccount:{{ $.Release.Namespace }}:{{ include "k8s-dencer.componentServiceAccountName" (dict "component" $component "ctx" $) }}
+{{- end }}
+  # both must print: no
+
+{{ if .Values.auth.enabled -}}
+Authentication is ON. Nobody can read a plan until you grant them the
+permission — the chart deliberately does not decide that for you:
+
+  kubectl create rolebinding dencer-viewer -n {{ .Release.Namespace }} \
+    --clusterrole={{ include "k8s-dencer.fullname" . }}-viewer \
+{{- if .Values.auth.oidc.enabled }}
+    --group=oidc:YOUR-GROUP
+{{- else }}
+    --user=YOUR-USERNAME
+{{- end }}
+
+{{ if .Values.auth.oidc.enabled -}}
+Single sign-on is configured against:
+  {{ .Values.auth.oidc.issuerUrl }}
+
+This must be the SAME issuer your API server trusts (--oidc-issuer-url), or
+tokens will be issued in the browser and then rejected here. Confirm with:
+  kubectl get --raw /.well-known/openid-configuration
+{{- else -}}
+No OIDC issuer configured, so callers present a token directly:
+  kubectl create token {{ include "k8s-dencer.componentServiceAccountName" (dict "component" "ui-backend" "ctx" .) }} -n {{ .Release.Namespace }}
+
+Set auth.oidc.* to use single sign-on instead. If your API server already
+trusts an OIDC issuer, that is all it takes — an ID token from it is already a
+Kubernetes credential.
+{{- end }}
+{{- if .Values.auth.trustedProxy.enabled }}
+
+WARNING: auth.trustedProxy is ON. ui-backend now believes the
+{{ .Values.auth.trustedProxy.userHeader }} header on any request it receives.
+Make sure it is reachable ONLY through your auth proxy — otherwise anyone who
+can reach the pod can claim to be anyone.
+{{- if not .Values.networkPolicy.enabled }}
+networkPolicy.enabled is FALSE, so nothing is currently enforcing that.
+{{- end }}
+{{- end }}
+{{- else -}}
+WARNING: authentication is DISABLED. Every caller can read every plan and see
+your cluster's full capacity layout. Set auth.enabled=true before exposing this
+beyond a private cluster.
+{{- end }}
 
 {{ if eq .Values.database.type "sqlite" -}}
 Plan store: SQLite at {{ .Values.database.sqlite.path }}{{ if .Values.persistence.enabled }} on PVC {{ include "k8s-dencer.pvcName" . }}{{ else }} on an emptyDir (NOT durable — plan history is lost on restart){{ end }}.

--- a/charts/k8s-dencer/templates/_helpers.tpl
+++ b/charts/k8s-dencer/templates/_helpers.tpl
@@ -71,6 +71,30 @@ app.kubernetes.io/component: {{ .component }}
 {{- end }}
 
 {{/*
+Per-component ServiceAccount name. Call with (dict "component" "planner" "ctx" $).
+
+Each component runs under its own account so permissions can differ: only
+ui-backend may create TokenReviews and SubjectAccessReviews, and from Phase 2
+only the executor may evict. A shared account would mean the widest permission
+any component needs is held by all of them, which defeats the point of the
+executor having its own in the first place.
+
+Setting serviceAccount.name overrides this and runs every component under one
+existing account — an escape hatch for clusters that pre-provision identities
+(IRSA, Workload Identity), at the cost of that separation.
+*/}}
+{{- define "k8s-dencer.componentServiceAccountName" -}}
+{{- $ctx := .ctx -}}
+{{- if $ctx.Values.serviceAccount.name -}}
+{{- $ctx.Values.serviceAccount.name -}}
+{{- else if $ctx.Values.serviceAccount.create -}}
+{{- printf "%s-%s" (include "k8s-dencer.fullname" $ctx) .component -}}
+{{- else -}}
+default
+{{- end -}}
+{{- end }}
+
+{{/*
 Image reference. Call with (dict "image" .Values.<component>.image "ctx" $).
 Tag falls back to the chart appVersion so a chart release pins a coherent set.
 */}}

--- a/charts/k8s-dencer/templates/kagent/remotemcpserver.yaml
+++ b/charts/k8s-dencer/templates/kagent/remotemcpserver.yaml
@@ -20,4 +20,24 @@ spec:
     impact classifier.
   protocol: STREAMABLE_HTTP
   url: {{ printf "%s/mcp" (include "k8s-dencer.uiBackendURL" .) | quote }}
+  {{- with .Values.kagent.authSecret }}
+  {{/*
+  Presents a bearer token on the MCP endpoint, for installs that set
+  auth.mcpRequireToken=true.
+
+  The secret must live in the Kagent namespace and its value must be the WHOLE
+  header, "Bearer eyJ...", because Kagent substitutes it verbatim.
+
+  The chart does not mint this for you. Doing so would mean creating a
+  non-expiring ServiceAccount token Secret, and a long-lived credential
+  committed to a cluster is a worse default than a short-lived one you rotate
+  deliberately. See the README for the TokenRequest recipe.
+  */}}
+  headersFrom:
+    - name: Authorization
+      valueFrom:
+        type: Secret
+        name: {{ .name | quote }}
+        key: {{ .key | default "authorization" | quote }}
+  {{- end }}
 {{- end }}

--- a/charts/k8s-dencer/templates/planner/deployment.yaml
+++ b/charts/k8s-dencer/templates/planner/deployment.yaml
@@ -30,7 +30,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
-      serviceAccountName: {{ include "k8s-dencer.serviceAccountName" . }}
+      serviceAccountName: {{ include "k8s-dencer.componentServiceAccountName" (dict "component" "planner" "ctx" .) }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/k8s-dencer/templates/rbac.yaml
+++ b/charts/k8s-dencer/templates/rbac.yaml
@@ -57,7 +57,97 @@ roleRef:
   kind: ClusterRole
   name: {{ include "k8s-dencer.fullname" . }}-read
 subjects:
+  {{- range $component := list "planner" "ui-backend" }}
   - kind: ServiceAccount
-    name: {{ include "k8s-dencer.serviceAccountName" . }}
+    name: {{ include "k8s-dencer.componentServiceAccountName" (dict "component" $component "ctx" $) }}
+    namespace: {{ $.Release.Namespace }}
+  {{- end }}
+{{- if .Values.auth.enabled }}
+---
+{{/*
+Lets ui-backend ask the API server "who is this?" (TokenReview) and "may they?"
+(SubjectAccessReview). system:auth-delegator is the built-in role for exactly
+this; every aggregated API server in the ecosystem uses it.
+
+Neither verb grants anything. TokenReview validates a token that was already
+issued, and SubjectAccessReview only reads an existing policy — which is why
+delegating authentication is safe in a way that minting credentials would not be.
+
+Bound to ui-backend alone. The planner never sees a request from a human.
+*/}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "k8s-dencer.fullname" . }}-auth-delegator
+  labels:
+    {{- include "k8s-dencer.componentLabels" (dict "ctx" . "component" "ui-backend") | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "k8s-dencer.componentServiceAccountName" (dict "component" "ui-backend" "ctx" .) }}
     namespace: {{ .Release.Namespace }}
+---
+{{/*
+The permissions humans hold, shipped unbound.
+
+dencer.io/plans and dencer.io/consolidations are not CRDs and never will be —
+RBAC and SubjectAccessReview match on strings, so a permission can be granted
+against a resource name that has no API behind it. metrics-server and the
+Prometheus adapter rely on the same property.
+
+Bind whichever of these you need to a user or, better, to an IdP group:
+
+  kubectl create rolebinding dencer-viewer -n {{ .Release.Namespace }} \
+    --clusterrole={{ include "k8s-dencer.fullname" . }}-viewer --group=oidc:platform-eng
+
+Deliberately left unbound: the chart should not decide who may look at your
+capacity, still less who may drain a node.
+*/}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "k8s-dencer.fullname" . }}-viewer
+  labels:
+    {{- include "k8s-dencer.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+rules:
+  - apiGroups: ["dencer.io"]
+    resources: ["plans"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "k8s-dencer.fullname" . }}-consolidation-operator
+  labels:
+    {{- include "k8s-dencer.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+rules:
+  - apiGroups: ["dencer.io"]
+    resources: ["plans"]
+    verbs: ["get"]
+  {{/*
+  The permission to drain nodes. Nothing in this release accepts it yet — the
+  executor arrives in M10 — but it is defined now so that when the first
+  mutating route ships, the gate it sits behind is already deployed, already
+  bound, and already tested. An execute endpoint and its permission must never
+  be separated by a release.
+  */}}
+  - apiGroups: ["dencer.io"]
+    resources: ["consolidations"]
+    verbs: ["create"]
+{{- end }}
 {{- end }}

--- a/charts/k8s-dencer/templates/serviceaccount.yaml
+++ b/charts/k8s-dencer/templates/serviceaccount.yaml
@@ -1,16 +1,27 @@
-{{- if .Values.serviceAccount.create }}
+{{- if and .Values.serviceAccount.create (not .Values.serviceAccount.name) }}
+{{/*
+One ServiceAccount per component, so their permissions can differ. ui-backend
+alone is bound to system:auth-delegator; the planner has no business validating
+tokens, and in Phase 2 only the executor will be able to evict.
+
+The frontend is absent deliberately: it serves static assets and proxies, and
+never talks to the API server.
+*/}}
+{{- range $component := list "planner" "ui-backend" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "k8s-dencer.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  name: {{ include "k8s-dencer.componentServiceAccountName" (dict "component" $component "ctx" $) }}
+  namespace: {{ $.Release.Namespace }}
   labels:
-    {{- include "k8s-dencer.labels" . | nindent 4 }}
-  {{- with (merge (dict) .Values.serviceAccount.annotations .Values.commonAnnotations) }}
+    {{- include "k8s-dencer.componentLabels" (dict "ctx" $ "component" $component) | nindent 4 }}
+  {{- with (merge (dict) $.Values.serviceAccount.annotations $.Values.commonAnnotations) }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-# The planner needs an API token to run informers, so this stays true. The
-# frontend uses a separate token-less pod spec setting instead.
+# Both components call the API server — the planner to run informers, the
+# ui-backend to validate tokens — so both need a projected token.
 automountServiceAccountToken: true
+---
+{{- end }}
 {{- end }}

--- a/charts/k8s-dencer/templates/ui-backend/deployment.yaml
+++ b/charts/k8s-dencer/templates/ui-backend/deployment.yaml
@@ -34,7 +34,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
-      serviceAccountName: {{ include "k8s-dencer.serviceAccountName" . }}
+      serviceAccountName: {{ include "k8s-dencer.componentServiceAccountName" (dict "component" "ui-backend" "ctx" .) }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -81,6 +81,43 @@ spec:
             {{- end }}
             - name: POLL_INTERVAL
               value: {{ .Values.uiBackend.pollInterval | quote }}
+            # POD_NAMESPACE is already declared below; it also scopes the
+            # SubjectAccessReview, so permission can be granted with a
+            # RoleBinding in this namespace rather than a cluster-wide one.
+            - name: AUTH_ENABLED
+              value: {{ .Values.auth.enabled | quote }}
+            - name: AUTH_ANONYMOUS_READ
+              value: {{ .Values.auth.anonymousRead | quote }}
+            - name: AUTH_MCP_REQUIRE_TOKEN
+              value: {{ .Values.auth.mcpRequireToken | quote }}
+            {{- with .Values.auth.audiences }}
+            - name: AUTH_AUDIENCES
+              value: {{ join "," . | quote }}
+            {{- end }}
+            # Named in 403 responses so a denial can quote the command that
+            # grants the permission.
+            - name: AUTH_OPERATOR_ROLE
+              value: {{ include "k8s-dencer.fullname" . }}-consolidation-operator
+            - name: AUTH_OIDC_ENABLED
+              value: {{ .Values.auth.oidc.enabled | quote }}
+            {{- if .Values.auth.oidc.enabled }}
+            - name: AUTH_OIDC_ISSUER_URL
+              value: {{ .Values.auth.oidc.issuerUrl | quote }}
+            - name: AUTH_OIDC_CLIENT_ID
+              value: {{ .Values.auth.oidc.clientId | quote }}
+            {{- with .Values.auth.oidc.scopes }}
+            - name: AUTH_OIDC_SCOPES
+              value: {{ join "," . | quote }}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.auth.trustedProxy.enabled }}
+            - name: AUTH_TRUSTED_PROXY_ENABLED
+              value: "true"
+            - name: AUTH_TRUSTED_PROXY_USER_HEADER
+              value: {{ .Values.auth.trustedProxy.userHeader | quote }}
+            - name: AUTH_TRUSTED_PROXY_GROUPS_HEADER
+              value: {{ .Values.auth.trustedProxy.groupsHeader | quote }}
+            {{- end }}
             - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/charts/k8s-dencer/values.schema.json
+++ b/charts/k8s-dencer/values.schema.json
@@ -3,61 +3,110 @@
   "title": "k8s-dencer values",
   "type": "object",
   "properties": {
-    "nameOverride": { "type": "string" },
-    "fullnameOverride": { "type": "string" },
-    "imagePullSecrets": { "type": "array", "items": { "type": "object" } },
-    "commonLabels": { "type": "object" },
-    "commonAnnotations": { "type": "object" },
-
+    "nameOverride": {
+      "type": "string"
+    },
+    "fullnameOverride": {
+      "type": "string"
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "commonLabels": {
+      "type": "object"
+    },
+    "commonAnnotations": {
+      "type": "object"
+    },
     "serviceAccount": {
       "type": "object",
       "properties": {
-        "create": { "type": "boolean" },
-        "name": { "type": "string" },
-        "annotations": { "type": "object" }
+        "create": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string"
+        },
+        "annotations": {
+          "type": "object"
+        }
       }
     },
-
     "rbac": {
       "type": "object",
-      "properties": { "create": { "type": "boolean" } }
+      "properties": {
+        "create": {
+          "type": "boolean"
+        }
+      }
     },
-
     "database": {
       "type": "object",
       "properties": {
         "type": {
           "description": "Plan store backend. Only sqlite is implemented; the postgres Store lands in Phase 2, at which point this enum widens.",
-          "enum": ["sqlite"]
+          "enum": [
+            "sqlite"
+          ]
         },
         "sqlite": {
           "type": "object",
           "properties": {
-            "path": { "type": "string", "minLength": 1 }
+            "path": {
+              "type": "string",
+              "minLength": 1
+            }
           }
         },
         "postgres": {
           "type": "object",
           "properties": {
-            "host": { "type": "string" },
-            "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
-            "database": { "type": "string" },
-            "user": { "type": "string" },
-            "existingSecret": { "type": "string" },
-            "existingSecretPasswordKey": { "type": "string" },
+            "host": {
+              "type": "string"
+            },
+            "port": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 65535
+            },
+            "database": {
+              "type": "string"
+            },
+            "user": {
+              "type": "string"
+            },
+            "existingSecret": {
+              "type": "string"
+            },
+            "existingSecretPasswordKey": {
+              "type": "string"
+            },
             "sslMode": {
-              "enum": ["disable", "allow", "prefer", "require", "verify-ca", "verify-full"]
+              "enum": [
+                "disable",
+                "allow",
+                "prefer",
+                "require",
+                "verify-ca",
+                "verify-full"
+              ]
             }
           }
         }
       }
     },
-
     "persistence": {
       "type": "object",
       "properties": {
-        "enabled": { "type": "boolean" },
-        "existingClaim": { "type": "string" },
+        "enabled": {
+          "type": "boolean"
+        },
+        "existingClaim": {
+          "type": "string"
+        },
         "storageClass": {
           "description": "Empty string inherits the cluster default StorageClass.",
           "type": "string"
@@ -65,19 +114,34 @@
         "accessModes": {
           "type": "array",
           "minItems": 1,
-          "items": { "enum": ["ReadWriteOnce", "ReadWriteMany", "ReadWriteOncePod"] }
+          "items": {
+            "enum": [
+              "ReadWriteOnce",
+              "ReadWriteMany",
+              "ReadWriteOncePod"
+            ]
+          }
         },
-        "size": { "type": "string", "pattern": "^[0-9]+(\\.[0-9]+)?(Ki|Mi|Gi|Ti|K|M|G|T)?$" },
-        "annotations": { "type": "object" }
+        "size": {
+          "type": "string",
+          "pattern": "^[0-9]+(\\.[0-9]+)?(Ki|Mi|Gi|Ti|K|M|G|T)?$"
+        },
+        "annotations": {
+          "type": "object"
+        }
       }
     },
-
-    "podSecurityContext": { "$ref": "#/definitions/podSecurityContext" },
-    "securityContext": { "$ref": "#/definitions/containerSecurityContext" },
-
+    "podSecurityContext": {
+      "$ref": "#/definitions/podSecurityContext"
+    },
+    "securityContext": {
+      "$ref": "#/definitions/containerSecurityContext"
+    },
     "planner": {
       "allOf": [
-        { "$ref": "#/definitions/schedulingCommon" },
+        {
+          "$ref": "#/definitions/schedulingCommon"
+        },
         {
           "type": "object",
           "properties": {
@@ -86,146 +150,351 @@
               "type": "integer",
               "const": 1
             },
-            "image": { "$ref": "#/definitions/image" },
-            "logLevel": { "$ref": "#/definitions/logLevel" },
-            "resyncPeriod": { "$ref": "#/definitions/duration" },
-            "healthPort": { "$ref": "#/definitions/port" },
+            "image": {
+              "$ref": "#/definitions/image"
+            },
+            "logLevel": {
+              "$ref": "#/definitions/logLevel"
+            },
+            "resyncPeriod": {
+              "$ref": "#/definitions/duration"
+            },
+            "healthPort": {
+              "$ref": "#/definitions/port"
+            },
             "watchNamespaces": {
               "description": "Namespaces the pod/PDB/ReplicaSet informers watch. Empty watches all.",
               "type": "array",
-              "items": { "type": "string", "minLength": 1 }
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
             },
-            "minNodeAge": { "$ref": "#/definitions/duration" },
-            "maxSteps": { "type": "integer", "minimum": 0 },
+            "minNodeAge": {
+              "$ref": "#/definitions/duration"
+            },
+            "maxSteps": {
+              "type": "integer",
+              "minimum": 0
+            },
             "excludeNamespaces": {
               "type": "array",
-              "items": { "type": "string", "minLength": 1 }
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
             },
-            "retainPlans": { "type": "integer", "minimum": 1 },
+            "retainPlans": {
+              "type": "integer",
+              "minimum": 1
+            },
             "impact": {
               "type": "object",
               "properties": {
-                "yellowPodsMoved": { "type": "integer", "minimum": 1 },
-                "redPodsMoved": { "type": "integer", "minimum": 1 },
-                "tightPDBHeadroom": { "type": "integer", "minimum": 0 }
+                "yellowPodsMoved": {
+                  "type": "integer",
+                  "minimum": 1
+                },
+                "redPodsMoved": {
+                  "type": "integer",
+                  "minimum": 1
+                },
+                "tightPDBHeadroom": {
+                  "type": "integer",
+                  "minimum": 0
+                }
               }
             },
-            "resources": { "$ref": "#/definitions/resources" },
-            "podDisruptionBudget": { "$ref": "#/definitions/pdb" }
+            "resources": {
+              "$ref": "#/definitions/resources"
+            },
+            "podDisruptionBudget": {
+              "$ref": "#/definitions/pdb"
+            }
           }
         }
       ]
     },
-
     "uiBackend": {
       "allOf": [
-        { "$ref": "#/definitions/schedulingCommon" },
+        {
+          "$ref": "#/definitions/schedulingCommon"
+        },
         {
           "type": "object",
           "properties": {
-            "replicaCount": { "type": "integer", "minimum": 1 },
-            "pollInterval": { "$ref": "#/definitions/duration" },
-            "image": { "$ref": "#/definitions/image" },
-            "logLevel": { "$ref": "#/definitions/logLevel" },
-            "service": { "$ref": "#/definitions/service" },
-            "resources": { "$ref": "#/definitions/resources" },
-            "podDisruptionBudget": { "$ref": "#/definitions/pdb" }
+            "replicaCount": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "pollInterval": {
+              "$ref": "#/definitions/duration"
+            },
+            "image": {
+              "$ref": "#/definitions/image"
+            },
+            "logLevel": {
+              "$ref": "#/definitions/logLevel"
+            },
+            "service": {
+              "$ref": "#/definitions/service"
+            },
+            "resources": {
+              "$ref": "#/definitions/resources"
+            },
+            "podDisruptionBudget": {
+              "$ref": "#/definitions/pdb"
+            }
           }
         }
       ]
     },
-
     "uiFrontend": {
       "allOf": [
-        { "$ref": "#/definitions/schedulingCommon" },
+        {
+          "$ref": "#/definitions/schedulingCommon"
+        },
         {
           "type": "object",
           "properties": {
-            "replicaCount": { "type": "integer", "minimum": 1 },
-            "image": { "$ref": "#/definitions/image" },
-            "service": { "$ref": "#/definitions/service" },
+            "replicaCount": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "image": {
+              "$ref": "#/definitions/image"
+            },
+            "service": {
+              "$ref": "#/definitions/service"
+            },
             "config": {
               "type": "object",
               "properties": {
-                "apiBaseUrl": { "type": "string" },
-                "kagentUrl": { "type": "string" }
+                "apiBaseUrl": {
+                  "type": "string"
+                },
+                "kagentUrl": {
+                  "type": "string"
+                }
               }
             },
-            "podSecurityContext": { "$ref": "#/definitions/podSecurityContext" },
-            "securityContext": { "$ref": "#/definitions/containerSecurityContext" },
-            "resources": { "$ref": "#/definitions/resources" },
-            "podDisruptionBudget": { "$ref": "#/definitions/pdb" }
+            "podSecurityContext": {
+              "$ref": "#/definitions/podSecurityContext"
+            },
+            "securityContext": {
+              "$ref": "#/definitions/containerSecurityContext"
+            },
+            "resources": {
+              "$ref": "#/definitions/resources"
+            },
+            "podDisruptionBudget": {
+              "$ref": "#/definitions/pdb"
+            }
           }
         }
       ]
     },
-
     "ingress": {
       "type": "object",
       "properties": {
-        "enabled": { "type": "boolean" },
-        "className": { "type": "string" },
-        "annotations": { "type": "object" },
+        "enabled": {
+          "type": "boolean"
+        },
+        "className": {
+          "type": "string"
+        },
+        "annotations": {
+          "type": "object"
+        },
         "hosts": {
           "type": "array",
           "items": {
             "type": "object",
-            "required": ["host", "paths"],
+            "required": [
+              "host",
+              "paths"
+            ],
             "properties": {
-              "host": { "type": "string", "minLength": 1 },
+              "host": {
+                "type": "string",
+                "minLength": 1
+              },
               "paths": {
                 "type": "array",
                 "minItems": 1,
                 "items": {
                   "type": "object",
-                  "required": ["path", "pathType"],
+                  "required": [
+                    "path",
+                    "pathType"
+                  ],
                   "properties": {
-                    "path": { "type": "string", "minLength": 1 },
-                    "pathType": { "enum": ["Exact", "Prefix", "ImplementationSpecific"] }
+                    "path": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "pathType": {
+                      "enum": [
+                        "Exact",
+                        "Prefix",
+                        "ImplementationSpecific"
+                      ]
+                    }
                   }
                 }
               }
             }
           }
         },
-        "tls": { "type": "array", "items": { "type": "object" } }
+        "tls": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        }
       }
     },
-
     "networkPolicy": {
       "type": "object",
       "properties": {
-        "enabled": { "type": "boolean" },
-        "extraIngressFrom": { "type": "array", "items": { "type": "object" } }
+        "enabled": {
+          "type": "boolean"
+        },
+        "extraIngressFrom": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        }
       }
     },
-
+    "auth": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "anonymousRead": {
+          "type": "boolean"
+        },
+        "audiences": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "mcpRequireToken": {
+          "type": "boolean"
+        },
+        "oidc": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "issuerUrl": {
+              "type": "string",
+              "$comment": "Must be the same issuer the API server trusts via --oidc-issuer-url.",
+              "anyOf": [
+                {
+                  "const": ""
+                },
+                {
+                  "format": "uri",
+                  "pattern": "^https://"
+                }
+              ]
+            },
+            "clientId": {
+              "type": "string"
+            },
+            "scopes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "trustedProxy": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "userHeader": {
+              "type": "string"
+            },
+            "groupsHeader": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
     "serviceMonitor": {
       "type": "object",
       "properties": {
-        "enabled": { "type": "boolean" },
-        "interval": { "$ref": "#/definitions/duration" },
-        "scrapeTimeout": { "$ref": "#/definitions/duration" },
-        "labels": { "type": "object" }
+        "enabled": {
+          "type": "boolean"
+        },
+        "interval": {
+          "$ref": "#/definitions/duration"
+        },
+        "scrapeTimeout": {
+          "$ref": "#/definitions/duration"
+        },
+        "labels": {
+          "type": "object"
+        }
       }
     },
-
     "kagent": {
       "type": "object",
       "properties": {
-        "enabled": { "type": "boolean" },
-        "namespace": { "type": "string" },
-        "modelConfig": { "type": "string", "minLength": 1 },
-        "runtime": { "enum": ["python", "declarative"] },
+        "enabled": {
+          "type": "boolean"
+        },
+        "namespace": {
+          "type": "string"
+        },
+        "modelConfig": {
+          "type": "string",
+          "minLength": 1
+        },
+        "runtime": {
+          "enum": [
+            "python",
+            "declarative"
+          ]
+        },
         "toolNames": {
           "type": "array",
           "minItems": 1,
-          "items": { "type": "string", "minLength": 1 }
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "authSecret": {
+          "type": "object",
+          "additionalProperties": false,
+          "$comment": "Secret in the Kagent namespace holding the whole Authorization header value.",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "key": {
+              "type": "string"
+            }
+          }
         }
       }
     }
   },
-
   "allOf": [
     {
       "$comment": "SQLite is a single-writer store on a ReadWriteOnce claim. More than one ui-backend replica risks database corruption, so the chart refuses to render it rather than letting it be discovered in production.",
@@ -233,11 +502,19 @@
         "properties": {
           "database": {
             "type": "object",
-            "properties": { "type": { "const": "sqlite" } },
-            "required": ["type"]
+            "properties": {
+              "type": {
+                "const": "sqlite"
+              }
+            },
+            "required": [
+              "type"
+            ]
           }
         },
-        "required": ["database"]
+        "required": [
+          "database"
+        ]
       },
       "then": {
         "properties": {
@@ -259,132 +536,349 @@
         "properties": {
           "persistence": {
             "type": "object",
-            "properties": { "enabled": { "const": false } },
-            "required": ["enabled"]
+            "properties": {
+              "enabled": {
+                "const": false
+              }
+            },
+            "required": [
+              "enabled"
+            ]
           }
         },
-        "required": ["persistence"]
+        "required": [
+          "persistence"
+        ]
       },
       "then": {
         "properties": {
           "persistence": {
             "type": "object",
-            "properties": { "existingClaim": { "const": "" } }
-          }
-        }
-      }
-    }
-  ],
-
-  "definitions": {
-    "logLevel": { "enum": ["debug", "info", "warn", "error"] },
-
-    "duration": {
-      "type": "string",
-      "pattern": "^[0-9]+(\\.[0-9]+)?(ns|us|ms|s|m|h)$"
-    },
-
-    "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
-
-    "image": {
-      "type": "object",
-      "properties": {
-        "registry": { "type": "string" },
-        "repository": { "type": "string", "minLength": 1 },
-        "tag": {
-          "description": "Empty defaults to the chart appVersion.",
-          "type": "string",
-          "not": { "const": "latest" }
-        },
-        "pullPolicy": {
-          "description": "Always is rejected: it makes rollouts depend on registry availability and defeats digest-stable deploys.",
-          "enum": ["IfNotPresent", "Never"]
-        }
-      },
-      "required": ["repository"]
-    },
-
-    "service": {
-      "type": "object",
-      "properties": {
-        "type": { "enum": ["ClusterIP", "NodePort", "LoadBalancer"] },
-        "port": { "$ref": "#/definitions/port" },
-        "annotations": { "type": "object" }
-      }
-    },
-
-    "resources": {
-      "type": "object",
-      "description": "Both requests and limits are required: an unbounded component on a shared cluster is not shippable.",
-      "required": ["requests", "limits"],
-      "properties": {
-        "requests": { "$ref": "#/definitions/resourceQuantities" },
-        "limits": { "$ref": "#/definitions/resourceQuantities" }
-      }
-    },
-
-    "resourceQuantities": {
-      "type": "object",
-      "required": ["cpu", "memory"],
-      "properties": {
-        "cpu": { "type": ["string", "number"] },
-        "memory": { "type": "string" }
-      }
-    },
-
-    "pdb": {
-      "type": "object",
-      "properties": {
-        "enabled": { "type": "boolean" },
-        "maxUnavailable": {
-          "description": "maxUnavailable only. A minAvailable PDB can make its own pods undrainable, which is the failure mode this product exists to detect.",
-          "type": ["integer", "string"]
-        }
-      }
-    },
-
-    "podSecurityContext": {
-      "type": "object",
-      "properties": {
-        "runAsNonRoot": { "const": true },
-        "runAsUser": { "type": "integer", "minimum": 1 },
-        "runAsGroup": { "type": "integer", "minimum": 1 },
-        "fsGroup": { "type": "integer", "minimum": 1 },
-        "seccompProfile": { "type": "object" }
-      }
-    },
-
-    "containerSecurityContext": {
-      "type": "object",
-      "properties": {
-        "readOnlyRootFilesystem": { "const": true },
-        "allowPrivilegeEscalation": { "const": false },
-        "privileged": { "const": false },
-        "capabilities": {
-          "type": "object",
-          "properties": {
-            "drop": {
-              "type": "array",
-              "contains": { "const": "ALL" }
+            "properties": {
+              "existingClaim": {
+                "const": ""
+              }
             }
           }
         }
       }
     },
-
+    {
+      "$comment": "OIDC sign-in cannot work without an issuer and a client ID. Rendering a half-configured issuer would produce a UI whose login button fails at the redirect, which is far harder to diagnose than a refused install.",
+      "if": {
+        "properties": {
+          "auth": {
+            "type": "object",
+            "properties": {
+              "oidc": {
+                "type": "object",
+                "properties": {
+                  "enabled": {
+                    "const": true
+                  }
+                },
+                "required": [
+                  "enabled"
+                ]
+              }
+            },
+            "required": [
+              "oidc"
+            ]
+          }
+        },
+        "required": [
+          "auth"
+        ]
+      },
+      "then": {
+        "properties": {
+          "auth": {
+            "type": "object",
+            "properties": {
+              "oidc": {
+                "type": "object",
+                "properties": {
+                  "issuerUrl": {
+                    "$comment": "auth.oidc.enabled=true requires auth.oidc.issuerUrl",
+                    "minLength": 1
+                  },
+                  "clientId": {
+                    "$comment": "auth.oidc.enabled=true requires auth.oidc.clientId",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "issuerUrl",
+                  "clientId"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "$comment": "A trusted proxy asserts identity through a header, so the header name is not optional. An empty one would silently disable the mechanism and leave every caller anonymous on an install that believes it has SSO.",
+      "if": {
+        "properties": {
+          "auth": {
+            "type": "object",
+            "properties": {
+              "trustedProxy": {
+                "type": "object",
+                "properties": {
+                  "enabled": {
+                    "const": true
+                  }
+                },
+                "required": [
+                  "enabled"
+                ]
+              }
+            },
+            "required": [
+              "trustedProxy"
+            ]
+          }
+        },
+        "required": [
+          "auth"
+        ]
+      },
+      "then": {
+        "properties": {
+          "auth": {
+            "type": "object",
+            "properties": {
+              "trustedProxy": {
+                "type": "object",
+                "properties": {
+                  "userHeader": {
+                    "$comment": "auth.trustedProxy.enabled=true requires auth.trustedProxy.userHeader",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "userHeader"
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  ],
+  "definitions": {
+    "logLevel": {
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "error"
+      ]
+    },
+    "duration": {
+      "type": "string",
+      "pattern": "^[0-9]+(\\.[0-9]+)?(ns|us|ms|s|m|h)$"
+    },
+    "port": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 65535
+    },
+    "image": {
+      "type": "object",
+      "properties": {
+        "registry": {
+          "type": "string"
+        },
+        "repository": {
+          "type": "string",
+          "minLength": 1
+        },
+        "tag": {
+          "description": "Empty defaults to the chart appVersion.",
+          "type": "string",
+          "not": {
+            "const": "latest"
+          }
+        },
+        "pullPolicy": {
+          "description": "Always is rejected: it makes rollouts depend on registry availability and defeats digest-stable deploys.",
+          "enum": [
+            "IfNotPresent",
+            "Never"
+          ]
+        }
+      },
+      "required": [
+        "repository"
+      ]
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "ClusterIP",
+            "NodePort",
+            "LoadBalancer"
+          ]
+        },
+        "port": {
+          "$ref": "#/definitions/port"
+        },
+        "annotations": {
+          "type": "object"
+        }
+      }
+    },
+    "resources": {
+      "type": "object",
+      "description": "Both requests and limits are required: an unbounded component on a shared cluster is not shippable.",
+      "required": [
+        "requests",
+        "limits"
+      ],
+      "properties": {
+        "requests": {
+          "$ref": "#/definitions/resourceQuantities"
+        },
+        "limits": {
+          "$ref": "#/definitions/resourceQuantities"
+        }
+      }
+    },
+    "resourceQuantities": {
+      "type": "object",
+      "required": [
+        "cpu",
+        "memory"
+      ],
+      "properties": {
+        "cpu": {
+          "type": [
+            "string",
+            "number"
+          ]
+        },
+        "memory": {
+          "type": "string"
+        }
+      }
+    },
+    "pdb": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "maxUnavailable": {
+          "description": "maxUnavailable only. A minAvailable PDB can make its own pods undrainable, which is the failure mode this product exists to detect.",
+          "type": [
+            "integer",
+            "string"
+          ]
+        }
+      }
+    },
+    "podSecurityContext": {
+      "type": "object",
+      "properties": {
+        "runAsNonRoot": {
+          "const": true
+        },
+        "runAsUser": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "runAsGroup": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "fsGroup": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "seccompProfile": {
+          "type": "object"
+        }
+      }
+    },
+    "containerSecurityContext": {
+      "type": "object",
+      "properties": {
+        "readOnlyRootFilesystem": {
+          "const": true
+        },
+        "allowPrivilegeEscalation": {
+          "const": false
+        },
+        "privileged": {
+          "const": false
+        },
+        "capabilities": {
+          "type": "object",
+          "properties": {
+            "drop": {
+              "type": "array",
+              "contains": {
+                "const": "ALL"
+              }
+            }
+          }
+        }
+      }
+    },
     "schedulingCommon": {
       "type": "object",
       "properties": {
-        "podAnnotations": { "type": "object" },
-        "podLabels": { "type": "object" },
-        "nodeSelector": { "type": "object" },
-        "tolerations": { "type": "array", "items": { "type": "object" } },
-        "affinity": { "type": "object" },
-        "topologySpreadConstraints": { "type": "array", "items": { "type": "object" } },
-        "priorityClassName": { "type": "string" },
-        "extraEnv": { "type": "array", "items": { "type": "object" } },
-        "extraVolumes": { "type": "array", "items": { "type": "object" } },
-        "extraVolumeMounts": { "type": "array", "items": { "type": "object" } }
+        "podAnnotations": {
+          "type": "object"
+        },
+        "podLabels": {
+          "type": "object"
+        },
+        "nodeSelector": {
+          "type": "object"
+        },
+        "tolerations": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "affinity": {
+          "type": "object"
+        },
+        "topologySpreadConstraints": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "priorityClassName": {
+          "type": "string"
+        },
+        "extraEnv": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "extraVolumes": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "extraVolumeMounts": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        }
       }
     }
   }

--- a/charts/k8s-dencer/values.yaml
+++ b/charts/k8s-dencer/values.yaml
@@ -256,9 +256,96 @@ ingress:
 
 networkPolicy:
   # Restricts ui-backend ingress to the frontend and (when enabled) Kagent.
-  enabled: false
+  #
+  # On by default. The policy is ingress-only: egress to the API server cannot
+  # be expressed portably (it needs an ipBlock for the endpoint, or a
+  # cluster-wide CIDR), and restricting inbound traffic is where the value is.
+  #
+  # Harmless on clusters whose CNI does not enforce NetworkPolicy — the object
+  # is simply inert. Worth knowing, though, because it means this being on is
+  # not proof that anything is being enforced.
+  enabled: true
   # Extra selectors allowed to reach ui-backend, e.g. a Prometheus namespace.
   extraIngressFrom: []
+
+# Authentication and authorization for the API.
+#
+# k8s-dencer owns no credential store. A caller presents a token, ui-backend
+# validates it with a TokenReview, and permission is decided by a
+# SubjectAccessReview — so "who may see the plan" and "who may drain a node"
+# are ordinary RoleBindings that compose with whatever your cluster already
+# uses.
+#
+# The chart ships two unbound ClusterRoles to bind:
+#   <release>-viewer                  — may read plans
+#   <release>-consolidation-operator  — may read plans and execute steps
+auth:
+  # On by default. This service reports where a cluster's spare capacity is,
+  # and from the next release it accepts execution requests.
+  enabled: true
+
+  # Permit unauthenticated GETs. Never covers execution, whatever this is set
+  # to. Reasonable behind a trusted network boundary; not a good default.
+  anonymousRead: false
+
+  # Restricts acceptable token audiences. Empty means the API server's own,
+  # which is usually right: for an OIDC ID token the audience is the client ID
+  # the API server was configured with, so the check is already being made by
+  # the party best placed to make it.
+  audiences: []
+
+  # Single sign-on.
+  #
+  # When your API server runs with --oidc-issuer-url, an ID token from that
+  # issuer is ALREADY a Kubernetes credential — the TokenReview above will
+  # validate it and return the user's IdP groups. So SSO costs a redirect flow
+  # in the browser and nothing on the server: no session store, no user
+  # database, no client secret.
+  #
+  # Set issuerUrl to the SAME issuer the API server trusts. A different one
+  # will authenticate the user in the browser and then be rejected here, which
+  # is a confusing way to fail.
+  #
+  # Unavailable on clusters whose API server cannot validate a third-party
+  # token (EKS with IAM auth, GKE with Google auth) — use trustedProxy there.
+  oidc:
+    enabled: false
+    issuerUrl: ""
+    # A public client using Authorization Code + PKCE. There is no secret,
+    # because a secret shipped to a browser is not a secret.
+    clientId: ""
+    scopes:
+      - openid
+      - profile
+      - email
+      - groups
+
+  # Accept an identity asserted by an upstream auth proxy (oauth2-proxy,
+  # Ingress auth, a service mesh) instead of validating a token.
+  #
+  # OFF, and while it is off these headers are IGNORED — a request carrying
+  # them is anonymous, not trusted. Turning it on means anything that can reach
+  # ui-backend can claim to be anyone, so it is only as strong as the network
+  # path: keep networkPolicy.enabled on and make sure the proxy cannot be
+  # bypassed.
+  trustedProxy:
+    enabled: false
+    userHeader: X-Forwarded-User
+    groupsHeader: X-Forwarded-Groups
+
+  # Require a token on the MCP endpoint the Kagent agent calls.
+  #
+  # Verified working against Kagent 0.9.12: set kagent.authSecret and the agent
+  # presents a bearer token via RemoteMCPServer's headersFrom.
+  #
+  # Off only because turning it on needs a secret you create and rotate — see
+  # kagent.authSecret. Turn it on if you can: many CNIs (k3s's default among
+  # them) accept NetworkPolicy objects without enforcing them, and where that
+  # is true this token is the ONLY control on the endpoint.
+  #
+  # The surface is read-only either way — four read tools, and a test fails if
+  # a fifth ever appears.
+  mcpRequireToken: false
 
 serviceMonitor:
   # Requires the Prometheus Operator CRDs.
@@ -282,3 +369,21 @@ kagent:
     - explain_step
     - get_node_constraints
     - why_not_drained
+
+  # Bearer token for the MCP endpoint, when auth.mcpRequireToken is on.
+  #
+  # Kagent's RemoteMCPServer supports headersFrom, so the agent can present a
+  # credential — but the secret is yours to create and rotate. The chart will
+  # not mint it, because the only way to do that declaratively is a
+  # non-expiring ServiceAccount token Secret, and a permanent credential is a
+  # poor default. The README has a TokenRequest recipe.
+  #
+  # The value must be the ENTIRE header, "Bearer eyJ...", not just the token:
+  # Kagent substitutes it verbatim.
+  #
+  # Worth reading if you rely on networkPolicy instead: many CNIs (k3s's
+  # default among them) accept NetworkPolicy objects without enforcing them,
+  # in which case this token is the only real control on the endpoint.
+  authSecret: {}
+  #  name: dencer-mcp-token
+  #  key: authorization

--- a/cmd/ui-backend/main.go
+++ b/cmd/ui-backend/main.go
@@ -13,11 +13,16 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
+	"k8s.io/client-go/kubernetes"
+	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
+
 	"github.com/atedgimo/k8s-dencer/internal/api/agenttools"
 	"github.com/atedgimo/k8s-dencer/internal/api/rest"
+	"github.com/atedgimo/k8s-dencer/internal/auth"
 	"github.com/atedgimo/k8s-dencer/internal/httpserver"
 	sqlitestore "github.com/atedgimo/k8s-dencer/internal/store/sqlite"
 	"github.com/atedgimo/k8s-dencer/internal/telemetry"
@@ -59,7 +64,13 @@ func run(ctx context.Context, log *slog.Logger) error {
 	}
 	log.Info("plan store ready", "path", path)
 
-	api := rest.New(db, log, version)
+	authCfg := authConfig()
+	guard, err := buildGuard(authCfg, log)
+	if err != nil {
+		return err
+	}
+
+	api := rest.New(db, log, version, guard, authCfg.Describe())
 
 	health := &httpserver.Health{}
 	mux := http.NewServeMux()
@@ -70,8 +81,18 @@ func run(ctx context.Context, log *slog.Logger) error {
 	// the ui-backend rather than shipped as its own image because the agent
 	// itself runs inside Kagent — architecture doc §5 — so all we owe it is a
 	// tool endpoint.
-	mux.Handle("/mcp", agenttools.New(db, log, version).Handler())
-	mux.Handle("/mcp/", agenttools.New(db, log, version).Handler())
+	//
+	// Whether a token is demanded here is separate from the rest of the API.
+	// Kagent's RemoteMCPServer does not necessarily forward one, so the
+	// primary control on this surface is the chart's NetworkPolicy, which
+	// admits only the Kagent namespace. The surface stays read-only either way
+	// — a test asserts it exposes exactly four read tools and no fifth.
+	var mcpHandler http.Handler = agenttools.New(db, log, version).Handler()
+	if boolEnv("AUTH_MCP_REQUIRE_TOKEN", false) {
+		mcpHandler = guard.Require(auth.ReadPlans, mcpHandler)
+	}
+	mux.Handle("/mcp", mcpHandler)
+	mux.Handle("/mcp/", mcpHandler)
 
 	// Change detection is a poll of the latest plan ID rather than an event
 	// feed: the planner is a separate process reached only through the shared
@@ -85,6 +106,70 @@ func run(ctx context.Context, log *slog.Logger) error {
 	return httpserver.Run(ctx, log, env("HTTP_ADDR", ":8080"), mux)
 }
 
+// authConfig reads the authentication configuration the chart supplies.
+//
+// Enabled defaults to true: a component that answers questions about where a
+// cluster's capacity is should not be open by default, and from M10 the same
+// service accepts execution requests.
+func authConfig() auth.Config {
+	return auth.Config{
+		Enabled:            boolEnv("AUTH_ENABLED", true),
+		AllowAnonymousRead: boolEnv("AUTH_ANONYMOUS_READ", false),
+		Audiences:          listEnv("AUTH_AUDIENCES"),
+		Namespace:          env("POD_NAMESPACE", ""),
+		OperatorRoleName:   env("AUTH_OPERATOR_ROLE", ""),
+		TokenCacheTTL:      auth.DefaultTokenCacheTTL,
+		OIDC: auth.OIDCInfo{
+			Enabled:   boolEnv("AUTH_OIDC_ENABLED", false),
+			IssuerURL: env("AUTH_OIDC_ISSUER_URL", ""),
+			ClientID:  env("AUTH_OIDC_CLIENT_ID", ""),
+			Scopes:    listEnv("AUTH_OIDC_SCOPES"),
+		},
+		TrustedProxy: auth.TrustedProxy{
+			Enabled:      boolEnv("AUTH_TRUSTED_PROXY_ENABLED", false),
+			UserHeader:   env("AUTH_TRUSTED_PROXY_USER_HEADER", "X-Forwarded-User"),
+			GroupsHeader: env("AUTH_TRUSTED_PROXY_GROUPS_HEADER", "X-Forwarded-Groups"),
+		},
+	}
+}
+
+// buildGuard wires the middleware. When auth is disabled no Kubernetes client
+// is built at all, so the binary still runs outside a cluster for development.
+func buildGuard(cfg auth.Config, log *slog.Logger) (*auth.Middleware, error) {
+	if !cfg.Enabled {
+		log.Warn("authentication is DISABLED; every caller is anonymous")
+		return auth.NewMiddleware(nil, nil, cfg, log), nil
+	}
+
+	restCfg, err := ctrlconfig.GetConfig()
+	if err != nil {
+		return nil, err
+	}
+	client, err := kubernetes.NewForConfig(restCfg)
+	if err != nil {
+		return nil, err
+	}
+
+	if cfg.TrustedProxy.Enabled {
+		// Worth a loud line in the log: from here on, anything that can reach
+		// this port can assert an identity, and only the NetworkPolicy stops it.
+		log.Warn("trusting proxy-asserted identity headers",
+			"userHeader", cfg.TrustedProxy.UserHeader,
+			"note", "ui-backend must be reachable only through the auth proxy")
+	}
+	log.Info("authentication enabled",
+		"namespace", cfg.Namespace,
+		"anonymousRead", cfg.AllowAnonymousRead,
+		"oidc", cfg.OIDC.Enabled)
+
+	return auth.NewMiddleware(
+		auth.NewAuthenticator(client, cfg),
+		auth.NewAuthorizer(client, cfg.Namespace),
+		cfg,
+		log,
+	), nil
+}
+
 type errUnsupportedDatabase string
 
 func (e errUnsupportedDatabase) Error() string {
@@ -96,6 +181,35 @@ func env(key, fallback string) string {
 		return v
 	}
 	return fallback
+}
+
+// boolEnv reads a boolean setting. An unparseable value takes the fallback,
+// which for security settings is the safe end: a typo in AUTH_ENABLED leaves
+// authentication on rather than silently opening the API.
+func boolEnv(key string, fallback bool) bool {
+	raw, ok := os.LookupEnv(key)
+	if !ok || raw == "" {
+		return fallback
+	}
+	v, err := strconv.ParseBool(raw)
+	if err != nil {
+		return fallback
+	}
+	return v
+}
+
+func listEnv(key string) []string {
+	raw := os.Getenv(key)
+	if raw == "" {
+		return nil
+	}
+	var out []string
+	for _, part := range strings.Split(raw, ",") {
+		if part = strings.TrimSpace(part); part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
 }
 
 func duration(log *slog.Logger, key string, fallback time.Duration) time.Duration {

--- a/hack/lint-chart.sh
+++ b/hack/lint-chart.sh
@@ -84,6 +84,78 @@ for profile in defaults minimal production orbstack; do
 done
 green "  no profile grants pods/eviction"
 
+bold "==> contract: no duplicate env keys in any container"
+# kubeconform passes duplicate env names and so does helm template — a
+# duplicate is valid YAML and a valid PodSpec on paper. The API server rejects
+# it on server-side apply, so without this check the failure lands at deploy
+# time on a build that linted clean.
+for profile in defaults minimal production orbstack; do
+  dupes="$(render "$profile" \
+    | awk '
+        /^[[:space:]]*- name: [A-Z_][A-Z0-9_]*$/ && in_env {
+          gsub(/^[[:space:]]*- name: /, ""); print indent_key "/" $0; next
+        }
+        /^[[:space:]]*env:[[:space:]]*$/ { in_env = 1; next }
+        /^[[:space:]]*(volumeMounts|ports|resources|args|command|livenessProbe|readinessProbe|startupProbe|securityContext):[[:space:]]*$/ { in_env = 0 }
+        /^[[:space:]]*- name: / && !in_env { indent_key = $0; sub(/^[[:space:]]*- name: /, "", indent_key) }
+      ' \
+    | sort | uniq -d)"
+  [[ -z "$dupes" ]] || fail "$profile declares duplicate env keys: $dupes"
+done
+green "  env keys unique in every container"
+
+bold "==> contract: authentication is on unless a profile deliberately opts out"
+for profile in defaults production orbstack; do
+  render "$profile" | grep -q 'name: AUTH_ENABLED' \
+    || fail "$profile does not configure AUTH_ENABLED at all"
+  # The env var is rendered from .Values.auth.enabled; "false" here means the
+  # profile shipped an unauthenticated API.
+  if render "$profile" | grep -A1 'name: AUTH_ENABLED' | grep -q 'value: "false"'; then
+    fail "$profile disables authentication"
+  fi
+done
+green "  defaults, production and orbstack all authenticate"
+
+bold "==> contract: ui-backend can delegate authn, and only ui-backend can"
+delegator="$(render defaults | awk '/name: dencer-k8s-dencer-auth-delegator/,/^---/')"
+grep -q 'system:auth-delegator' <<<"$delegator" \
+  || fail "ui-backend is not bound to system:auth-delegator; TokenReview will 403"
+grep -q 'name: dencer-k8s-dencer-ui-backend' <<<"$delegator" \
+  || fail "the auth-delegator binding does not name the ui-backend ServiceAccount"
+if grep -q 'name: dencer-k8s-dencer-planner' <<<"$delegator"; then
+  fail "the planner is bound to system:auth-delegator; it never authenticates anyone"
+fi
+green "  system:auth-delegator scoped to ui-backend"
+
+bold "==> contract: the operator ClusterRole ships unbound"
+if render defaults | grep -q 'name: dencer-k8s-dencer-consolidation-operator' ; then
+  # Present as a ClusterRole, but nothing may bind it: who is allowed to drain
+  # nodes is the cluster owner's decision, not the chart's.
+  bindings="$(render defaults | awk '/^kind: (Cluster)?RoleBinding/,/^---/' \
+                | grep -c 'name: dencer-k8s-dencer-consolidation-operator' || true)"
+  [[ "$bindings" == "0" ]] \
+    || fail "the chart binds the consolidation-operator role to someone; it must ship unbound"
+else
+  fail "the consolidation-operator ClusterRole is missing"
+fi
+green "  shipped, unbound"
+
+bold "==> contract: NetworkPolicy defends ui-backend by default"
+render defaults | grep -q 'kind: NetworkPolicy' \
+  || fail "defaults render no NetworkPolicy; ui-backend is reachable from any pod"
+# Ingress-only on purpose: egress to the API server needs an ipBlock for the
+# endpoint or a cluster-wide CIDR, neither of which is portable.
+if render defaults | awk '/kind: NetworkPolicy/,/^---/' | grep -q '^\s*- Egress'; then
+  fail "the NetworkPolicy restricts egress; that cannot be expressed portably"
+fi
+green "  ingress-only policy present by default"
+
+bold "==> contract: OIDC cannot be half-configured"
+if helm template dencer "$CHART" --set auth.oidc.enabled=true >/dev/null 2>&1; then
+  fail "schema accepted auth.oidc.enabled=true with no issuerUrl or clientId"
+fi
+green "  rejected as expected"
+
 bold "==> contract: SQLite guard rejects a second ui-backend replica"
 if helm template dencer "$CHART" \
      --set database.type=sqlite \

--- a/internal/api/rest/guarded_test.go
+++ b/internal/api/rest/guarded_test.go
@@ -1,0 +1,134 @@
+package rest_test
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// openRoutes are the only endpoints permitted to bypass the guard.
+//
+// /api/v1/authinfo has to be open: a client cannot present a credential until
+// it knows which issuer to get one from, and the answer is public by
+// construction — an issuer URL and a public OIDC client ID.
+var openRoutes = map[string]bool{
+	"GET /api/v1/authinfo": true,
+}
+
+// Every route must go through the guard.
+//
+// Checked against the source rather than by probing, because probing can only
+// find routes a test already knows about — and the failure that matters is
+// somebody adding a route and not thinking about auth at all. Routes registers
+// guarded endpoints through the read() helper, which builds its pattern by
+// concatenation; anything handed a plain string literal went straight onto the
+// mux and skipped the guard.
+//
+// From M10 this file is what stops an execute route shipping unauthenticated,
+// which is the single worst mistake available in this codebase.
+func TestEveryRouteIsGuarded(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "rest.go", nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	routes := findRoutesMethod(t, file)
+
+	var direct []string
+	ast.Inspect(routes, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok || len(call.Args) == 0 {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		recv, ok := sel.X.(*ast.Ident)
+		if !ok || recv.Name != "mux" {
+			return true
+		}
+		if sel.Sel.Name != "Handle" && sel.Sel.Name != "HandleFunc" {
+			return true
+		}
+		// A plain string literal means the pattern was registered inline. The
+		// read() helper concatenates, so its calls are BinaryExprs and are not
+		// collected here.
+		lit, ok := call.Args[0].(*ast.BasicLit)
+		if !ok || lit.Kind != token.STRING {
+			return true
+		}
+		pattern, err := strconv.Unquote(lit.Value)
+		if err != nil {
+			t.Fatalf("unparseable route pattern %s", lit.Value)
+		}
+		direct = append(direct, pattern)
+		return true
+	})
+
+	for _, pattern := range direct {
+		if !openRoutes[pattern] {
+			t.Errorf("route %q is registered directly on the mux and is therefore unauthenticated.\n"+
+				"Register it through the read() helper, or add it to openRoutes with a comment "+
+				"explaining why it is safe to serve without credentials.", pattern)
+		}
+	}
+
+	// The converse: if authinfo stops being registered we would never notice,
+	// because the loop above only rejects. A UI that cannot discover the issuer
+	// cannot sign in.
+	found := false
+	for _, p := range direct {
+		if p == "GET /api/v1/authinfo" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("GET /api/v1/authinfo is no longer served openly; clients cannot discover how to sign in")
+	}
+}
+
+func findRoutesMethod(t *testing.T, file *ast.File) *ast.FuncDecl {
+	t.Helper()
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if ok && fn.Name.Name == "Routes" && fn.Recv != nil {
+			return fn
+		}
+	}
+	t.Fatal("no Routes method found in rest.go; this test needs updating")
+	return nil
+}
+
+// authinfo must stay free of anything an unauthenticated caller should not
+// have. It exists to bootstrap a login, not to describe the deployment.
+func TestAuthInfoLeaksNothingSensitive(t *testing.T) {
+	srv := testServer(t)
+
+	res, err := http.Get(srv.URL + "/api/v1/authinfo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = res.Body.Close() }()
+
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("authinfo must be reachable without credentials, got %d", res.StatusCode)
+	}
+
+	raw, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(raw)
+	for _, forbidden := range []string{"secret", "Secret", "password", "Password", "bearer", "Bearer"} {
+		if strings.Contains(body, forbidden) {
+			t.Errorf("authinfo mentions %q, which suggests a credential leaked in:\n%s", forbidden, body)
+		}
+	}
+}

--- a/internal/api/rest/rest.go
+++ b/internal/api/rest/rest.go
@@ -3,6 +3,10 @@
 // Read-only by construction. Phase 1 has no executor, so there is no endpoint
 // that mutates anything — not even a disabled one. The absence is the
 // guarantee; a "not implemented" execute route would be an invitation.
+//
+// Every route except /api/v1/authinfo sits behind a Guard. authinfo is
+// deliberately open: a client cannot sign in without first learning where to
+// sign in, and the answer contains only public values.
 package rest
 
 import (
@@ -16,22 +20,42 @@ import (
 	"time"
 
 	"github.com/atedgimo/k8s-dencer/internal/api/graph"
+	"github.com/atedgimo/k8s-dencer/internal/auth"
 	"github.com/atedgimo/k8s-dencer/internal/constraints"
 	"github.com/atedgimo/k8s-dencer/internal/model"
 	"github.com/atedgimo/k8s-dencer/internal/store"
 )
 
-// Server serves the API over a plan store.
-type Server struct {
-	store   store.Store
-	log     *slog.Logger
-	version string
-	events  *Broker
+// Guard authorizes a request before it reaches a handler.
+//
+// An interface rather than *auth.Middleware so that a disabled configuration
+// and an enabled one take the same code path — there is no nil case to forget
+// to handle, and no route can accidentally be registered unguarded.
+type Guard interface {
+	Require(res auth.Resource, next http.Handler) http.Handler
 }
 
-// New builds a server.
-func New(s store.Store, log *slog.Logger, version string) *Server {
-	return &Server{store: s, log: log, version: version, events: NewBroker(log)}
+// Server serves the API over a plan store.
+type Server struct {
+	store    store.Store
+	log      *slog.Logger
+	version  string
+	events   *Broker
+	guard    Guard
+	authInfo auth.Info
+}
+
+// New builds a server. guard authorizes every route; authInfo is published
+// unauthenticated so a client knows how to sign in.
+func New(s store.Store, log *slog.Logger, version string, guard Guard, authInfo auth.Info) *Server {
+	return &Server{
+		store:    s,
+		log:      log,
+		version:  version,
+		events:   NewBroker(log),
+		guard:    guard,
+		authInfo: authInfo,
+	}
 }
 
 // Events exposes the broker so the poller can publish plan changes.
@@ -39,16 +63,33 @@ func (s *Server) Events() *Broker { return s.events }
 
 // Routes registers every endpoint on mux.
 func (s *Server) Routes(mux *http.ServeMux) {
-	mux.HandleFunc("GET /api/v1/version", s.handleVersion)
-	mux.HandleFunc("GET /api/v1/plans", s.handleListPlans)
-	mux.HandleFunc("GET /api/v1/plans/latest", s.handleLatestPlan)
-	mux.HandleFunc("GET /api/v1/plans/{id}", s.handlePlan)
-	mux.HandleFunc("GET /api/v1/plans/{id}/steps/{seq}", s.handleStep)
-	mux.HandleFunc("GET /api/v1/plans/{id}/graph", s.handleGraph)
-	mux.HandleFunc("GET /api/v1/plans/{id}/snapshot", s.handleSnapshot)
-	mux.HandleFunc("GET /api/v1/plans/{id}/constraints", s.handleConstraints)
-	mux.HandleFunc("GET /api/v1/plans/{id}/constraints/{namespace}/{pod}", s.handlePodConstraints)
-	mux.HandleFunc("GET /api/v1/events", s.events.ServeHTTP)
+	read := func(pattern string, h http.HandlerFunc) {
+		mux.Handle("GET "+pattern, s.guard.Require(auth.ReadPlans, h))
+	}
+
+	// The one open route. It reveals the issuer URL and public client ID a
+	// caller needs in order to authenticate, and nothing else.
+	mux.HandleFunc("GET /api/v1/authinfo", s.handleAuthInfo)
+
+	read("/api/v1/version", s.handleVersion)
+	read("/api/v1/plans", s.handleListPlans)
+	read("/api/v1/plans/latest", s.handleLatestPlan)
+	read("/api/v1/plans/{id}", s.handlePlan)
+	read("/api/v1/plans/{id}/steps/{seq}", s.handleStep)
+	read("/api/v1/plans/{id}/graph", s.handleGraph)
+	read("/api/v1/plans/{id}/snapshot", s.handleSnapshot)
+	read("/api/v1/plans/{id}/constraints", s.handleConstraints)
+	read("/api/v1/plans/{id}/constraints/{namespace}/{pod}", s.handlePodConstraints)
+
+	// The event stream carries plan data, so it is guarded like any other
+	// read. EventSource cannot send an Authorization header, which is why the
+	// frontend consumes this with fetch streaming instead — putting the token
+	// in a query string would write it to every access log in the path.
+	read("/api/v1/events", s.events.ServeHTTP)
+}
+
+func (s *Server) handleAuthInfo(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, s.authInfo)
 }
 
 func (s *Server) handleVersion(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/rest/rest_test.go
+++ b/internal/api/rest/rest_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/atedgimo/k8s-dencer/internal/api/rest"
+	"github.com/atedgimo/k8s-dencer/internal/auth"
 	"github.com/atedgimo/k8s-dencer/internal/constraints"
 	"github.com/atedgimo/k8s-dencer/internal/model"
 	"github.com/atedgimo/k8s-dencer/internal/store"
@@ -35,7 +36,12 @@ func testServer(t *testing.T, records ...store.Record) *httptest.Server {
 		}
 	}
 
-	api := rest.New(db, slog.New(slog.DiscardHandler), "test")
+	// Auth disabled: these tests cover the read API's behaviour, and the guard
+	// has its own suite in internal/auth. A disabled middleware is the real
+	// type on a transparent path, not a stub, so the wiring is still exercised.
+	guard := auth.NewMiddleware(nil, nil, auth.Config{Enabled: false}, slog.New(slog.DiscardHandler))
+
+	api := rest.New(db, slog.New(slog.DiscardHandler), "test", guard, auth.Config{Enabled: false}.Describe())
 	mux := http.NewServeMux()
 	api.Routes(mux)
 	srv := httptest.NewServer(mux)

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -1,0 +1,200 @@
+// Package auth authenticates and authorizes callers by delegating to
+// Kubernetes.
+//
+// We deliberately own no credential store. A caller proves who they are with a
+// token the API server already trusts, and "may this person drain a node?"
+// becomes an ordinary RoleBinding that composes with whatever the cluster
+// already uses — OIDC, IRSA, or plain ServiceAccount tokens.
+//
+// Three ways an identity can arrive, all converging on the same
+// SubjectAccessReview so that authorization is one code path:
+//
+//  1. A bearer token, validated by TokenReview. When the API server is
+//     configured with --oidc-issuer-url, an ID token from that issuer is
+//     already a Kubernetes credential, so SSO costs us nothing but a redirect
+//     flow in the browser.
+//  2. A header from a trusted auth proxy, for clusters whose API server cannot
+//     validate a third-party token (EKS with IAM auth, GKE with Google auth).
+//     Off by default; see TrustedProxy.
+//  3. Anonymous, permitted for reads only when explicitly configured.
+package auth
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+// Source records how an identity was established. It is carried into the audit
+// trail because "who drained this node" is a different question depending on
+// whether the answer came from a verified token or an asserted header.
+type Source string
+
+const (
+	SourceToken     Source = "token"
+	SourceProxy     Source = "proxy"
+	SourceAnonymous Source = "anonymous"
+)
+
+// Identity is an authenticated caller.
+type Identity struct {
+	Username string              `json:"username"`
+	UID      string              `json:"uid,omitempty"`
+	Groups   []string            `json:"groups,omitempty"`
+	Extra    map[string][]string `json:"extra,omitempty"`
+	Source   Source              `json:"source"`
+}
+
+// Anonymous is the identity of an unauthenticated caller. It is only ever
+// authorized when AllowAnonymousRead is set, and never for a mutation.
+var Anonymous = Identity{Username: "system:anonymous", Source: SourceAnonymous}
+
+// IsAnonymous reports whether no credential was presented.
+func (i Identity) IsAnonymous() bool { return i.Source == SourceAnonymous }
+
+// Resource names a permission to check.
+//
+// The group and resource strings need no CRD behind them: RBAC and
+// SubjectAccessReview match on strings, so an admin can grant
+// "create consolidations.dencer.io" against a resource that exists only as a
+// name. metrics-server and the Prometheus adapter lean on the same property.
+type Resource struct {
+	Group    string
+	Resource string
+	Verb     string
+}
+
+// The two permissions k8s-dencer checks. Read and execute are separate verbs on
+// separate resources so that "may look" and "may drain" can be granted to
+// different people — which is the entire point of putting this behind RBAC.
+var (
+	// ReadPlans guards the plan, graph and constraint endpoints.
+	ReadPlans = Resource{Group: "dencer.io", Resource: "plans", Verb: "get"}
+
+	// ExecuteConsolidations guards every route that can change the cluster.
+	// Nothing in Phase 1 uses it; it exists now so the executor lands in M10
+	// with its gate already built and tested.
+	ExecuteConsolidations = Resource{Group: "dencer.io", Resource: "consolidations", Verb: "create"}
+)
+
+// String renders a permission the way kubectl does, so a denial message can be
+// pasted more or less straight into a Role.
+func (r Resource) String() string {
+	return fmt.Sprintf("%s %s.%s", r.Verb, r.Resource, r.Group)
+}
+
+// TrustedProxy configures identity assertion by an upstream auth proxy
+// (oauth2-proxy, Ingress auth, a service mesh).
+//
+// Off by default, and the headers are ignored entirely while it is off — a
+// request carrying them is treated as anonymous rather than trusted. When it is
+// on, the headers are only as trustworthy as the network path, so the chart's
+// NetworkPolicy is what actually makes the proxy unbypassable.
+type TrustedProxy struct {
+	Enabled bool
+	// UserHeader carries the authenticated username, e.g. X-Forwarded-User.
+	UserHeader string
+	// GroupsHeader carries comma-separated groups, e.g. X-Forwarded-Groups.
+	// Optional: an IdP that asserts no groups still yields a usable identity.
+	GroupsHeader string
+}
+
+// Config is the authentication and authorization configuration.
+type Config struct {
+	// Enabled turns the whole mechanism on. When false every request runs as
+	// Anonymous and every check passes. The chart's schema refuses to combine
+	// that with an enabled executor.
+	Enabled bool
+
+	// AllowAnonymousRead permits unauthenticated GETs. It never applies to a
+	// mutation, whatever it is set to.
+	AllowAnonymousRead bool
+
+	// Audiences restricts which token audiences are acceptable. Empty means the
+	// API server's own audience, which is the right default: for an OIDC ID
+	// token the audience is the client ID the API server was configured with,
+	// so the check is already being made by the party best placed to make it.
+	Audiences []string
+
+	// Namespace scopes the SubjectAccessReview, so permission can be granted
+	// with a RoleBinding in the release namespace rather than cluster-wide.
+	Namespace string
+
+	// OperatorRoleName is the ClusterRole the chart ships carrying the execute
+	// permission. It appears in denial messages so a 403 can name the command
+	// that fixes it.
+	OperatorRoleName string
+
+	// TokenCacheTTL caches positive TokenReview results. The UI polls, and a
+	// round-trip to the API server per request is waste.
+	//
+	// Only authentication is cached, never authorization: a revoked RoleBinding
+	// must stop working immediately, and a cached "allowed" that outlives the
+	// grant is exactly the bug you cannot afford in the component that drains
+	// nodes.
+	TokenCacheTTL time.Duration
+
+	// OIDC describes the issuer the UI should sign in against. It is published
+	// verbatim to unauthenticated callers, so it must contain only public
+	// values — an issuer URL and a public client ID, never a client secret.
+	OIDC OIDCInfo
+
+	TrustedProxy TrustedProxy
+}
+
+// OIDCInfo is the public half of an OIDC client configuration.
+//
+// There is no client secret because the UI is a browser application using
+// Authorization Code with PKCE: a secret shipped to a browser is not a secret.
+type OIDCInfo struct {
+	Enabled   bool     `json:"enabled"`
+	IssuerURL string   `json:"issuerUrl,omitempty"`
+	ClientID  string   `json:"clientId,omitempty"`
+	Scopes    []string `json:"scopes,omitempty"`
+}
+
+// Info tells an unauthenticated client how to authenticate.
+//
+// Served openly and deliberately: a caller cannot sign in without knowing the
+// issuer, and every field here is public by construction. Publishing it from
+// the API rather than the frontend's ConfigMap keeps the two from drifting.
+type Info struct {
+	Enabled       bool     `json:"enabled"`
+	AnonymousRead bool     `json:"anonymousRead"`
+	OIDC          OIDCInfo `json:"oidc"`
+}
+
+// Describe renders the public description of this configuration.
+func (c Config) Describe() Info {
+	return Info{Enabled: c.Enabled, AnonymousRead: c.AllowAnonymousRead, OIDC: c.OIDC}
+}
+
+// DefaultTokenCacheTTL is short enough that a revoked token stops working
+// promptly and long enough to absorb the UI's polling.
+const DefaultTokenCacheTTL = 30 * time.Second
+
+// ErrNoCredentials means the caller presented nothing to authenticate with.
+var ErrNoCredentials = errors.New("no credentials presented")
+
+// InvalidTokenError means a token was presented and rejected. The reason is
+// deliberately not surfaced to the caller — it can distinguish "expired" from
+// "forged", which is more than an unauthenticated client should learn.
+type InvalidTokenError struct{ Reason string }
+
+func (e *InvalidTokenError) Error() string { return "invalid token: " + e.Reason }
+
+// DeniedError is an authorization failure carrying enough detail for an admin
+// to write the missing RoleBinding straight from the error text.
+type DeniedError struct {
+	Identity Identity
+	Resource Resource
+	Reason   string
+}
+
+func (e *DeniedError) Error() string {
+	msg := fmt.Sprintf("user %q cannot %s", e.Identity.Username, e.Resource)
+	if e.Reason != "" {
+		msg += ": " + e.Reason
+	}
+	return msg
+}

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -1,0 +1,452 @@
+package auth_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	authenticationv1 "k8s.io/api/authentication/v1"
+	authorizationv1 "k8s.io/api/authorization/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
+
+	"github.com/atedgimo/k8s-dencer/internal/auth"
+)
+
+// user is the identity a valid token resolves to throughout these tests.
+const validToken = "a-valid-token"
+
+var testUser = authenticationv1.UserInfo{
+	Username: "alice@example.com",
+	UID:      "uid-1",
+	Groups:   []string{"system:authenticated", "oidc:platform-sre"},
+}
+
+// clusterOpts configures the fake API server's answers.
+type clusterOpts struct {
+	authenticated map[string]authenticationv1.UserInfo // token -> user
+	allow         bool
+	denyReason    string
+	tokenErr      error
+	sarErr        error
+	tokenReviews  *atomic.Int32
+}
+
+func newCluster(t *testing.T, opts clusterOpts) *fake.Clientset {
+	t.Helper()
+	cs := fake.NewSimpleClientset()
+
+	cs.PrependReactor("create", "tokenreviews", func(a ktesting.Action) (bool, runtime.Object, error) {
+		if opts.tokenReviews != nil {
+			opts.tokenReviews.Add(1)
+		}
+		if opts.tokenErr != nil {
+			return true, nil, opts.tokenErr
+		}
+		tr := a.(ktesting.CreateAction).GetObject().(*authenticationv1.TokenReview)
+		user, ok := opts.authenticated[tr.Spec.Token]
+		if !ok {
+			tr.Status = authenticationv1.TokenReviewStatus{
+				Authenticated: false,
+				Error:         "token lookup failed",
+			}
+			return true, tr, nil
+		}
+		tr.Status = authenticationv1.TokenReviewStatus{Authenticated: true, User: user}
+		return true, tr, nil
+	})
+
+	cs.PrependReactor("create", "subjectaccessreviews", func(a ktesting.Action) (bool, runtime.Object, error) {
+		if opts.sarErr != nil {
+			return true, nil, opts.sarErr
+		}
+		sar := a.(ktesting.CreateAction).GetObject().(*authorizationv1.SubjectAccessReview)
+		sar.Status = authorizationv1.SubjectAccessReviewStatus{
+			Allowed: opts.allow,
+			Reason:  opts.denyReason,
+		}
+		return true, sar, nil
+	})
+
+	return cs
+}
+
+func guarded(t *testing.T, cs *fake.Clientset, cfg auth.Config, res auth.Resource) http.Handler {
+	t.Helper()
+	if cfg.Namespace == "" {
+		cfg.Namespace = "k8s-dencer"
+	}
+	m := auth.NewMiddleware(
+		auth.NewAuthenticator(cs, cfg),
+		auth.NewAuthorizer(cs, cfg.Namespace),
+		cfg,
+		slog.New(slog.DiscardHandler),
+	)
+	return m.Require(res, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id, _ := auth.IdentityFrom(r.Context())
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(id)
+	}))
+}
+
+func do(h http.Handler, mutate func(*http.Request)) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/plans/latest", nil)
+	if mutate != nil {
+		mutate(req)
+	}
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+func withToken(tok string) func(*http.Request) {
+	return func(r *http.Request) { r.Header.Set("Authorization", "Bearer "+tok) }
+}
+
+func enabled() auth.Config {
+	return auth.Config{Enabled: true, Namespace: "k8s-dencer"}
+}
+
+// The single most important test in this package. An operator who can reach
+// ui-backend directly must not be able to promote themselves by setting the
+// header an auth proxy would have set. While trustedProxy is off the header is
+// ignored outright, not merely unused.
+func TestForgedProxyHeaderIsIgnoredWhenTrustedProxyDisabled(t *testing.T) {
+	cfg := enabled()
+	cfg.TrustedProxy = auth.TrustedProxy{
+		Enabled:      false,
+		UserHeader:   "X-Forwarded-User",
+		GroupsHeader: "X-Forwarded-Groups",
+	}
+	cs := newCluster(t, clusterOpts{allow: true})
+
+	rec := do(guarded(t, cs, cfg, auth.ExecuteConsolidations), func(r *http.Request) {
+		r.Header.Set("X-Forwarded-User", "attacker")
+		r.Header.Set("X-Forwarded-Groups", "system:masters")
+	})
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("forged header was honoured: got %d, want 401\n%s", rec.Code, rec.Body)
+	}
+	// Even the SubjectAccessReview must not have been attempted — a cluster
+	// that happens to bind system:masters would otherwise allow the request.
+	for _, a := range cs.Actions() {
+		if a.GetResource().Resource == "subjectaccessreviews" {
+			t.Error("a forged header reached the authorizer; it must never get that far")
+		}
+	}
+}
+
+func TestTrustedProxyHeaderIsHonouredWhenEnabled(t *testing.T) {
+	cfg := enabled()
+	cfg.TrustedProxy = auth.TrustedProxy{
+		Enabled:      true,
+		UserHeader:   "X-Forwarded-User",
+		GroupsHeader: "X-Forwarded-Groups",
+	}
+	cs := newCluster(t, clusterOpts{allow: true})
+
+	rec := do(guarded(t, cs, cfg, auth.ExecuteConsolidations), func(r *http.Request) {
+		r.Header.Set("X-Forwarded-User", "bob@example.com")
+		r.Header.Set("X-Forwarded-Groups", "platform-sre, oncall")
+	})
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("got %d, want 200\n%s", rec.Code, rec.Body)
+	}
+	var id auth.Identity
+	if err := json.Unmarshal(rec.Body.Bytes(), &id); err != nil {
+		t.Fatal(err)
+	}
+	if id.Username != "bob@example.com" || id.Source != auth.SourceProxy {
+		t.Errorf("identity wrong: %+v", id)
+	}
+	// Groups drive the RoleBinding, so the split has to be right.
+	if len(id.Groups) != 2 || id.Groups[0] != "platform-sre" || id.Groups[1] != "oncall" {
+		t.Errorf("groups mis-parsed: %q", id.Groups)
+	}
+}
+
+// Both credentials present: the verifiable one must win over the asserted one.
+func TestBearerTokenBeatsProxyHeader(t *testing.T) {
+	cfg := enabled()
+	cfg.TrustedProxy = auth.TrustedProxy{Enabled: true, UserHeader: "X-Forwarded-User"}
+	cs := newCluster(t, clusterOpts{
+		authenticated: map[string]authenticationv1.UserInfo{validToken: testUser},
+		allow:         true,
+	})
+
+	rec := do(guarded(t, cs, cfg, auth.ReadPlans), func(r *http.Request) {
+		r.Header.Set("Authorization", "Bearer "+validToken)
+		r.Header.Set("X-Forwarded-User", "someone-else")
+	})
+
+	var id auth.Identity
+	_ = json.Unmarshal(rec.Body.Bytes(), &id)
+	if id.Username != testUser.Username || id.Source != auth.SourceToken {
+		t.Errorf("token should have won, got %+v", id)
+	}
+}
+
+func TestValidTokenCarriesOIDCGroupsThrough(t *testing.T) {
+	cs := newCluster(t, clusterOpts{
+		authenticated: map[string]authenticationv1.UserInfo{validToken: testUser},
+		allow:         true,
+	})
+
+	rec := do(guarded(t, cs, enabled(), auth.ExecuteConsolidations), withToken(validToken))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("got %d, want 200\n%s", rec.Code, rec.Body)
+	}
+
+	// The group claim is the whole point of OIDC passthrough: permission is
+	// granted to oidc:platform-sre, not to a list of usernames.
+	var sarGroups []string
+	for _, a := range cs.Actions() {
+		if c, ok := a.(ktesting.CreateAction); ok && a.GetResource().Resource == "subjectaccessreviews" {
+			sarGroups = c.GetObject().(*authorizationv1.SubjectAccessReview).Spec.Groups
+		}
+	}
+	if len(sarGroups) != 2 || sarGroups[1] != "oidc:platform-sre" {
+		t.Errorf("IdP groups did not reach the SubjectAccessReview: %q", sarGroups)
+	}
+}
+
+func TestSubjectAccessReviewAsksForTheDocumentedVerbs(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		res              auth.Resource
+		wantVerb, wantRe string
+	}{
+		{"read", auth.ReadPlans, "get", "plans"},
+		{"execute", auth.ExecuteConsolidations, "create", "consolidations"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cs := newCluster(t, clusterOpts{
+				authenticated: map[string]authenticationv1.UserInfo{validToken: testUser},
+				allow:         true,
+			})
+			do(guarded(t, cs, enabled(), tc.res), withToken(validToken))
+
+			var spec *authorizationv1.ResourceAttributes
+			for _, a := range cs.Actions() {
+				if c, ok := a.(ktesting.CreateAction); ok && a.GetResource().Resource == "subjectaccessreviews" {
+					spec = c.GetObject().(*authorizationv1.SubjectAccessReview).Spec.ResourceAttributes
+				}
+			}
+			if spec == nil {
+				t.Fatal("no SubjectAccessReview was created")
+			}
+			if spec.Verb != tc.wantVerb || spec.Resource != tc.wantRe || spec.Group != "dencer.io" {
+				t.Errorf("wrong permission checked: %+v", spec)
+			}
+			// Namespaced, so access can be granted with a RoleBinding rather
+			// than requiring a cluster-wide grant.
+			if spec.Namespace != "k8s-dencer" {
+				t.Errorf("SAR should be namespaced, got %q", spec.Namespace)
+			}
+		})
+	}
+}
+
+// A 403 has to be actionable. An operator reading it should learn the exact
+// verb they lack and the command that grants it.
+func TestForbiddenNamesThePermissionAndHowToGrantIt(t *testing.T) {
+	cfg := enabled()
+	cfg.OperatorRoleName = "dencer-consolidation-operator"
+	cs := newCluster(t, clusterOpts{
+		authenticated: map[string]authenticationv1.UserInfo{validToken: testUser},
+		allow:         false,
+		denyReason:    "no RoleBinding found",
+	})
+
+	rec := do(guarded(t, cs, cfg, auth.ExecuteConsolidations), withToken(validToken))
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("got %d, want 403", rec.Code)
+	}
+
+	var body struct {
+		Code      string            `json:"code"`
+		User      string            `json:"user"`
+		Required  map[string]string `json:"required"`
+		GrantWith string            `json:"grantWith"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body.Code != "forbidden" || body.User != testUser.Username {
+		t.Errorf("unexpected body: %+v", body)
+	}
+	if body.Required["verb"] != "create" || body.Required["resource"] != "consolidations" {
+		t.Errorf("denial does not name the permission: %+v", body.Required)
+	}
+	for _, want := range []string{"kubectl create rolebinding", "dencer-consolidation-operator", testUser.Username} {
+		if !strings.Contains(body.GrantWith, want) {
+			t.Errorf("grant hint missing %q: %s", want, body.GrantWith)
+		}
+	}
+}
+
+func TestMissingCredentialsAreUnauthorizedWithAChallenge(t *testing.T) {
+	cs := newCluster(t, clusterOpts{allow: true})
+	rec := do(guarded(t, cs, enabled(), auth.ReadPlans), nil)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("got %d, want 401", rec.Code)
+	}
+	if !strings.HasPrefix(rec.Header().Get("WWW-Authenticate"), "Bearer") {
+		t.Error("401 must carry a Bearer challenge so a client knows what to present")
+	}
+}
+
+func TestAnonymousReadIsOptInAndNeverCoversExecute(t *testing.T) {
+	cfg := enabled()
+	cfg.AllowAnonymousRead = true
+	cs := newCluster(t, clusterOpts{allow: true})
+
+	if got := do(guarded(t, cs, cfg, auth.ReadPlans), nil).Code; got != http.StatusOK {
+		t.Errorf("anonymous read: got %d, want 200", got)
+	}
+	// The critical half: allowing anonymous reads must not leak into the
+	// permission that drains nodes.
+	if got := do(guarded(t, cs, cfg, auth.ExecuteConsolidations), nil).Code; got != http.StatusUnauthorized {
+		t.Errorf("anonymous execute: got %d, want 401", got)
+	}
+}
+
+// An expired token must not be quietly downgraded to anonymous when anonymous
+// reads are permitted, or a UI would show stale data with no sign the session
+// had lapsed.
+func TestRejectedTokenIs401EvenWhenAnonymousReadIsAllowed(t *testing.T) {
+	cfg := enabled()
+	cfg.AllowAnonymousRead = true
+	cs := newCluster(t, clusterOpts{allow: true})
+
+	rec := do(guarded(t, cs, cfg, auth.ReadPlans), withToken("expired"))
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("got %d, want 401", rec.Code)
+	}
+	// The reason a token failed is more than an unauthenticated caller should
+	// learn; "expired" versus "forged" is a probing oracle.
+	if strings.Contains(rec.Body.String(), "token lookup failed") {
+		t.Errorf("internal rejection reason leaked: %s", rec.Body)
+	}
+}
+
+// An unreachable API server is our failure, not the caller's. Reporting it as
+// 401 or 403 would send an operator hunting for a RoleBinding they already have.
+func TestApiServerFailuresFailClosedAs500(t *testing.T) {
+	t.Run("tokenreview", func(t *testing.T) {
+		cs := newCluster(t, clusterOpts{tokenErr: errors.New("connection refused")})
+		rec := do(guarded(t, cs, enabled(), auth.ReadPlans), withToken(validToken))
+		if rec.Code != http.StatusInternalServerError {
+			t.Errorf("got %d, want 500", rec.Code)
+		}
+	})
+	t.Run("subjectaccessreview", func(t *testing.T) {
+		cs := newCluster(t, clusterOpts{
+			authenticated: map[string]authenticationv1.UserInfo{validToken: testUser},
+			sarErr:        errors.New("connection refused"),
+		})
+		rec := do(guarded(t, cs, enabled(), auth.ReadPlans), withToken(validToken))
+		if rec.Code != http.StatusInternalServerError {
+			t.Errorf("got %d, want 500", rec.Code)
+		}
+	})
+}
+
+func TestDisabledAuthIsTransparent(t *testing.T) {
+	cs := newCluster(t, clusterOpts{allow: false})
+	rec := do(guarded(t, cs, auth.Config{Enabled: false}, auth.ExecuteConsolidations), nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("got %d, want 200 when auth is disabled", rec.Code)
+	}
+	if len(cs.Actions()) != 0 {
+		t.Error("disabled auth should not talk to the API server at all")
+	}
+}
+
+// The UI polls. Re-validating the same token against the API server on every
+// request would put avoidable load on the control plane.
+func TestPositiveTokenReviewsAreCached(t *testing.T) {
+	var reviews atomic.Int32
+	cs := newCluster(t, clusterOpts{
+		authenticated: map[string]authenticationv1.UserInfo{validToken: testUser},
+		allow:         true,
+		tokenReviews:  &reviews,
+	})
+	h := guarded(t, cs, enabled(), auth.ReadPlans)
+
+	for range 5 {
+		if got := do(h, withToken(validToken)).Code; got != http.StatusOK {
+			t.Fatalf("got %d, want 200", got)
+		}
+	}
+	if n := reviews.Load(); n != 1 {
+		t.Errorf("TokenReview ran %d times, want 1 (the rest served from cache)", n)
+	}
+
+	// Authorization, by contrast, must never be cached: a revoked RoleBinding
+	// has to stop working immediately.
+	var sars int
+	for _, a := range cs.Actions() {
+		if a.GetResource().Resource == "subjectaccessreviews" {
+			sars++
+		}
+	}
+	if sars != 5 {
+		t.Errorf("SubjectAccessReview ran %d times, want 5 — authorization must not be cached", sars)
+	}
+}
+
+// A rejected token is not cached, so revoking access takes effect at once and a
+// caller cannot pin a negative result.
+func TestRejectedTokensAreNotCached(t *testing.T) {
+	var reviews atomic.Int32
+	cs := newCluster(t, clusterOpts{allow: true, tokenReviews: &reviews})
+	h := guarded(t, cs, enabled(), auth.ReadPlans)
+
+	do(h, withToken("nope"))
+	do(h, withToken("nope"))
+
+	if n := reviews.Load(); n != 2 {
+		t.Errorf("TokenReview ran %d times, want 2", n)
+	}
+}
+
+func TestBearerSchemeIsCaseInsensitive(t *testing.T) {
+	cs := newCluster(t, clusterOpts{
+		authenticated: map[string]authenticationv1.UserInfo{validToken: testUser},
+		allow:         true,
+	})
+	rec := do(guarded(t, cs, enabled(), auth.ReadPlans), func(r *http.Request) {
+		r.Header.Set("Authorization", "bearer "+validToken)
+	})
+	if rec.Code != http.StatusOK {
+		t.Errorf("lowercase scheme rejected: %d", rec.Code)
+	}
+}
+
+// system:anonymous is a real Kubernetes user that a cluster could in principle
+// bind to a role. We refuse before asking, so a careless binding elsewhere
+// cannot hand an unauthenticated caller the ability to drain nodes.
+func TestAnonymousIsRefusedWithoutConsultingRBAC(t *testing.T) {
+	cs := newCluster(t, clusterOpts{allow: true})
+	err := auth.NewAuthorizer(cs, "k8s-dencer").
+		Authorize(context.Background(), auth.Anonymous, auth.ExecuteConsolidations)
+
+	var denied *auth.DeniedError
+	if !errors.As(err, &denied) {
+		t.Fatalf("anonymous was authorized: %v", err)
+	}
+	if len(cs.Actions()) != 0 {
+		t.Error("anonymous reached the API server; it must be refused locally")
+	}
+}

--- a/internal/auth/authenticator.go
+++ b/internal/auth/authenticator.go
@@ -1,0 +1,199 @@
+package auth
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	authenticationv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// Authenticator resolves an HTTP request to an Identity.
+type Authenticator interface {
+	Authenticate(ctx context.Context, r *http.Request) (Identity, error)
+}
+
+// TokenReviewAuthenticator validates bearer tokens against the Kubernetes API
+// server, falling back to a trusted proxy header when one is configured.
+type TokenReviewAuthenticator struct {
+	client kubernetes.Interface
+	cfg    Config
+	cache  *tokenCache
+	now    func() time.Time
+}
+
+// NewAuthenticator builds an authenticator over a Kubernetes client.
+func NewAuthenticator(client kubernetes.Interface, cfg Config) *TokenReviewAuthenticator {
+	ttl := cfg.TokenCacheTTL
+	if ttl <= 0 {
+		ttl = DefaultTokenCacheTTL
+	}
+	return &TokenReviewAuthenticator{
+		client: client,
+		cfg:    cfg,
+		cache:  newTokenCache(ttl),
+		now:    time.Now,
+	}
+}
+
+// Authenticate resolves the caller.
+//
+// A bearer token wins over a proxy header when both are present: the token is
+// verifiable against the API server, whereas the header is merely asserted, and
+// the stronger evidence should decide.
+func (a *TokenReviewAuthenticator) Authenticate(ctx context.Context, r *http.Request) (Identity, error) {
+	if token := bearerToken(r); token != "" {
+		return a.authenticateToken(ctx, token)
+	}
+	if id, ok := a.proxyIdentity(r); ok {
+		return id, nil
+	}
+	return Anonymous, ErrNoCredentials
+}
+
+func (a *TokenReviewAuthenticator) authenticateToken(ctx context.Context, token string) (Identity, error) {
+	key := hashToken(token)
+	if id, ok := a.cache.get(key, a.now()); ok {
+		return id, nil
+	}
+
+	review, err := a.client.AuthenticationV1().TokenReviews().Create(ctx, &authenticationv1.TokenReview{
+		Spec: authenticationv1.TokenReviewSpec{
+			Token:     token,
+			Audiences: a.cfg.Audiences,
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		// The API server is unreachable or we lack permission to create
+		// TokenReviews. Either way this is our fault, not the caller's, and it
+		// must not be reported as a rejected token.
+		return Anonymous, err
+	}
+
+	if !review.Status.Authenticated {
+		reason := review.Status.Error
+		if reason == "" {
+			reason = "not authenticated"
+		}
+		return Anonymous, &InvalidTokenError{Reason: reason}
+	}
+
+	id := Identity{
+		Username: review.Status.User.Username,
+		UID:      review.Status.User.UID,
+		Groups:   review.Status.User.Groups,
+		Extra:    extraFromUserInfo(review.Status.User.Extra),
+		Source:   SourceToken,
+	}
+	a.cache.put(key, id, a.now())
+	return id, nil
+}
+
+// proxyIdentity reads an identity asserted by an upstream auth proxy.
+//
+// The headers are read only when TrustedProxy is enabled. While it is off they
+// are not merely unused but actively ignored, so a client that sets
+// X-Forwarded-User by hand is anonymous rather than an administrator.
+func (a *TokenReviewAuthenticator) proxyIdentity(r *http.Request) (Identity, bool) {
+	if !a.cfg.TrustedProxy.Enabled || a.cfg.TrustedProxy.UserHeader == "" {
+		return Anonymous, false
+	}
+	user := strings.TrimSpace(r.Header.Get(a.cfg.TrustedProxy.UserHeader))
+	if user == "" {
+		return Anonymous, false
+	}
+
+	var groups []string
+	if h := a.cfg.TrustedProxy.GroupsHeader; h != "" {
+		for _, g := range strings.Split(r.Header.Get(h), ",") {
+			if g = strings.TrimSpace(g); g != "" {
+				groups = append(groups, g)
+			}
+		}
+	}
+	return Identity{Username: user, Groups: groups, Source: SourceProxy}, true
+}
+
+func bearerToken(r *http.Request) string {
+	h := r.Header.Get("Authorization")
+	// RFC 7235 makes the scheme case-insensitive, and clients differ.
+	if len(h) < 7 || !strings.EqualFold(h[:7], "bearer ") {
+		return ""
+	}
+	return strings.TrimSpace(h[7:])
+}
+
+// hashToken keys the cache without holding the credential. Storing raw tokens
+// in a long-lived map would turn a heap dump into a set of working credentials.
+func hashToken(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(sum[:])
+}
+
+func extraFromUserInfo(in map[string]authenticationv1.ExtraValue) map[string][]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string][]string, len(in))
+	for k, v := range in {
+		out[k] = []string(v)
+	}
+	return out
+}
+
+// maxCachedTokens bounds the cache. Reached only under an unusual number of
+// distinct tokens, at which point we stop caching rather than evict something
+// arbitrary — degrading to the uncached path is always correct.
+const maxCachedTokens = 1024
+
+type cacheEntry struct {
+	identity  Identity
+	expiresAt time.Time
+}
+
+type tokenCache struct {
+	mu      sync.Mutex
+	ttl     time.Duration
+	entries map[string]cacheEntry
+}
+
+func newTokenCache(ttl time.Duration) *tokenCache {
+	return &tokenCache{ttl: ttl, entries: make(map[string]cacheEntry)}
+}
+
+func (c *tokenCache) get(key string, now time.Time) (Identity, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e, ok := c.entries[key]
+	if !ok {
+		return Identity{}, false
+	}
+	if !now.Before(e.expiresAt) {
+		delete(c.entries, key)
+		return Identity{}, false
+	}
+	return e.identity, true
+}
+
+func (c *tokenCache) put(key string, id Identity, now time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if len(c.entries) >= maxCachedTokens {
+		for k, e := range c.entries {
+			if !now.Before(e.expiresAt) {
+				delete(c.entries, k)
+			}
+		}
+		if len(c.entries) >= maxCachedTokens {
+			return
+		}
+	}
+	c.entries[key] = cacheEntry{identity: id, expiresAt: now.Add(c.ttl)}
+}

--- a/internal/auth/authorizer.go
+++ b/internal/auth/authorizer.go
@@ -1,0 +1,94 @@
+package auth
+
+import (
+	"context"
+
+	authorizationv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// Authorizer decides whether an identity may act on a resource.
+type Authorizer interface {
+	Authorize(ctx context.Context, id Identity, res Resource) error
+}
+
+// SubjectAccessReviewAuthorizer asks the Kubernetes API server.
+//
+// Using SubjectAccessReview rather than checking a local policy is what makes
+// the three authentication paths interchangeable: a token-derived identity and
+// a proxy-asserted one are both just a username and a set of groups by the time
+// they reach here, so both are evaluated against the cluster's own RBAC.
+type SubjectAccessReviewAuthorizer struct {
+	client    kubernetes.Interface
+	namespace string
+}
+
+// NewAuthorizer builds an authorizer scoped to a namespace. An empty namespace
+// produces a cluster-scoped check.
+func NewAuthorizer(client kubernetes.Interface, namespace string) *SubjectAccessReviewAuthorizer {
+	return &SubjectAccessReviewAuthorizer{client: client, namespace: namespace}
+}
+
+// Authorize returns nil when the identity holds the permission, a *DeniedError
+// when it does not, and any other error when the decision could not be made.
+//
+// The distinction matters: an API server we cannot reach must fail closed with
+// a 500, not be reported to the caller as a denial they could fix by asking for
+// a RoleBinding they already have.
+func (a *SubjectAccessReviewAuthorizer) Authorize(ctx context.Context, id Identity, res Resource) error {
+	if id.IsAnonymous() {
+		// system:anonymous is a real Kubernetes user and could in principle be
+		// bound to a role. Short-circuiting keeps a misconfigured cluster from
+		// granting an unauthenticated caller the ability to drain nodes.
+		return &DeniedError{Identity: id, Resource: res, Reason: "no credentials presented"}
+	}
+
+	review, err := a.client.AuthorizationV1().SubjectAccessReviews().Create(ctx, &authorizationv1.SubjectAccessReview{
+		Spec: authorizationv1.SubjectAccessReviewSpec{
+			User:   id.Username,
+			UID:    id.UID,
+			Groups: id.Groups,
+			Extra:  extraToSAR(id.Extra),
+			ResourceAttributes: &authorizationv1.ResourceAttributes{
+				Namespace: a.namespace,
+				Group:     res.Group,
+				Resource:  res.Resource,
+				Verb:      res.Verb,
+			},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		return err
+	}
+
+	// Denied is checked before Allowed: an authorizer may set both, and an
+	// explicit deny is required to win.
+	if review.Status.Denied || !review.Status.Allowed {
+		return &DeniedError{Identity: id, Resource: res, Reason: review.Status.Reason}
+	}
+	if review.Status.EvaluationError != "" {
+		// Allowed, but the authorizer hit an error reaching that conclusion.
+		// Treating a partially-evaluated allow as an allow is how permissions
+		// get granted by accident.
+		return &DeniedError{Identity: id, Resource: res, Reason: review.Status.EvaluationError}
+	}
+	return nil
+}
+
+func extraToSAR(in map[string][]string) map[string]authorizationv1.ExtraValue {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]authorizationv1.ExtraValue, len(in))
+	for k, v := range in {
+		out[k] = authorizationv1.ExtraValue(v)
+	}
+	return out
+}
+
+// AllowAll authorizes everything. Used when auth is disabled, and in tests.
+type AllowAll struct{}
+
+// Authorize always succeeds.
+func (AllowAll) Authorize(context.Context, Identity, Resource) error { return nil }

--- a/internal/auth/cache_test.go
+++ b/internal/auth/cache_test.go
@@ -1,0 +1,112 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	authenticationv1 "k8s.io/api/authentication/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
+)
+
+func authenticatingClient(reviews *int) *fake.Clientset {
+	cs := fake.NewSimpleClientset()
+	cs.PrependReactor("create", "tokenreviews", func(a ktesting.Action) (bool, runtime.Object, error) {
+		*reviews++
+		tr := a.(ktesting.CreateAction).GetObject().(*authenticationv1.TokenReview)
+		tr.Status = authenticationv1.TokenReviewStatus{
+			Authenticated: true,
+			User:          authenticationv1.UserInfo{Username: "alice@example.com"},
+		}
+		return true, tr, nil
+	})
+	return cs
+}
+
+func request(token string) *http.Request {
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("Authorization", "Bearer "+token)
+	return r
+}
+
+// The cache outlives any single request, so it must never hold a credential a
+// heap dump could recover. Keys are SHA-256 digests, and this test fails if
+// anyone later "simplifies" that to the token itself.
+func TestCacheNeverStoresTheRawToken(t *testing.T) {
+	const secret = "super-secret-token-value"
+	reviews := 0
+	a := NewAuthenticator(authenticatingClient(&reviews), Config{Enabled: true})
+
+	if _, err := a.Authenticate(context.Background(), request(secret)); err != nil {
+		t.Fatal(err)
+	}
+
+	a.cache.mu.Lock()
+	defer a.cache.mu.Unlock()
+	if len(a.cache.entries) != 1 {
+		t.Fatalf("expected one cached entry, got %d", len(a.cache.entries))
+	}
+	for key, entry := range a.cache.entries {
+		if strings.Contains(key, secret) {
+			t.Error("the raw token is being used as a cache key")
+		}
+		if len(key) != 64 {
+			t.Errorf("cache key is not a SHA-256 digest: %q", key)
+		}
+		if strings.Contains(entry.identity.Username, secret) {
+			t.Error("the raw token leaked into the cached identity")
+		}
+	}
+}
+
+func TestCachedIdentityExpires(t *testing.T) {
+	reviews := 0
+	a := NewAuthenticator(authenticatingClient(&reviews), Config{Enabled: true, TokenCacheTTL: time.Minute})
+
+	clock := time.Now()
+	a.now = func() time.Time { return clock }
+
+	ctx := context.Background()
+	if _, err := a.Authenticate(ctx, request("t")); err != nil {
+		t.Fatal(err)
+	}
+	clock = clock.Add(59 * time.Second)
+	if _, err := a.Authenticate(ctx, request("t")); err != nil {
+		t.Fatal(err)
+	}
+	if reviews != 1 {
+		t.Fatalf("within the TTL: TokenReview ran %d times, want 1", reviews)
+	}
+
+	// Past the TTL the token must be re-validated, so a revocation takes
+	// effect rather than being masked for the lifetime of the process.
+	clock = clock.Add(2 * time.Second)
+	if _, err := a.Authenticate(ctx, request("t")); err != nil {
+		t.Fatal(err)
+	}
+	if reviews != 2 {
+		t.Errorf("after the TTL: TokenReview ran %d times, want 2", reviews)
+	}
+}
+
+func TestCacheIsBounded(t *testing.T) {
+	reviews := 0
+	a := NewAuthenticator(authenticatingClient(&reviews), Config{Enabled: true})
+
+	for i := range maxCachedTokens + 50 {
+		if _, err := a.Authenticate(context.Background(), request(string(rune(i))+"-token")); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	a.cache.mu.Lock()
+	defer a.cache.mu.Unlock()
+	if len(a.cache.entries) > maxCachedTokens {
+		t.Errorf("cache grew to %d entries, past the %d cap", len(a.cache.entries), maxCachedTokens)
+	}
+}

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -1,0 +1,155 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+)
+
+type contextKey struct{}
+
+// WithIdentity stores an identity on a context.
+func WithIdentity(ctx context.Context, id Identity) context.Context {
+	return context.WithValue(ctx, contextKey{}, id)
+}
+
+// IdentityFrom recovers the authenticated caller. Handlers use it to attribute
+// an action in the audit trail; it reports false when auth is disabled.
+func IdentityFrom(ctx context.Context) (Identity, bool) {
+	id, ok := ctx.Value(contextKey{}).(Identity)
+	return id, ok
+}
+
+// Middleware guards handlers with a required permission.
+type Middleware struct {
+	authn Authenticator
+	authz Authorizer
+	cfg   Config
+	log   *slog.Logger
+}
+
+// NewMiddleware wires an authenticator and authorizer into HTTP middleware.
+func NewMiddleware(authn Authenticator, authz Authorizer, cfg Config, log *slog.Logger) *Middleware {
+	return &Middleware{authn: authn, authz: authz, cfg: cfg, log: log}
+}
+
+// Require wraps next so it runs only for callers holding res.
+//
+// When authentication is disabled the wrapper is transparent. That is a
+// deployment choice for a private demo cluster, and the chart's schema refuses
+// to combine it with an enabled executor — an unauthenticated route that can
+// drain nodes should not be reachable by editing one value.
+func (m *Middleware) Require(res Resource, next http.Handler) http.Handler {
+	if !m.cfg.Enabled {
+		return next
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id, err := m.authn.Authenticate(r.Context(), r)
+
+		switch {
+		case err == nil:
+			// Authenticated; fall through to the authorization check.
+
+		case errors.Is(err, ErrNoCredentials):
+			// Nothing was presented. Anonymous reads are permitted only when
+			// configured, and never for a mutation whatever the setting says.
+			if !(m.cfg.AllowAnonymousRead && res == ReadPlans) {
+				m.unauthorized(w, "authentication required")
+				return
+			}
+			// Setting allowAnonymousRead *is* the grant, so there is no
+			// RoleBinding to consult. Asking anyway would always fail:
+			// system:anonymous is refused before RBAC is even reached.
+			next.ServeHTTP(w, r.WithContext(WithIdentity(r.Context(), id)))
+			return
+
+		default:
+			var invalid *InvalidTokenError
+			if errors.As(err, &invalid) {
+				// A credential was presented and rejected. Report that even
+				// when anonymous reads are allowed: silently downgrading an
+				// expired token to anonymous would leave a UI showing stale
+				// data with no clue that its session had lapsed.
+				m.log.Debug("token rejected", "reason", invalid.Reason)
+				m.unauthorized(w, "invalid or expired credentials")
+				return
+			}
+			// TokenReview itself failed. Fail closed.
+			m.log.Error("authentication unavailable", "error", err)
+			writeAuthError(w, http.StatusInternalServerError, "unavailable",
+				"could not verify credentials", nil)
+			return
+		}
+
+		if err := m.authz.Authorize(r.Context(), id, res); err != nil {
+			var denied *DeniedError
+			if errors.As(err, &denied) {
+				m.forbidden(w, denied)
+				return
+			}
+			m.log.Error("authorization unavailable", "error", err, "user", id.Username)
+			writeAuthError(w, http.StatusInternalServerError, "unavailable",
+				"could not check permissions", nil)
+			return
+		}
+
+		next.ServeHTTP(w, r.WithContext(WithIdentity(r.Context(), id)))
+	})
+}
+
+// RequireFunc is Require for a HandlerFunc.
+func (m *Middleware) RequireFunc(res Resource, next http.HandlerFunc) http.Handler {
+	return m.Require(res, next)
+}
+
+func (m *Middleware) unauthorized(w http.ResponseWriter, msg string) {
+	w.Header().Set("WWW-Authenticate", `Bearer realm="k8s-dencer"`)
+	writeAuthError(w, http.StatusUnauthorized, "unauthenticated", msg, nil)
+}
+
+// forbidden answers with the exact permission that was missing, and a command
+// that grants it. An operator who has just been refused should not have to read
+// our source to find out which verb to ask their admin for.
+func (m *Middleware) forbidden(w http.ResponseWriter, denied *DeniedError) {
+	detail := map[string]any{
+		"user":     denied.Identity.Username,
+		"groups":   denied.Identity.Groups,
+		"required": map[string]string{"verb": denied.Resource.Verb, "group": denied.Resource.Group, "resource": denied.Resource.Resource},
+	}
+	if denied.Reason != "" {
+		detail["reason"] = denied.Reason
+	}
+	if hint := m.grantHint(denied); hint != "" {
+		detail["grantWith"] = hint
+	}
+	writeAuthError(w, http.StatusForbidden, "forbidden",
+		fmt.Sprintf("user %q may not %s", denied.Identity.Username, denied.Resource), detail)
+}
+
+func (m *Middleware) grantHint(denied *DeniedError) string {
+	role := m.cfg.OperatorRoleName
+	if role == "" || denied.Identity.IsAnonymous() {
+		return ""
+	}
+	ns := m.cfg.Namespace
+	if ns == "" {
+		return fmt.Sprintf("kubectl create clusterrolebinding dencer-operator --clusterrole=%s --user=%q",
+			role, denied.Identity.Username)
+	}
+	return fmt.Sprintf("kubectl create rolebinding dencer-operator -n %s --clusterrole=%s --user=%q",
+		ns, role, denied.Identity.Username)
+}
+
+func writeAuthError(w http.ResponseWriter, status int, code, msg string, detail map[string]any) {
+	body := map[string]any{"error": msg, "code": code}
+	for k, v := range detail {
+		body[k] = v
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -3,6 +3,7 @@ import CapacityRibbon from "./components/CapacityRibbon";
 import Inspector, { Selection } from "./components/Inspector";
 import PlanCanvas from "./components/PlanCanvas";
 import Scrubber from "./components/Scrubber";
+import { SignIn } from "./components/SignIn";
 import StatTiles from "./components/StatTiles";
 import StepList from "./components/StepList";
 import { runtimeConfig } from "./runtime-config";
@@ -74,8 +75,14 @@ export default function App() {
         />
       )}
 
-      {state.status === "error" && (
-        <Placeholder title="Cannot reach the planner" detail={state.message} tone="error" />
+      {state.status === "error" && state.needsAuth && <SignIn onDone={state.reload} />}
+
+      {state.status === "error" && !state.needsAuth && (
+        <Placeholder
+          title={state.grantWith ? "Not permitted" : "Cannot reach the planner"}
+          detail={state.grantWith ? `${state.message}\n\nGrant it with:\n${state.grantWith}` : state.message}
+          tone="error"
+        />
       )}
 
       {state.status === "ready" && (

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -1,3 +1,4 @@
+import { authHeaders } from "./auth";
 import { runtimeConfig } from "./runtime-config";
 
 export type Impact = "Green" | "Yellow" | "Red";
@@ -129,26 +130,59 @@ export class ApiError extends Error {
   constructor(
     readonly status: number,
     message: string,
+    /** How to obtain the missing permission, when the server supplied it. */
+    readonly grantWith?: string,
   ) {
     super(message);
   }
   get isEmpty() {
     return this.status === 404;
   }
+  /** No credentials, or they expired. The caller should offer a sign-in. */
+  get needsAuth() {
+    return this.status === 401;
+  }
+  /** Authenticated, but lacking the permission. Signing in again will not help. */
+  get isForbidden() {
+    return this.status === 403;
+  }
+}
+
+/** Turns a failed response into an ApiError carrying the server's own words. */
+async function toApiError(res: Response): Promise<ApiError> {
+  let detail = res.statusText || `request failed (${res.status})`;
+  let grantWith: string | undefined;
+  try {
+    const body = (await res.json()) as { error?: string; grantWith?: string };
+    if (body.error) detail = body.error;
+    grantWith = body.grantWith;
+  } catch {
+    /* non-JSON error body */
+  }
+  return new ApiError(res.status, detail, grantWith);
+}
+
+/** Reports a transport failure in terms an operator can act on.
+ *
+ *  A bare "Failed to fetch" is what the browser gives us when the backend is
+ *  unreachable, and it tells nobody anything. */
+function toNetworkError(err: unknown): Error {
+  if (err instanceof ApiError) return err;
+  const target = base() || "the ui-backend";
+  return new Error(
+    `Cannot reach ${target}. The backend may be restarting, or a port-forward may have dropped.`,
+  );
 }
 
 async function get<T>(path: string, signal?: AbortSignal): Promise<T> {
-  const res = await fetch(`${base()}${path}`, { signal });
-  if (!res.ok) {
-    let detail = res.statusText;
-    try {
-      const body = (await res.json()) as { error?: string };
-      if (body.error) detail = body.error;
-    } catch {
-      /* non-JSON error body */
-    }
-    throw new ApiError(res.status, detail);
+  let res: Response;
+  try {
+    res = await fetch(`${base()}${path}`, { signal, headers: authHeaders() });
+  } catch (err) {
+    if (signal?.aborted) throw err;
+    throw toNetworkError(err);
   }
+  if (!res.ok) throw await toApiError(res);
   return (await res.json()) as T;
 }
 
@@ -162,22 +196,94 @@ export const api = {
 
 /** Subscribes to plan changes. Returns an unsubscribe function.
  *
- *  EventSource reconnects on its own, so there is no retry logic here. */
+ *  Built on fetch rather than EventSource because the stream is authenticated
+ *  and EventSource cannot send an Authorization header. The alternative —
+ *  putting the token in the query string — would write a working credential
+ *  into every access log between here and the backend.
+ *
+ *  Reconnection is therefore ours to handle, where EventSource gave it to us. */
 export function subscribePlans(onChange: (planId: string) => void): () => void {
-  const source = new EventSource(`${base()}/api/v1/events`);
-  const handler = (e: MessageEvent) => {
-    try {
-      const data = JSON.parse(e.data) as { planId?: string };
-      if (data.planId) onChange(data.planId);
-    } catch {
-      /* ignore malformed frames */
+  const controller = new AbortController();
+  let attempt = 0;
+
+  const run = async () => {
+    while (!controller.signal.aborted) {
+      try {
+        const res = await fetch(`${base()}/api/v1/events`, {
+          signal: controller.signal,
+          headers: authHeaders({ Accept: "text/event-stream" }),
+        });
+        if (!res.ok || !res.body) throw await toApiError(res);
+
+        attempt = 0; // a successful connection resets the backoff
+        await readEventStream(res.body, (event, data) => {
+          if (event !== "plan") return;
+          try {
+            const parsed = JSON.parse(data) as { planId?: string };
+            if (parsed.planId) onChange(parsed.planId);
+          } catch {
+            /* ignore malformed frames */
+          }
+        });
+      } catch (err) {
+        if (controller.signal.aborted) return;
+        // A 401/403 will not fix itself by retrying harder; back off to the
+        // ceiling immediately rather than hammering the API server with
+        // TokenReviews for a token that is not going to start working.
+        if (err instanceof ApiError && (err.needsAuth || err.isForbidden)) attempt = 5;
+      }
+      if (controller.signal.aborted) return;
+      const delay = Math.min(1000 * 2 ** attempt++, 30_000);
+      await new Promise((r) => setTimeout(r, delay));
     }
   };
-  source.addEventListener("plan", handler as EventListener);
-  return () => {
-    source.removeEventListener("plan", handler as EventListener);
-    source.close();
-  };
+
+  void run();
+  return () => controller.abort();
+}
+
+/** Parses an SSE byte stream, invoking onEvent for each complete frame. */
+async function readEventStream(
+  body: ReadableStream<Uint8Array>,
+  onEvent: (event: string, data: string) => void,
+): Promise<void> {
+  const reader = body.getReader();
+  // Decoding incrementally rather than via TextDecoderStream: a multi-byte
+  // character can straddle two chunks, and { stream: true } is what holds the
+  // partial sequence until the rest arrives.
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) return;
+    buffer += decoder.decode(value, { stream: true });
+
+    // Frames are separated by a blank line. A chunk can split a frame
+    // anywhere, so only complete frames are consumed and the tail is kept.
+    let boundary = buffer.indexOf("\n\n");
+    while (boundary !== -1) {
+      const frame = buffer.slice(0, boundary);
+      buffer = buffer.slice(boundary + 2);
+      dispatchFrame(frame, onEvent);
+      boundary = buffer.indexOf("\n\n");
+    }
+  }
+}
+
+function dispatchFrame(frame: string, onEvent: (event: string, data: string) => void) {
+  let event = "message";
+  const data: string[] = [];
+  for (const line of frame.split("\n")) {
+    if (line.startsWith(":")) continue; // comment / keep-alive
+    const colon = line.indexOf(":");
+    const field = colon === -1 ? line : line.slice(0, colon);
+    // A single leading space after the colon is part of the framing, not data.
+    const value = colon === -1 ? "" : line.slice(colon + 1).replace(/^ /, "");
+    if (field === "event") event = value;
+    else if (field === "data") data.push(value);
+  }
+  if (data.length > 0) onEvent(event, data.join("\n"));
 }
 
 export function formatCPU(milli: number): string {

--- a/ui/src/auth.ts
+++ b/ui/src/auth.ts
@@ -1,0 +1,96 @@
+import { runtimeConfig } from "./runtime-config";
+
+/** Public description of how this install expects callers to authenticate. */
+export interface AuthInfo {
+  enabled: boolean;
+  anonymousRead: boolean;
+  oidc: {
+    enabled: boolean;
+    issuerUrl?: string;
+    clientId?: string;
+    scopes?: string[];
+  };
+}
+
+const STORAGE_KEY = "dencer.token";
+
+/**
+ * Holds the caller's bearer token for the lifetime of the tab.
+ *
+ * sessionStorage rather than localStorage: a token in localStorage outlives the
+ * browsing session and is readable by every script on the origin for as long as
+ * it sits there. Scoping it to the tab means closing the tab ends the session,
+ * which is the behaviour an operator expects from something that can drain
+ * nodes.
+ *
+ * M12 replaces manual entry with an OIDC redirect flow, at which point this
+ * becomes the fallback for installs without an issuer configured.
+ */
+export const token = {
+  get(): string | null {
+    try {
+      return sessionStorage.getItem(STORAGE_KEY);
+    } catch {
+      // Storage can be blocked outright by browser settings. Losing the token
+      // on reload is a far better outcome than failing to render.
+      return null;
+    }
+  },
+
+  set(value: string): void {
+    try {
+      sessionStorage.setItem(STORAGE_KEY, value.trim());
+    } catch {
+      /* non-fatal; see get() */
+    }
+    notify();
+  },
+
+  clear(): void {
+    try {
+      sessionStorage.removeItem(STORAGE_KEY);
+    } catch {
+      /* non-fatal */
+    }
+    notify();
+  },
+};
+
+const listeners = new Set<() => void>();
+
+function notify() {
+  for (const fn of listeners) fn();
+}
+
+/** Subscribes to token changes so views can re-fetch after a sign-in. */
+export function onTokenChange(fn: () => void): () => void {
+  listeners.add(fn);
+  return () => listeners.delete(fn);
+}
+
+/** Adds the Authorization header when a token is held. */
+export function authHeaders(init?: HeadersInit): Headers {
+  const headers = new Headers(init);
+  const value = token.get();
+  if (value) headers.set("Authorization", `Bearer ${value}`);
+  return headers;
+}
+
+let cached: Promise<AuthInfo> | null = null;
+
+/**
+ * Fetches how this install authenticates. Served unauthenticated by design —
+ * a client cannot sign in without first learning where to sign in.
+ *
+ * Cached for the page's lifetime: the answer is fixed at deploy time.
+ */
+export function authInfo(): Promise<AuthInfo> {
+  cached ??= fetch(`${runtimeConfig().apiBaseUrl}/api/v1/authinfo`)
+    .then((res) => (res.ok ? (res.json() as Promise<AuthInfo>) : Promise.reject(new Error(String(res.status)))))
+    .catch(
+      // An older backend has no authinfo route. Assuming auth is off matches
+      // how that build actually behaves.
+      (): AuthInfo => ({ enabled: false, anonymousRead: true, oidc: { enabled: false } }),
+    );
+  return cached;
+}

--- a/ui/src/components/SignIn.tsx
+++ b/ui/src/components/SignIn.tsx
@@ -1,0 +1,72 @@
+import { FormEvent, useEffect, useState } from "react";
+import { AuthInfo, authInfo, token } from "../auth";
+
+/**
+ * Collects a bearer token when the backend has rejected the request.
+ *
+ * Deliberately plain. M11 rebuilds the header and M12 replaces this with an
+ * OIDC redirect flow, so anything more elaborate here would be built twice —
+ * but an install with auth on and no way to present a credential is unusable,
+ * so it cannot simply wait.
+ */
+export function SignIn({ onDone }: { onDone: () => void }) {
+  const [info, setInfo] = useState<AuthInfo | null>(null);
+  const [value, setValue] = useState("");
+
+  useEffect(() => {
+    let live = true;
+    void authInfo().then((i) => live && setInfo(i));
+    return () => {
+      live = false;
+    };
+  }, []);
+
+  const submit = (e: FormEvent) => {
+    e.preventDefault();
+    if (!value.trim()) return;
+    token.set(value);
+    setValue("");
+    onDone();
+  };
+
+  return (
+    <div className="signin">
+      <h2>Sign in</h2>
+      <p className="signin-detail">
+        This install requires a Kubernetes credential. Permission to view plans is granted by RBAC,
+        so any token your cluster already trusts will work.
+      </p>
+
+      {info?.oidc.enabled && info.oidc.issuerUrl && (
+        <p className="signin-detail">
+          Single sign-on is configured against <code>{info.oidc.issuerUrl}</code>. Browser sign-in
+          arrives in the next release; until then, paste a token below.
+        </p>
+      )}
+
+      <form onSubmit={submit}>
+        <label htmlFor="token">Bearer token</label>
+        <input
+          id="token"
+          type="password"
+          autoComplete="off"
+          spellCheck={false}
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          placeholder="eyJhbGciOi…"
+        />
+        <button type="submit" disabled={!value.trim()}>
+          Continue
+        </button>
+      </form>
+
+      <details className="signin-help">
+        <summary>How do I get one?</summary>
+        <pre>kubectl create token dencer-viewer -n k8s-dencer</pre>
+        <p>
+          Or run <code>make token</code> from the repository, which mints one and prints it.
+        </p>
+      </details>
+    </div>
+  );
+}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -762,10 +762,99 @@
   max-width: 32rem;
   color: var(--text-secondary);
   font-size: 0.88rem;
+  /* A 403 carries the kubectl command that grants the missing permission.
+     Collapsing it onto one line would make it unreadable and un-copyable. */
+  white-space: pre-line;
 }
 
 .placeholder-error h2 {
   color: var(--impact-red);
+}
+
+/* --------------------------------------------------------------- sign-in */
+
+.signin {
+  grid-row: 2 / -1;
+  align-self: center;
+  justify-self: center;
+  width: min(30rem, calc(100vw - 3rem));
+  padding: 1.75rem;
+  background: var(--surface);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius);
+}
+
+.signin h2 {
+  margin: 0 0 0.65rem;
+  font-family: var(--font-display);
+  font-size: 1.05rem;
+  font-weight: 650;
+}
+
+.signin-detail {
+  margin: 0 0 0.9rem;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+
+.signin form {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.signin label {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
+.signin input {
+  padding: 0.55rem 0.65rem;
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  color: var(--text-primary);
+  background: var(--surface-sunken);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+}
+
+.signin button {
+  justify-self: start;
+  margin-top: 0.35rem;
+  padding: 0.5rem 1.1rem;
+  font-family: var(--font-body);
+  font-size: 0.85rem;
+  color: #fff;
+  background: var(--accent);
+  border: 0;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+.signin button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.signin-help {
+  margin-top: 1.1rem;
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+}
+
+.signin-help summary {
+  cursor: pointer;
+  color: var(--text-muted);
+}
+
+.signin-help pre {
+  margin: 0.6rem 0;
+  padding: 0.55rem 0.65rem;
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  background: var(--surface-sunken);
+  border-radius: var(--radius-sm);
 }
 
 @media (max-width: 1000px) {

--- a/ui/src/usePlan.ts
+++ b/ui/src/usePlan.ts
@@ -1,10 +1,11 @@
 import { useCallback, useEffect, useState } from "react";
 import { ApiError, GraphPayload, PlanResponse, api, subscribePlans } from "./api";
+import { onTokenChange } from "./auth";
 
 export type PlanState =
   | { status: "loading" }
   | { status: "empty" }
-  | { status: "error"; message: string }
+  | { status: "error"; message: string; needsAuth?: boolean; grantWith?: string }
   | { status: "ready"; plan: PlanResponse; graph: GraphPayload };
 
 /**
@@ -41,6 +42,8 @@ export function usePlan(): PlanState & { reload: () => void } {
         setState({
           status: "error",
           message: err instanceof Error ? err.message : String(err),
+          needsAuth: err instanceof ApiError && err.needsAuth,
+          grantWith: err instanceof ApiError ? err.grantWith : undefined,
         });
       }
     })();
@@ -51,6 +54,10 @@ export function usePlan(): PlanState & { reload: () => void } {
   useEffect(() => {
     return subscribePlans(() => reload());
   }, [reload]);
+
+  // Signing in has to re-drive the fetch: without this the operator enters a
+  // valid token and stares at the same 401 until they reload the page.
+  useEffect(() => onTokenChange(reload), [reload]);
 
   return { ...state, reload };
 }


### PR DESCRIPTION
Phase 2 begins with the gate, not the executor. A window in which an execute
endpoint exists unauthenticated is worse than either state on its own, so the
authorization path ships and is tested before there is anything to authorize.

## Approach

Delegates entirely to Kubernetes. A caller presents a token, ui-backend
validates it with a `TokenReview`, and permission is decided by a
`SubjectAccessReview` — so "who may read the plan" and "who may drain a node"
are ordinary RoleBindings that compose with existing OIDC/SSO, audit flows
through the API server, and there is no credential store of ours to breach.

The verbs are `get plans.dencer.io` and `create consolidations.dencer.io`.
Neither is a CRD, because RBAC and SAR match on strings — the same property
metrics-server relies on.

Three authentication paths, one authorization path:

| Tier | For | Identity from |
|---|---|---|
| OIDC passthrough | API server with `--oidc-issuer-url` | Code+PKCE → ID token → TokenReview |
| Auth proxy | EKS-IAM / GKE, where TokenReview can't validate a third-party token | header → SAR `spec.user`/`spec.groups` |
| Bearer token | POC, CI | `make token` |

## Notable

- **ServiceAccounts split per component.** `system:auth-delegator` belongs to
  ui-backend alone, and M10 needs to assert eviction is absent from planner and
  ui-backend specifically.
- **The frontend consumes SSE with `fetch`, not `EventSource`**, which costs the
  reconnect logic `EventSource` gives away. `EventSource` cannot send an
  `Authorization` header, and the alternative — token in the query string —
  would write a working credential into every access log in the path.
- **A 403 carries its own fix**: the exact verb, group and resource, plus the
  `kubectl create rolebinding` that grants them.
- **Authn is cached 30s; authz never is.** A revoked RoleBinding must stop
  working immediately.

## Two findings from verifying rather than assuming

- **The NetworkPolicy is NOT enforced by k3s's default CNI.** A pod in `default`
  reaches ui-backend with a 200 despite the policy. It cannot be counted as a
  control in the threat model, and `auth.trustedProxy` is unsafe wherever that
  holds. Documented with a probe recipe.
- **Kagent's `RemoteMCPServer` DOES support bearer headers**, contrary to what
  the plan assumed. `auth.mcpRequireToken` + `kagent.authSecret` ship working,
  with all four tools discovered through a guarded `/mcp` while an
  unauthenticated probe gets 401. Off by default only because the secret is the
  operator's to create and rotate.

## Bugs found on the way

- `allowAnonymousRead` never worked — the authorizer refuses `system:anonymous`
  before consulting RBAC, so that path always 403'd. The config flag *is* the
  grant decision, so it now skips authorization.
- A duplicate `POD_NAMESPACE` broke server-side apply after a clean lint.
  `helm template` and kubeconform both accept duplicate env keys, so there is
  now an assertion for it — verified by reintroducing the duplicate.

## Verification

Against the live cluster: no token → 401 + challenge; `authinfo` → 200 open;
valid token without permission → 403 naming the verb; `make token` → 200 serving
the 16-step plan (29→13 nodes); forged `X-Forwarded-User` → 401, never reaching
the authorizer; `pods/eviction` → `no` for both ServiceAccounts.

138 tests, 17 chart contract assertions, all green.

A source-level test fails the build if any route is registered outside the
guarded helper — verified by temporarily adding an unguarded
`POST /api/v1/execute`, which is precisely the M10 failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)