### PR TITLE
M10: executor and Safety Guard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,11 @@ images: ## Build native-arch images for the local cluster
 		--build-arg VERSION=$(IMAGE_TAG) \
 		-t $(IMAGE_PREFIX)-ui-backend:$(IMAGE_TAG) .
 	docker buildx build --load \
+		-f build/go.Dockerfile \
+		--build-arg COMPONENT=executor \
+		--build-arg VERSION=$(IMAGE_TAG) \
+		-t $(IMAGE_PREFIX)-executor:$(IMAGE_TAG) .
+	docker buildx build --load \
 		-f build/ui.Dockerfile \
 		-t $(IMAGE_PREFIX)-ui-frontend:$(IMAGE_TAG) .
 
@@ -133,6 +138,11 @@ images-release: ## Build multi-arch images (buildx cannot --load these; use --pu
 		--build-arg VERSION=$(IMAGE_TAG) \
 		-t $(IMAGE_PREFIX)-ui-backend:$(IMAGE_TAG) .
 	docker buildx build --platform $(PLATFORMS) \
+		-f build/go.Dockerfile \
+		--build-arg COMPONENT=executor \
+		--build-arg VERSION=$(IMAGE_TAG) \
+		-t $(IMAGE_PREFIX)-executor:$(IMAGE_TAG) .
+	docker buildx build --platform $(PLATFORMS) \
 		-f build/ui.Dockerfile \
 		-t $(IMAGE_PREFIX)-ui-frontend:$(IMAGE_TAG) .
 
@@ -141,12 +151,13 @@ images-load: ## Make locally built images visible to the cluster
 ifeq ($(CLUSTER_PROVIDER),orbstack)
 	@echo "==> orbstack shares the docker image store; nothing to load"
 else ifeq ($(CLUSTER_PROVIDER),k3d)
-	k3d image import $(IMAGE_PREFIX)-planner:$(IMAGE_TAG) $(IMAGE_PREFIX)-ui-backend:$(IMAGE_TAG) $(IMAGE_PREFIX)-ui-frontend:$(IMAGE_TAG)
+	k3d image import $(IMAGE_PREFIX)-planner:$(IMAGE_TAG) $(IMAGE_PREFIX)-ui-backend:$(IMAGE_TAG) $(IMAGE_PREFIX)-executor:$(IMAGE_TAG) $(IMAGE_PREFIX)-ui-frontend:$(IMAGE_TAG)
 else ifeq ($(CLUSTER_PROVIDER),kind)
-	kind load docker-image $(IMAGE_PREFIX)-planner:$(IMAGE_TAG) $(IMAGE_PREFIX)-ui-backend:$(IMAGE_TAG) $(IMAGE_PREFIX)-ui-frontend:$(IMAGE_TAG)
+	kind load docker-image $(IMAGE_PREFIX)-planner:$(IMAGE_TAG) $(IMAGE_PREFIX)-ui-backend:$(IMAGE_TAG) $(IMAGE_PREFIX)-executor:$(IMAGE_TAG) $(IMAGE_PREFIX)-ui-frontend:$(IMAGE_TAG)
 else ifeq ($(CLUSTER_PROVIDER),minikube)
 	minikube image load $(IMAGE_PREFIX)-planner:$(IMAGE_TAG)
 	minikube image load $(IMAGE_PREFIX)-ui-backend:$(IMAGE_TAG)
+	minikube image load $(IMAGE_PREFIX)-executor:$(IMAGE_TAG)
 	minikube image load $(IMAGE_PREFIX)-ui-frontend:$(IMAGE_TAG)
 else
 	$(error unknown CLUSTER_PROVIDER: $(CLUSTER_PROVIDER))
@@ -171,6 +182,7 @@ deploy: ## Install/upgrade the product chart with the provider overlay
 		-f $(CHART)/ci/$(CLUSTER_PROVIDER)-values.yaml \
 		--set planner.image.tag=$(IMAGE_TAG) \
 		--set uiBackend.image.tag=$(IMAGE_TAG) \
+		--set executor.image.tag=$(IMAGE_TAG) \
 		--set uiFrontend.image.tag=$(IMAGE_TAG) \
 		--wait --timeout 5m
 
@@ -301,12 +313,29 @@ demo-down: ## Remove the synthetic topology (deletes the fake nodes)
 	-kubectl delete namespace $(DEMO_NAMESPACE) --wait=false
 	-kubectl delete nodes -l dencer.io/synthetic=true --wait=false
 
+.PHONY: fabric-reset
+fabric-reset: ## Uncordon every KWOK node (undo an executor run)
+	@# Draining a node makes the node controller add
+	@# node.kubernetes.io/unschedulable to .spec.taints, owned by the
+	@# cluster's own field manager. The demo chart also manages .spec.taints,
+	@# so a server-side apply then fails with a field-manager conflict — which
+	@# is how `make scenario` breaks after a run. A scenario switch is a fabric
+	@# reset, so uncordoning first is both the fix and the honest semantics.
+	@nodes=$$(kubectl get nodes -l type=kwok -o jsonpath='{range .items[?(@.spec.unschedulable)]}{.metadata.name}{" "}{end}'); \
+	if [ -n "$$nodes" ]; then \
+		echo "==> uncordoning $$(echo $$nodes | wc -w | tr -d ' ') drained node(s)"; \
+		kubectl uncordon $$nodes >/dev/null; \
+	else \
+		echo "==> no cordoned KWOK nodes"; \
+	fi
+
 .PHONY: scenario
 scenario: ## Switch scenario: make scenario S=b-pdb-blocked
 	@if [ -z "$(S)" ]; then \
 		echo "usage: make scenario S=<a-fragmented|b-pdb-blocked|c-topology-spread|d-anti-affinity|e-tainted-pool|f-stateful>"; \
 		exit 1; \
 	fi
+	@$(MAKE) --no-print-directory fabric-reset
 	helm upgrade --install $(DEMO_RELEASE) demo/charts/dencer-demo \
 		--namespace $(DEMO_NAMESPACE) --create-namespace \
 		--set scenario=$(S)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 k8s-dencer continuously analyzes your Kubernetes cluster's constraints (PDBs, topology spread, affinity, taints) and builds a node consolidation plan — broken into discrete, impact-rated steps you can inspect and run on your own terms, on request or during a maintenance window. Nothing executes without explicit approval.
 
-**Still read-only.** It plans and explains; it never cordons, drains or evicts. No ServiceAccount is granted `pods/eviction`, and `make lint` fails the build if any values profile ever grants it. The executor arrives in M10 — with its own ServiceAccount, behind the authorization gate that M9 has already shipped.
+**Execution is opt-in, gated, and off by default.** Set `executor.enabled=true` and a separate workload — its own image, its own ServiceAccount, no inbound network surface — becomes able to cordon and evict. Everything else stays read-only: `make lint` fails the build if `pods/eviction` appears on any role but the executor's, or in any profile that did not ask for one.
 
 Full design: [docs/k8s-consolidation-agent-architecture.md](docs/k8s-consolidation-agent-architecture.md)
 
@@ -33,7 +33,7 @@ state on its own.
 | Milestone | Scope | State |
 |---|---|---|
 | **M9** | AuthN/AuthZ via TokenReview + SubjectAccessReview; OIDC SSO; NetworkPolicy on by default | **done** |
-| **M10** | Executor + Safety Guard, own ServiceAccount, `pods/eviction` | planned |
+| **M10** | Executor + Safety Guard, own ServiceAccount, `pods/eviction`, audited runs | **done** |
 | **M11** | UI rebuild: packing view, motion, action-first header | planned |
 | **M12** | Execution controls, live run, OIDC sign-in flow, plan pinning | planned |
 | **M13** | End-to-end on KWOK incl. real SSO against Dex | planned |
@@ -57,8 +57,12 @@ plan:        id=dcdd608cf7c9 steps=16 nodesBefore=29 nodesAfter=13 reclaims=16
 
 Plans are rated, explained, persisted, visualised, and answerable in natural
 language through a Kagent agent. The API is authenticated and authorized
-against cluster RBAC. Nothing in the release can drain, cordon or evict — and
-`make lint` fails the build if any values profile grants `pods/eviction`.
+against cluster RBAC.
+
+With `executor.enabled=true`, an operator holding `create consolidations.dencer.io`
+can run a chosen subset of steps. Nothing else in the release can cordon, drain
+or evict, and `make lint` fails the build if `pods/eviction` reaches any role
+but the executor's.
 
 Three debug endpoints on the planner's health port expose current state as
 YAML: `/debug/snapshot`, `/debug/constraints` and `/debug/plan`.
@@ -70,10 +74,11 @@ YAML: `/debug/snapshot`, `/debug/constraints` and `/debug/plan`.
 **Prerequisites:** a Kubernetes cluster, Docker, Helm 3.8+, Go 1.26+, Node 22+. Kagent is optional and, if wanted, must be installed separately (see [Kagent](#kagent) below).
 
 ```bash
-make demo     # KWOK fabric + 30-node topology + build images + install the chart
-make token    # mint an operator token — the UI asks for one
-make ui       # port-forward and print the URLs
-make down     # remove all three releases
+make demo          # KWOK fabric + 30-node topology + build images + install the chart
+make token         # mint an operator token — the UI asks for one
+make ui            # port-forward and print the URLs
+make fabric-reset  # uncordon every KWOK node after an executor run
+make down          # remove all three releases
 ```
 
 `make` with no target lists everything.
@@ -84,13 +89,15 @@ make down     # remove all three releases
 
 ```
 api/v1alpha1/      CRD types (ConsolidationPolicy) — importable, not internal/
-cmd/               planner, ui-backend — one dir per shipped image
+cmd/               planner, ui-backend, executor — one dir per shipped image
 internal/
   model/           domain types; NO k8s imports, so the planner is testable from a YAML snapshot
   cluster/         informer-backed collector, k8s->model conversion, MetricsSource
   constraints/     effective per-pod constraints + explanations; placement feasibility
   planner/         Strategy interface + greedy first-fit-decreasing packer
   impact/          Green/Yellow/Red classifier + rationale composition
+  safety/          the non-negotiable rails; refuses Red, caps blast radius, re-checks PDBs
+  executor/        the ONLY package that mutates a cluster: cordon, evict, verify, abort
   store/           Store interface + SQLite implementation and migrations
   auth/            TokenReview authn + SubjectAccessReview authz; no credential store of our own
   api/             rest/ (+ SSE events), graph/ (Cytoscape payload), agenttools/ (MCP)
@@ -143,11 +150,16 @@ Runs `helm lint` and `kubeconform --strict` across every profile, then asserts t
 4. **no profile grants `pods/eviction`**
 5. `database.type=sqlite` with `uiBackend.replicaCount=2` is rejected by `values.schema.json`
 6. the packaged chart excludes the `ci/` fixtures
-7. **no profile disables authentication**
-8. `system:auth-delegator` is bound to ui-backend and to nothing else
-9. the consolidation-operator ClusterRole ships **unbound**
-10. a NetworkPolicy is present by default, and restricts ingress only
-11. `auth.oidc.enabled=true` without an issuer and client ID is rejected
+7. **`pods/eviction` appears only on the executor's ClusterRole**, and only in a profile that enabled it
+8. planner and ui-backend hold **no write verb on nodes or pods**, ever
+9. the executor renders **no Service** — the component that can evict is unreachable
+10. `executor.enabled=true` is rejected without `auth.enabled` and without `persistence.enabled`
+11. no container declares a **duplicate env key** (valid YAML, rejected by server-side apply)
+12. **no profile disables authentication**
+13. `system:auth-delegator` is bound to ui-backend and to nothing else
+14. the consolidation-operator ClusterRole ships **unbound**
+15. a NetworkPolicy is present by default, and restricts ingress only
+16. `auth.oidc.enabled=true` without an issuer and client ID is rejected
 
 ### Known constraints
 
@@ -273,6 +285,117 @@ make token     # mints one and prints it; paste into the UI
 
 ---
 
+## Execution
+
+Off by default. `executor.enabled=true` adds one workload and one route.
+
+```
+browser ──POST /api/v1/plans/{id}/execute──► ui-backend
+                                              │ SubjectAccessReview
+                                              │ create consolidations.dencer.io
+                                              ▼
+                                        runs table  ◄── shared SQLite volume
+                                              │
+                                              │ atomic claim
+                                              ▼
+                                          executor ──► cordon / evict
+```
+
+ui-backend authorizes and writes a row; the executor claims it. That split is
+the design:
+
+- **The component that answers HTTP cannot evict.** ui-backend's ServiceAccount
+  has no write verb on nodes or pods, and never will — a lint assertion holds it
+  there.
+- **The component that can evict answers nothing.** The executor has no Service
+  and no API. Its only inbound path is a row appearing in a table.
+- **Authorization happens once, at enqueue.** The executor then works under its
+  own identity, so a 15-minute ID token can authorize a 40-minute
+  consolidation. The requester's username and groups are recorded on the run.
+
+### What the executor does per step
+
+```
+guard.CheckStep      against state read seconds ago, not the plan's snapshot
+cordon               merge patch of spec.unschedulable — no `update` verb needed
+for each pod:
+    guard.CheckEviction   live PDB headroom, re-read before EVERY eviction
+    evict                 policy/v1 eviction API, so the API server enforces PDBs
+    wait                  until the pod is actually gone
+verify               affected workloads regained their replicas elsewhere
+```
+
+Eviction goes through the **eviction subresource**, never a pod delete. A delete
+would bypass PodDisruptionBudgets entirely; that single choice is what makes
+every PDB guarantee in this product real. The executor's RBAC grants
+`create pods/eviction` and deliberately does **not** grant `delete pods`.
+
+### The Safety Guard
+
+[`internal/safety`](internal/safety/safety.go) — architecture doc §9, enforced in
+code rather than in API validation, so no crafted request reaches around it.
+Each rail is named in the audit event that blocks on it.
+
+| Rule | Refuses |
+|---|---|
+| `RedRequiresWindow` | any Red step — maintenance windows are Phase 3, so there is no window to be inside |
+| `MaxNodesPerRun` | draining more than `safety.maxNodesPerRun` in one request |
+| `MinReadyNodes` | dropping below `safety.minReadyNodes` schedulable nodes |
+| `StepFreshness` | a step whose pods no longer have anywhere to go |
+| `PDBHeadroom` | an eviction the budget cannot absorb, re-checked per pod |
+| `NodeNotFound` | a target node that has vanished |
+
+**Red is not configurable.** There is no value that permits it. Exposing one
+would turn a safety rail into a footgun.
+
+The guard predicts; the executor then **verifies reality**. This is the
+deliberate alternative to importing kube-scheduler's framework (doc §7): after
+each step, affected workloads must have regained their replicas elsewhere or the
+run stops. A prediction that turns out wrong aborts rather than compounding.
+
+### Abort means uncordon, not rollback
+
+**Evicted pods are not restored.** Eviction cannot be undone, and calling the
+abort path "rollback" would be a lie in the docs and a surprise at 3am. On
+failure or timeout the executor uncordons the node and stops — using a context
+detached from the step deadline, since the usual reason to abort is that the
+deadline expired. If the uncordon itself fails, the audit event says so and
+names the `kubectl uncordon` needed.
+
+A run ends in one of three terminal states, and `Blocked` is deliberately
+distinct from `Failed`: "the rails protected you" and "something broke" call for
+different responses.
+
+### Confirming the split yourself
+
+```bash
+# NOTE --subresource. `can-i create pods/eviction` answers "no" for everyone,
+# including accounts that hold the permission — a check that cannot fail.
+for sa in planner ui-backend executor; do
+  printf '%-12s ' "$sa"
+  kubectl auth can-i create pods --subresource=eviction -n k8s-dencer \
+    --as=system:serviceaccount:k8s-dencer:k8s-dencer-$sa
+done
+# planner no / ui-backend no / executor yes
+
+kubectl auth can-i delete pods -n k8s-dencer \
+  --as=system:serviceaccount:k8s-dencer:k8s-dencer-executor
+# no — a delete would bypass PodDisruptionBudgets
+```
+
+### Audit trail
+
+Every action lands in `run_events` with the plan, the step, the node, the pod,
+the action, the rule that refused, and the actor. A plan with a run against it
+is **never pruned**, however old — doc §9 ties the audit log to the plan version,
+and pruning it would leave the log pointing at nothing.
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" localhost:8090/api/v1/runs/<runId> | jq .events
+```
+
+---
+
 ## Test fabric (KWOK)
 
 A node-consolidation planner cannot be tested on a single-node cluster. [KWOK](https://kwok.sigs.k8s.io/) provides fake nodes with no kubelet, so a laptop presents a 30-node topology while the **real** scheduler, PDB accounting and eviction API all apply.
@@ -283,6 +406,13 @@ make demo-up                        # 30 fake nodes across 3 zones + the base wo
 make scenario S=b-pdb-blocked       # switch constraint scenario
 make demo-down && make kwok-down
 ```
+
+**After an executor run, reset the fabric before switching scenarios.**
+Cordoning a node makes the node controller add
+`node.kubernetes.io/unschedulable` to `.spec.taints`, owned by the cluster's own
+field manager — and the demo chart manages `.spec.taints` too, so its
+server-side apply then fails with a field-manager conflict. `make scenario`
+calls `make fabric-reset` first for exactly this reason.
 
 > KWOK's docs advertise OCI coordinates at `oci://registry.k8s.io/kwok/charts/*`, but that path currently publishes no tags. The Makefile uses the classic repo `https://kwok.sigs.k8s.io/charts/`.
 
@@ -403,7 +533,12 @@ GET /api/v1/plans/{id}/steps/{seq}                   step + the constraints of t
 GET /api/v1/plans/{id}/graph                         Cytoscape elements + stat tiles
 GET /api/v1/plans/{id}/snapshot                      the cluster state it was planned against
 GET /api/v1/plans/{id}/constraints[/{ns}/{pod}]      constraint analysis
-GET /api/v1/events                                   live plan changes (SSE)
+GET /api/v1/events                                   live plan changes and run progress (SSE)
+GET /api/v1/runs                                     the in-flight run, if any
+GET /api/v1/runs/{runId}                             one run plus its full audit trail
+GET /api/v1/plans/{id}/runs                          runs against a plan
+
+POST /api/v1/plans/{id}/execute                      queue steps for execution
 ```
 
 Everything but `authinfo` requires `get plans.dencer.io` — see

--- a/charts/k8s-dencer/ci/orbstack-values.yaml
+++ b/charts/k8s-dencer/ci/orbstack-values.yaml
@@ -65,6 +65,29 @@ persistence:
   storageClass: ""
   size: 1Gi
 
+# On by default here because the POC exists to exercise real drains against the
+# KWOK fabric — real cordons, real evictions, real PDB enforcement. This is the
+# one profile that turns it on; the product defaults keep it off.
+executor:
+  enabled: true
+  image:
+    registry: ""
+    repository: k8s-dencer-executor
+    pullPolicy: IfNotPresent
+  resources:
+    requests:
+      cpu: 25m
+      memory: 64Mi
+    limits:
+      cpu: 500m
+      memory: 256Mi
+
+safety:
+  # The fabric is 30 fake nodes with a floor that would otherwise refuse most
+  # of the plan; and a demo wants to see several nodes drain in one run.
+  maxNodesPerRun: 8
+  minReadyNodes: 5
+
 # Kagent 0.9.12 is already installed in this cluster.
 kagent:
   enabled: true

--- a/charts/k8s-dencer/templates/NOTES.txt
+++ b/charts/k8s-dencer/templates/NOTES.txt
@@ -15,12 +15,27 @@ Reach the UI:
   open http://localhost:8080
 {{- end }}
 
-Verify the read-only guarantee:
+Verify who can evict. Note --subresource: `can-i create pods/eviction` answers
+"no" for everyone, including accounts that hold the permission, so the obvious
+form is a check that cannot fail.
 {{- range $component := list "planner" "ui-backend" }}
-  kubectl auth can-i create pods/eviction \
+  kubectl auth can-i create pods --subresource=eviction -n {{ $.Release.Namespace }} \
     --as=system:serviceaccount:{{ $.Release.Namespace }}:{{ include "k8s-dencer.componentServiceAccountName" (dict "component" $component "ctx" $) }}
 {{- end }}
   # both must print: no
+{{- if .Values.executor.enabled }}
+
+  kubectl auth can-i create pods --subresource=eviction -n {{ .Release.Namespace }} \
+    --as=system:serviceaccount:{{ .Release.Namespace }}:{{ include "k8s-dencer.componentServiceAccountName" (dict "component" "executor" "ctx" .) }}
+  # must print: yes — this is the one account that may drain nodes
+
+EXECUTION IS ENABLED. An operator holding create consolidations.dencer.io can
+drain nodes through the UI. Rails currently in force:
+  Red-rated steps      refused outright (maintenance windows are Phase 3)
+  max nodes per run    {{ .Values.safety.maxNodesPerRun }}
+  minimum ready nodes  {{ .Values.safety.minReadyNodes }}
+Aborting a step uncordons the node; it does NOT restore evicted pods.
+{{- end }}
 
 {{ if .Values.auth.enabled -}}
 Authentication is ON. Nobody can read a plan until you grant them the

--- a/charts/k8s-dencer/templates/executor/deployment.yaml
+++ b/charts/k8s-dencer/templates/executor/deployment.yaml
@@ -1,0 +1,163 @@
+{{- if .Values.executor.enabled }}
+{{/*
+The only workload that can change a cluster.
+
+Three properties are deliberate:
+
+  - No Service. Work is claimed from the plan store, so the one component
+    holding pods/eviction has no inbound network surface at all.
+  - One replica, always. Two executors would each be making placement
+    decisions the other invalidates. The store's atomic claim would stop them
+    taking the same run, but not from draining two nodes at once.
+  - Recreate, not RollingUpdate. It shares the SQLite volume with the planner
+    and ui-backend, and an overlap would put two writers on one file.
+*/}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "k8s-dencer.fullname" . }}-executor
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "k8s-dencer.componentLabels" (dict "ctx" . "component" "executor") | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "k8s-dencer.componentSelectorLabels" (dict "ctx" . "component" "executor") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "k8s-dencer.componentLabels" (dict "ctx" . "component" "executor") | nindent 8 }}
+        {{- with .Values.executor.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with (merge (dict) .Values.executor.podAnnotations .Values.commonAnnotations) }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "k8s-dencer.componentServiceAccountName" (dict "component" "executor" "ctx" .) }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.executor.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: executor
+          image: {{ include "k8s-dencer.image" (dict "image" .Values.executor.image "ctx" .) | quote }}
+          imagePullPolicy: {{ .Values.executor.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          env:
+            - name: LOG_LEVEL
+              value: {{ .Values.executor.logLevel | quote }}
+            - name: HTTP_ADDR
+              value: ":{{ .Values.executor.probePort }}"
+            - name: DATABASE_PATH
+              value: {{ .Values.database.sqlite.path | quote }}
+            # Identifies this executor in claims and audit events, so a run can
+            # be traced back to a specific pod.
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: SAFETY_MAX_NODES_PER_RUN
+              value: {{ .Values.safety.maxNodesPerRun | quote }}
+            - name: SAFETY_MIN_READY_NODES
+              value: {{ .Values.safety.minReadyNodes | quote }}
+            - name: STEP_TIMEOUT
+              value: {{ .Values.executor.stepTimeout | quote }}
+            - name: SETTLE_TIMEOUT
+              value: {{ .Values.executor.settleTimeout | quote }}
+            - name: QUEUE_POLL_INTERVAL
+              value: {{ .Values.executor.queuePollInterval | quote }}
+            - name: CLUSTER_POLL_INTERVAL
+              value: {{ .Values.executor.clusterPollInterval | quote }}
+            {{- with .Values.executor.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          ports:
+            # Probes only. There is no API on this port.
+            - name: probe
+              containerPort: {{ .Values.executor.probePort }}
+              protocol: TCP
+          startupProbe:
+            httpGet:
+              path: /startupz
+              port: probe
+            periodSeconds: 5
+            failureThreshold: 24
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: probe
+            periodSeconds: 20
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: probe
+            periodSeconds: 10
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.executor.resources | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: data
+              mountPath: {{ dir .Values.database.sqlite.path }}
+            {{- with .Values.executor.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: data
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "k8s-dencer.pvcName" . }}
+          {{- else }}
+          # With no persistence the executor gets its own empty volume and will
+          # never see a queued run. values.schema.json rejects that combination.
+          emptyDir: {}
+          {{- end }}
+        {{- with .Values.executor.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.executor.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.executor.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      affinity:
+        {{- if .Values.executor.affinity }}
+        {{- toYaml .Values.executor.affinity | nindent 8 }}
+        {{- else if eq .Values.database.type "sqlite" }}
+        # A ReadWriteOnce claim can only be mounted by pods on one node, so the
+        # executor must land wherever ui-backend did. Same constraint the
+        # planner already carries; it lifts when the Postgres store arrives.
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  {{- include "k8s-dencer.componentSelectorLabels" (dict "ctx" . "component" "ui-backend") | nindent 18 }}
+        {{- end }}
+{{- end }}

--- a/charts/k8s-dencer/templates/rbac.yaml
+++ b/charts/k8s-dencer/templates/rbac.yaml
@@ -150,4 +150,73 @@ rules:
     resources: ["consolidations"]
     verbs: ["create"]
 {{- end }}
+{{- if .Values.executor.enabled }}
+---
+{{/*
+The only grant of pods/eviction in this chart, on the only ServiceAccount that
+is not attached to anything reachable from the network.
+
+Read this list against internal/executor/cluster.go, which enumerates the four
+operations the code can perform. They should match exactly:
+
+  nodes  patch   -> cordon and uncordon, as a merge patch of spec.unschedulable
+  pods/eviction  -> the policy/v1 eviction API, which is what makes the API
+                    server enforce PodDisruptionBudgets
+
+Note what is absent and must stay absent:
+
+  - delete on pods. A delete bypasses PodDisruptionBudgets entirely. Eviction
+    is the whole point; a delete verb here would silently defeat it.
+  - update on nodes. patch carries one field, so a concurrent change by the
+    cluster autoscaler or an operator with kubectl cannot be clobbered.
+  - anything on secrets, configmaps, deployments, or scale subresources.
+*/}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "k8s-dencer.fullname" . }}-executor
+  labels:
+    {{- include "k8s-dencer.componentLabels" (dict "ctx" . "component" "executor") | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch", "patch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods/eviction"]
+    verbs: ["create"]
+  # Read-only, and only to name a pod's real controller in the audit trail and
+  # to verify a workload recovered after its pods moved.
+  - apiGroups: ["apps"]
+    resources: ["replicasets", "deployments", "statefulsets", "daemonsets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "k8s-dencer.fullname" . }}-executor
+  labels:
+    {{- include "k8s-dencer.componentLabels" (dict "ctx" . "component" "executor") | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "k8s-dencer.fullname" . }}-executor
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "k8s-dencer.componentServiceAccountName" (dict "component" "executor" "ctx" .) }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- end }}

--- a/charts/k8s-dencer/templates/serviceaccount.yaml
+++ b/charts/k8s-dencer/templates/serviceaccount.yaml
@@ -2,12 +2,14 @@
 {{/*
 One ServiceAccount per component, so their permissions can differ. ui-backend
 alone is bound to system:auth-delegator; the planner has no business validating
-tokens, and in Phase 2 only the executor will be able to evict.
+tokens, and only the executor is granted pods/eviction.
 
 The frontend is absent deliberately: it serves static assets and proxies, and
 never talks to the API server.
 */}}
-{{- range $component := list "planner" "ui-backend" }}
+{{- $components := list "planner" "ui-backend" }}
+{{- if $.Values.executor.enabled }}{{ $components = append $components "executor" }}{{ end }}
+{{- range $component := $components }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/k8s-dencer/templates/ui-backend/deployment.yaml
+++ b/charts/k8s-dencer/templates/ui-backend/deployment.yaml
@@ -84,6 +84,11 @@ spec:
             # POD_NAMESPACE is already declared below; it also scopes the
             # SubjectAccessReview, so permission can be granted with a
             # RoleBinding in this namespace rather than a cluster-wide one.
+            # Adds POST /api/v1/plans/{id}/execute. Without an executor to
+            # claim the work there is no route at all, rather than one that
+            # queues requests nothing will ever perform.
+            - name: EXECUTOR_ENABLED
+              value: {{ .Values.executor.enabled | quote }}
             - name: AUTH_ENABLED
               value: {{ .Values.auth.enabled | quote }}
             - name: AUTH_ANONYMOUS_READ

--- a/charts/k8s-dencer/values.schema.json
+++ b/charts/k8s-dencer/values.schema.json
@@ -294,6 +294,109 @@
         }
       ]
     },
+    "executor": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "image": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "registry": {
+              "type": "string"
+            },
+            "repository": {
+              "type": "string"
+            },
+            "tag": {
+              "type": "string"
+            },
+            "pullPolicy": {
+              "type": "string",
+              "enum": [
+                "Always",
+                "IfNotPresent",
+                "Never"
+              ]
+            }
+          }
+        },
+        "logLevel": {
+          "type": "string",
+          "enum": [
+            "debug",
+            "info",
+            "warn",
+            "error"
+          ]
+        },
+        "probePort": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "stepTimeout": {
+          "type": "string"
+        },
+        "settleTimeout": {
+          "type": "string"
+        },
+        "queuePollInterval": {
+          "type": "string"
+        },
+        "clusterPollInterval": {
+          "type": "string"
+        },
+        "resources": {
+          "type": "object"
+        },
+        "podAnnotations": {
+          "type": "object"
+        },
+        "podLabels": {
+          "type": "object"
+        },
+        "nodeSelector": {
+          "type": "object"
+        },
+        "tolerations": {
+          "type": "array"
+        },
+        "affinity": {
+          "type": "object"
+        },
+        "priorityClassName": {
+          "type": "string"
+        },
+        "extraEnv": {
+          "type": "array"
+        },
+        "extraVolumes": {
+          "type": "array"
+        },
+        "extraVolumeMounts": {
+          "type": "array"
+        }
+      }
+    },
+    "safety": {
+      "type": "object",
+      "additionalProperties": false,
+      "$comment": "Red-rated steps are refused in code and are deliberately not configurable here.",
+      "properties": {
+        "maxNodesPerRun": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "minReadyNodes": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
     "ingress": {
       "type": "object",
       "properties": {
@@ -666,6 +769,86 @@
             }
           }
         }
+      }
+    },
+    {
+      "$comment": "An execute endpoint must never be reachable without authorization. Refusing to render is the only way to make that impossible rather than merely discouraged.",
+      "if": {
+        "properties": {
+          "executor": {
+            "type": "object",
+            "properties": {
+              "enabled": {
+                "const": true
+              }
+            },
+            "required": [
+              "enabled"
+            ]
+          }
+        },
+        "required": [
+          "executor"
+        ]
+      },
+      "then": {
+        "properties": {
+          "auth": {
+            "type": "object",
+            "properties": {
+              "enabled": {
+                "$comment": "executor.enabled=true requires auth.enabled=true",
+                "const": true
+              }
+            },
+            "required": [
+              "enabled"
+            ]
+          }
+        },
+        "required": [
+          "auth"
+        ]
+      }
+    },
+    {
+      "$comment": "The executor claims work from the shared plan store. On an emptyDir it gets its own empty copy, never sees a queued run, and appears silently broken.",
+      "if": {
+        "properties": {
+          "executor": {
+            "type": "object",
+            "properties": {
+              "enabled": {
+                "const": true
+              }
+            },
+            "required": [
+              "enabled"
+            ]
+          }
+        },
+        "required": [
+          "executor"
+        ]
+      },
+      "then": {
+        "properties": {
+          "persistence": {
+            "type": "object",
+            "properties": {
+              "enabled": {
+                "$comment": "executor.enabled=true requires persistence.enabled=true",
+                "const": true
+              }
+            },
+            "required": [
+              "enabled"
+            ]
+          }
+        },
+        "required": [
+          "persistence"
+        ]
       }
     }
   ],

--- a/charts/k8s-dencer/values.yaml
+++ b/charts/k8s-dencer/values.yaml
@@ -254,6 +254,82 @@ ingress:
           pathType: Prefix
   tls: []
 
+# The executor: the only component that can change your cluster.
+#
+# OFF by default, and an upgrade must never silently turn it on. Enabling it
+# creates a ServiceAccount holding pods/eviction and adds a POST route to
+# ui-backend — neither of which anyone should acquire by taking a chart bump.
+#
+# Even enabled, nothing runs without a person asking. The executor performs
+# only the steps named in a request that passed a SubjectAccessReview, and the
+# Safety Guard (see `safety` below) re-checks every one against live cluster
+# state before touching anything.
+#
+# Requires auth.enabled and persistence.enabled; values.schema.json rejects
+# either combination.
+executor:
+  enabled: false
+
+  image:
+    registry: ghcr.io
+    repository: atedgimo/k8s-dencer-executor
+    # Defaults to .Chart.AppVersion.
+    tag: ""
+    pullPolicy: IfNotPresent
+
+  logLevel: info
+
+  # Probes only. The executor serves no API — work arrives through the shared
+  # plan store, so it has no inbound network surface.
+  probePort: 8081
+
+  # How long one step may take end to end before it aborts and uncordons.
+  stepTimeout: 10m
+  # How long to wait for evicted pods to be replaced elsewhere before giving up
+  # on a step. Raise it for workloads with slow startup.
+  settleTimeout: 5m
+  # How often to look for queued work.
+  queuePollInterval: 3s
+  # How often cluster state is re-read while a drain is in progress. Every
+  # safety decision is made against a read this fresh.
+  clusterPollInterval: 2s
+
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+  podAnnotations: {}
+  podLabels: {}
+  nodeSelector: {}
+  tolerations: []
+  # Left empty to inherit the co-scheduling the SQLite volume requires.
+  affinity: {}
+  priorityClassName: ""
+  extraEnv: []
+  extraVolumes: []
+  extraVolumeMounts: []
+
+# The non-negotiable rails on execution (architecture doc §9).
+#
+# Enforced in code by internal/safety, checked before every step and before
+# every individual eviction against freshly-read state — not by API input
+# validation, so no crafted request can bypass them.
+#
+# Note what is NOT configurable: Red-rated steps are refused outright. They are
+# confined to approved maintenance windows, which do not exist until Phase 3,
+# and exposing that as a value would turn a safety rail into a footgun.
+safety:
+  # Most nodes one execution request may drain. Reached mid-run, the run stops
+  # cleanly with the steps so far completed.
+  maxNodesPerRun: 5
+  # Schedulable nodes to leave behind, so a consolidation cannot squeeze the
+  # cluster to the point where the next failure has nowhere to go.
+  minReadyNodes: 3
+
 networkPolicy:
   # Restricts ui-backend ingress to the frontend and (when enabled) Kagent.
   #

--- a/cmd/executor/main.go
+++ b/cmd/executor/main.go
@@ -1,0 +1,155 @@
+// Command executor performs consolidation steps an operator has approved.
+//
+// This is the only k8s-dencer component that changes a cluster, and the only
+// one whose ServiceAccount holds pods/eviction. It exposes no API: work is
+// claimed from the shared plan store, so the workload that can drain nodes
+// cannot be reached over the network at all. The health endpoints are the only
+// listener, and they serve probes.
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
+	"time"
+
+	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
+
+	"github.com/atedgimo/k8s-dencer/internal/cluster"
+	"github.com/atedgimo/k8s-dencer/internal/executor"
+	"github.com/atedgimo/k8s-dencer/internal/httpserver"
+	"github.com/atedgimo/k8s-dencer/internal/safety"
+	"github.com/atedgimo/k8s-dencer/internal/store"
+	sqlitestore "github.com/atedgimo/k8s-dencer/internal/store/sqlite"
+	"github.com/atedgimo/k8s-dencer/internal/telemetry"
+)
+
+// version is stamped at build time via -ldflags.
+var version = "dev"
+
+func main() {
+	log := telemetry.NewLogger("executor", env("LOG_LEVEL", "info"))
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	if err := run(ctx, log); err != nil {
+		log.Error("fatal", "error", err)
+		os.Exit(1)
+	}
+	log.Info("executor stopped")
+}
+
+func run(ctx context.Context, log *slog.Logger) error {
+	path := env("DATABASE_PATH", "/data/dencer.db")
+	db, err := sqlitestore.Open(path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+
+	// The ui-backend owns the schema and runs migrations. The executor waits
+	// for the tables rather than creating them, so two writers can never race
+	// to define them differently.
+	if err := waitForSchema(ctx, db, log); err != nil {
+		return err
+	}
+
+	cfg, err := ctrlconfig.GetConfig()
+	if err != nil {
+		return err
+	}
+	reader, err := cluster.NewDirect(cfg)
+	if err != nil {
+		return err
+	}
+
+	limits := safety.Limits{
+		MaxNodesPerRun: intEnv("SAFETY_MAX_NODES_PER_RUN", safety.DefaultLimits().MaxNodesPerRun),
+		MinReadyNodes:  intEnv("SAFETY_MIN_READY_NODES", safety.DefaultLimits().MinReadyNodes),
+		// Never read from configuration. Red steps are confined to approved
+		// maintenance windows, which do not exist until Phase 3, and making
+		// that a values key would turn a safety rail into a footgun.
+		AllowRed: false,
+	}
+
+	exec := executor.New(executor.NewK8sCluster(reader), db, db, log, executor.Options{
+		Worker:        env("POD_NAME", "executor"),
+		Limits:        limits,
+		StepTimeout:   duration(log, "STEP_TIMEOUT", 10*time.Minute),
+		SettleTimeout: duration(log, "SETTLE_TIMEOUT", 5*time.Minute),
+		PollInterval:  duration(log, "CLUSTER_POLL_INTERVAL", 2*time.Second),
+	})
+
+	health := &httpserver.Health{}
+	mux := http.NewServeMux()
+	health.Register(mux)
+	health.SetReady(true)
+
+	log.Info("starting", "version", version, "worker", env("POD_NAME", "executor"),
+		"maxNodesPerRun", limits.MaxNodesPerRun, "minReadyNodes", limits.MinReadyNodes)
+
+	go exec.Run(ctx, duration(log, "QUEUE_POLL_INTERVAL", 3*time.Second))
+
+	return httpserver.Run(ctx, log, env("HTTP_ADDR", ":8081"), mux)
+}
+
+// waitForSchema blocks until ui-backend has migrated the database.
+//
+// On a fresh install all three pods start together and the executor may well
+// win the race. Crashlooping until the tables appear would work but reads as a
+// broken deploy; waiting quietly is the same outcome without the alarm.
+func waitForSchema(ctx context.Context, db *sqlitestore.Store, log *slog.Logger) error {
+	for attempt := 0; ; attempt++ {
+		// ErrNotFound means the query ran and matched nothing, which is
+		// exactly what a migrated but idle database looks like.
+		if _, err := db.ActiveRun(ctx); err == nil || errors.Is(err, store.ErrNotFound) {
+			return nil
+		}
+		if attempt == 0 {
+			log.Info("waiting for ui-backend to migrate the plan store", "path", env("DATABASE_PATH", "/data/dencer.db"))
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(2 * time.Second):
+		}
+	}
+}
+
+func env(key, fallback string) string {
+	if v, ok := os.LookupEnv(key); ok && v != "" {
+		return v
+	}
+	return fallback
+}
+
+func intEnv(key string, fallback int) int {
+	raw, ok := os.LookupEnv(key)
+	if !ok || raw == "" {
+		return fallback
+	}
+	v, err := strconv.Atoi(raw)
+	if err != nil {
+		return fallback
+	}
+	return v
+}
+
+func duration(log *slog.Logger, key string, fallback time.Duration) time.Duration {
+	raw, ok := os.LookupEnv(key)
+	if !ok || raw == "" {
+		return fallback
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		log.Warn("invalid duration, using default", "key", key, "value", raw, "default", fallback)
+		return fallback
+	}
+	return d
+}

--- a/cmd/ui-backend/main.go
+++ b/cmd/ui-backend/main.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"net/http"
 	"os"
@@ -71,6 +72,23 @@ func run(ctx context.Context, log *slog.Logger) error {
 	}
 
 	api := rest.New(db, log, version, guard, authCfg.Describe())
+
+	// The execute route exists only where an executor is deployed to claim the
+	// work. Without one there is no endpoint at all rather than a disabled
+	// one — a "not implemented" execute route is an invitation.
+	//
+	// ui-backend still holds no eviction permission: it writes a row, and the
+	// executor, which is unreachable from the network, performs the drain.
+	if boolEnv("EXECUTOR_ENABLED", false) {
+		if !authCfg.Enabled {
+			// Belt and braces with the chart's schema, which rejects the same
+			// combination. A mutating endpoint must never be reachable without
+			// authorization, however the binary was launched.
+			return errExecutorWithoutAuth
+		}
+		api = api.WithExecution(db)
+		log.Info("execution enabled", "route", "POST /api/v1/plans/{id}/execute")
+	}
 
 	health := &httpserver.Health{}
 	mux := http.NewServeMux()
@@ -169,6 +187,13 @@ func buildGuard(cfg auth.Config, log *slog.Logger) (*auth.Middleware, error) {
 		log,
 	), nil
 }
+
+// errExecutorWithoutAuth refuses to start rather than serve an unauthenticated
+// endpoint that can drain nodes. Failing loudly beats running in a state no
+// operator would have chosen on purpose.
+var errExecutorWithoutAuth = errors.New(
+	"EXECUTOR_ENABLED is set but AUTH_ENABLED is false; " +
+		"an execute endpoint must never be reachable without authorization")
 
 type errUnsupportedDatabase string
 

--- a/hack/lint-chart.sh
+++ b/hack/lint-chart.sh
@@ -76,13 +76,77 @@ grep -q "readOnlyRootFilesystem: true" <<<"$minimal" || fail "minimal profile lo
 grep -q "allowPrivilegeEscalation: false" <<<"$minimal" || fail "minimal profile lost allowPrivilegeEscalation"
 green "  restricted security context intact with all optionals off"
 
-bold "==> contract: no eviction permission anywhere (Phase 1 is read-only)"
-for profile in defaults minimal production orbstack; do
+bold "==> contract: eviction is granted only to the executor, only when enabled"
+# Phase 1's assertion was "nobody, anywhere". Phase 2 narrows it rather than
+# dropping it: the executor exists to evict, but every other component must
+# still be provably unable to, and an install that did not ask for an executor
+# must gain nothing.
+# These profiles do not ask for an executor, so they must gain nothing. The
+# orbstack profile deliberately does — it is the POC that exercises real
+# drains — and is checked separately below.
+for profile in defaults minimal production; do
   if render "$profile" | grep -q "pods/eviction"; then
-    fail "$profile grants pods/eviction; Phase 1 must be read-only"
+    fail "$profile grants pods/eviction without enabling the executor"
   fi
 done
-green "  no profile grants pods/eviction"
+green "  no eviction in any profile that did not ask for an executor"
+
+# The one profile that opts in must still confine the grant.
+orbstack_eviction="$(awk '/^kind: ClusterRole$/,/^---/' <<<"$(render orbstack)" \
+  | awk '/^  name: /{n=$2} /pods\/eviction/{print n}' | sort -u)"
+if [[ "$orbstack_eviction" != "dencer-k8s-dencer-executor" ]]; then
+  fail "orbstack enables the executor but pods/eviction landed on: ${orbstack_eviction:-nothing}"
+fi
+green "  orbstack opts in, and only its executor role holds eviction"
+
+with_executor="$(helm template dencer "$CHART" --namespace k8s-dencer \
+  --set executor.enabled=true --set persistence.enabled=true)"
+
+# The grant must live on the executor's ClusterRole and no other.
+eviction_roles="$(awk '/^kind: ClusterRole$/,/^---/' <<<"$with_executor" \
+  | awk '/^  name: /{n=$2} /pods\/eviction/{print n}' | sort -u)"
+if [[ "$eviction_roles" != "dencer-k8s-dencer-executor" ]]; then
+  fail "pods/eviction appears on unexpected ClusterRole(s): ${eviction_roles:-none}"
+fi
+green "  pods/eviction confined to the executor ClusterRole"
+
+# The read role the planner and ui-backend share must never acquire a write
+# verb on a cluster workload. It legitimately writes status on its own
+# ConsolidationPolicy CRD, so the check is scoped to nodes and pods rather than
+# banning every write verb outright.
+read_role="$(awk '/name: dencer-k8s-dencer-read$/,/^---/' <<<"$with_executor")"
+offending="$(awk '
+  /^  - apiGroups:/       { resources = ""; }
+  /^    resources:/       { collecting = 1; next }
+  /^      - /             { if (collecting) { gsub(/^      - /, ""); resources = resources " " $0 } ; next }
+  /^    verbs:/           {
+      collecting = 0
+      if (resources ~ /(^| )(nodes|pods|pods\/eviction)( |$)/ &&
+          $0 ~ /(patch|update|delete|create)/) print "  " resources " ->" $0
+  }
+  /^    resources: \[/    { line = $0; sub(/^    resources: \[/, "", line); gsub(/[]"]/, "", line); resources = " " line }
+' <<<"$read_role")"
+if [[ -n "$offending" ]]; then
+  fail "the shared read ClusterRole grants writes on cluster workloads:
+$offending"
+fi
+green "  planner and ui-backend hold no write verb on nodes or pods"
+
+# The executor is the one workload with eviction, so it must also be the one
+# workload with no Service in front of it.
+if grep -q "name: dencer-k8s-dencer-executor$" <<<"$(awk '/^kind: Service$/,/^---/' <<<"$with_executor")"; then
+  fail "the executor has a Service; the component holding pods/eviction must not be reachable"
+fi
+green "  executor has no Service"
+
+bold "==> contract: the executor cannot be enabled into an unsafe configuration"
+if helm template dencer "$CHART" --set executor.enabled=true --set auth.enabled=false >/dev/null 2>&1; then
+  fail "schema accepted an executor with authentication disabled"
+fi
+if helm template dencer "$CHART" --set executor.enabled=true --set persistence.enabled=false >/dev/null 2>&1; then
+  fail "schema accepted an executor with no shared volume to claim work from"
+fi
+green "  rejected without auth, and without persistence"
 
 bold "==> contract: no duplicate env keys in any container"
 # kubeconform passes duplicate env names and so does helm template — a

--- a/internal/api/rest/execute.go
+++ b/internal/api/rest/execute.go
@@ -1,0 +1,233 @@
+package rest
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"sort"
+
+	"github.com/atedgimo/k8s-dencer/internal/auth"
+	"github.com/atedgimo/k8s-dencer/internal/model"
+	"github.com/atedgimo/k8s-dencer/internal/store"
+)
+
+// maxStepsPerRequest bounds one request. Not a safety rail — the Safety Guard
+// owns those and enforces them per step inside the executor — just a limit on
+// how much nonsense a single call can carry.
+const maxStepsPerRequest = 200
+
+// executeRequest is the body of POST /api/v1/plans/{id}/execute.
+type executeRequest struct {
+	// Steps are sequence numbers, in any order. Doc §5 requires an arbitrary
+	// subset or range rather than all-or-nothing.
+	Steps []int `json:"steps"`
+	// DryRun runs the full guard chain and emits the same event stream without
+	// cordoning or evicting anything.
+	DryRun bool `json:"dryRun"`
+}
+
+// handleExecute accepts an execution request and queues it.
+//
+// This route does not execute anything. It authorizes, validates, and writes a
+// row that the executor claims — so the component reachable from the network
+// holds no eviction permission, and the component holding eviction permission
+// is not reachable from the network.
+//
+// Authorization happens here, once. The executor then works under its own
+// ServiceAccount, which is why a run outlives the token that authorized it: a
+// 15-minute ID token can start a 40-minute consolidation. The requester's
+// identity is recorded on the run so it stays attributable afterwards.
+func (s *Server) handleExecute(w http.ResponseWriter, r *http.Request) {
+	if s.runs == nil {
+		writeError(w, http.StatusNotImplemented,
+			"this deployment has no executor; install with executor.enabled=true")
+		return
+	}
+
+	rec, err := s.record(r.Context(), r.PathValue("id"))
+	if err != nil {
+		s.fail(w, err)
+		return
+	}
+
+	var req executeRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<16)).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "request body is not valid JSON")
+		return
+	}
+
+	steps, err := validateSteps(req.Steps, rec.Plan)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	// One consolidation at a time. Two in flight would each be making
+	// placement decisions the other invalidates.
+	if active, err := s.runs.ActiveRun(r.Context()); err == nil {
+		writeJSON(w, http.StatusConflict, map[string]any{
+			"error":  fmt.Sprintf("run %s is already %s", active.ID, active.Status),
+			"code":   "run_in_progress",
+			"runId":  active.ID,
+			"status": active.Status,
+		})
+		return
+	} else if !errors.Is(err, store.ErrNotFound) {
+		s.fail(w, err)
+		return
+	}
+
+	// Identity is absent only when auth is disabled, which the chart's schema
+	// refuses to combine with an enabled executor.
+	actor := auth.Identity{Username: "auth-disabled", Source: auth.SourceAnonymous}
+	if id, ok := auth.IdentityFrom(r.Context()); ok {
+		actor = id
+	}
+
+	runID, err := s.runs.Enqueue(r.Context(), store.Run{
+		PlanID: rec.Plan.ID, Steps: steps, DryRun: req.DryRun,
+		Actor: actor.Username, ActorGroups: actor.Groups,
+	})
+	if err != nil {
+		s.fail(w, err)
+		return
+	}
+
+	s.log.Info("execution requested", "run", runID, "plan", rec.Plan.ID,
+		"steps", steps, "dryRun", req.DryRun, "actor", actor.Username)
+
+	// Tell connected clients immediately rather than making the UI wait for
+	// its next poll to discover a run it just started.
+	s.events.Publish(Event{Type: "run", Data: map[string]any{
+		"runId": runID, "planId": rec.Plan.ID, "status": store.RunPending,
+		"steps": steps, "dryRun": req.DryRun,
+	}})
+
+	writeJSON(w, http.StatusAccepted, map[string]any{
+		"runId": runID, "planId": rec.Plan.ID, "steps": steps,
+		"dryRun": req.DryRun, "status": store.RunPending,
+	})
+}
+
+// validateSteps rejects a request before it reaches the queue.
+//
+// Rejecting Red here is a courtesy, not a control: the Safety Guard refuses it
+// again inside the executor against live state, which is the check that
+// actually cannot be bypassed. Failing early just means the operator learns
+// now rather than after a run starts and immediately blocks.
+func validateSteps(requested []int, plan *model.Plan) ([]int, error) {
+	if len(requested) == 0 {
+		return nil, errors.New("no steps requested")
+	}
+	if len(requested) > maxStepsPerRequest {
+		return nil, fmt.Errorf("too many steps requested (%d); the maximum is %d",
+			len(requested), maxStepsPerRequest)
+	}
+
+	bySeq := make(map[int]model.PlanStep, len(plan.Steps))
+	for _, s := range plan.Steps {
+		bySeq[s.SequenceNumber] = s
+	}
+
+	seen := map[int]bool{}
+	out := make([]int, 0, len(requested))
+	var red []int
+
+	for _, seq := range requested {
+		step, ok := bySeq[seq]
+		if !ok {
+			return nil, fmt.Errorf("plan %s has no step %d", plan.ID, seq)
+		}
+		if seen[seq] {
+			continue // a duplicate is a client slip, not an error
+		}
+		seen[seq] = true
+		if step.RequiresMaintenanceWindow() {
+			red = append(red, seq)
+		}
+		out = append(out, seq)
+	}
+
+	if len(red) > 0 {
+		return nil, fmt.Errorf(
+			"step(s) %v are rated Red and may only run inside an approved maintenance window, "+
+				"which this release does not implement", red)
+	}
+
+	// Ascending regardless of how they were sent. Steps are ordered for a
+	// reason — later ones assume earlier ones freed capacity — and honouring a
+	// caller's shuffled order would quietly make the plan wrong.
+	sort.Ints(out)
+	return out, nil
+}
+
+func (s *Server) handleRun(w http.ResponseWriter, r *http.Request) {
+	if s.runs == nil {
+		writeError(w, http.StatusNotImplemented, "this deployment has no executor")
+		return
+	}
+	run, err := s.runs.RunByID(r.Context(), r.PathValue("runId"))
+	if err != nil {
+		s.failRun(w, err)
+		return
+	}
+	events, err := s.runs.Events(r.Context(), run.ID)
+	if err != nil {
+		s.fail(w, err)
+		return
+	}
+	if events == nil {
+		events = []store.RunEvent{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"run": run, "events": events})
+}
+
+func (s *Server) handleRunsForPlan(w http.ResponseWriter, r *http.Request) {
+	if s.runs == nil {
+		writeJSON(w, http.StatusOK, map[string]any{"runs": []store.Run{}})
+		return
+	}
+	rec, err := s.record(r.Context(), r.PathValue("id"))
+	if err != nil {
+		s.fail(w, err)
+		return
+	}
+	runs, err := s.runs.RunsForPlan(r.Context(), rec.Plan.ID, 50)
+	if err != nil {
+		s.fail(w, err)
+		return
+	}
+	if runs == nil {
+		runs = []store.Run{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"planId": rec.Plan.ID, "runs": runs})
+}
+
+// handleActiveRun lets the UI discover an in-flight run on load, so refreshing
+// the page during a consolidation does not lose sight of it.
+func (s *Server) handleActiveRun(w http.ResponseWriter, r *http.Request) {
+	if s.runs == nil {
+		writeJSON(w, http.StatusOK, map[string]any{"active": nil})
+		return
+	}
+	run, err := s.runs.ActiveRun(r.Context())
+	if errors.Is(err, store.ErrNotFound) {
+		writeJSON(w, http.StatusOK, map[string]any{"active": nil})
+		return
+	}
+	if err != nil {
+		s.fail(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"active": run})
+}
+
+func (s *Server) failRun(w http.ResponseWriter, err error) {
+	if errors.Is(err, store.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "no such run")
+		return
+	}
+	s.log.Error("run request failed", "error", err)
+	writeError(w, http.StatusInternalServerError, "internal error")
+}

--- a/internal/api/rest/execute_test.go
+++ b/internal/api/rest/execute_test.go
@@ -1,0 +1,243 @@
+package rest_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/atedgimo/k8s-dencer/internal/api/rest"
+	"github.com/atedgimo/k8s-dencer/internal/auth"
+	"github.com/atedgimo/k8s-dencer/internal/model"
+	"github.com/atedgimo/k8s-dencer/internal/store"
+	sqlitestore "github.com/atedgimo/k8s-dencer/internal/store/sqlite"
+)
+
+// denyExecute authorizes reads and refuses execution, so the two permissions
+// can be shown to be genuinely separate rather than one "authenticated" check.
+type denyExecute struct{ identity auth.Identity }
+
+func (d denyExecute) Require(res auth.Resource, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if res == auth.ExecuteConsolidations {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"code":"forbidden","error":"may not create consolidations.dencer.io"}`))
+			return
+		}
+		next.ServeHTTP(w, r.WithContext(auth.WithIdentity(r.Context(), d.identity)))
+	})
+}
+
+// allowAll stands in for a caller holding both permissions.
+type allowAll struct{ identity auth.Identity }
+
+func (a allowAll) Require(_ auth.Resource, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		next.ServeHTTP(w, r.WithContext(auth.WithIdentity(r.Context(), a.identity)))
+	})
+}
+
+func executableServer(t *testing.T, guard rest.Guard, steps ...model.PlanStep) (*httptest.Server, *sqlitestore.Store) {
+	t.Helper()
+	db, err := sqlitestore.Open(filepath.Join(t.TempDir(), "exec-api.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := db.Migrate(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := sampleRecord("plan-1")
+	rec.Plan.Steps = steps
+	if _, err := db.Save(context.Background(), rec); err != nil {
+		t.Fatal(err)
+	}
+
+	api := rest.New(db, slog.New(slog.DiscardHandler), "test", guard,
+		auth.Config{Enabled: true}.Describe()).WithExecution(db)
+	mux := http.NewServeMux()
+	api.Routes(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv, db
+}
+
+func planStep(seq int, node string, impact model.ImpactRating) model.PlanStep {
+	return model.PlanStep{
+		ID: "s", SequenceNumber: seq, TargetNode: node, Impact: impact,
+		Rationale: "rationale for step",
+		Moves:     []model.Move{{Namespace: "app", Pod: "web", FromNode: node, ToNode: "other"}},
+	}
+}
+
+func postExecute(t *testing.T, srv *httptest.Server, body string) (*http.Response, map[string]any) {
+	t.Helper()
+	res, err := http.Post(srv.URL+"/api/v1/plans/plan-1/execute", "application/json",
+		bytes.NewBufferString(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = res.Body.Close() })
+	var parsed map[string]any
+	_ = json.NewDecoder(res.Body).Decode(&parsed)
+	return res, parsed
+}
+
+var operator = auth.Identity{Username: "alice@example.com", Groups: []string{"oidc:sre"}, Source: auth.SourceToken}
+
+// Reading a plan and draining a node are different grants. A caller with the
+// first must not get the second.
+func TestExecuteRequiresItsOwnPermission(t *testing.T) {
+	srv, _ := executableServer(t, denyExecute{operator}, planStep(1, "a", model.ImpactGreen))
+
+	res, body := postExecute(t, srv, `{"steps":[1]}`)
+	if res.StatusCode != http.StatusForbidden {
+		t.Fatalf("got %d, want 403", res.StatusCode)
+	}
+	if body["code"] != "forbidden" {
+		t.Errorf("unexpected body: %v", body)
+	}
+
+	// And the read path still works for the same caller.
+	readRes, err := http.Get(srv.URL + "/api/v1/plans/latest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = readRes.Body.Close() }()
+	if readRes.StatusCode != http.StatusOK {
+		t.Errorf("read denied too: %d", readRes.StatusCode)
+	}
+}
+
+func TestExecuteQueuesARunAndRecordsTheRequester(t *testing.T) {
+	srv, db := executableServer(t, allowAll{operator},
+		planStep(1, "a", model.ImpactGreen), planStep(2, "b", model.ImpactYellow))
+
+	res, body := postExecute(t, srv, `{"steps":[2,1]}`)
+	if res.StatusCode != http.StatusAccepted {
+		t.Fatalf("got %d, want 202: %v", res.StatusCode, body)
+	}
+
+	runID, _ := body["runId"].(string)
+	run, err := db.RunByID(context.Background(), runID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.Status != store.RunPending {
+		t.Errorf("status = %s, want Pending", run.Status)
+	}
+	// Steps are ordered ascending whatever order they arrived in: later steps
+	// assume earlier ones freed capacity.
+	if len(run.Steps) != 2 || run.Steps[0] != 1 || run.Steps[1] != 2 {
+		t.Errorf("steps not normalised to ascending order: %v", run.Steps)
+	}
+	// The audit trail must name a person, not the service account.
+	if run.Actor != "alice@example.com" || len(run.ActorGroups) != 1 {
+		t.Errorf("requester not recorded: %+v", run)
+	}
+}
+
+// The API refuses Red early as a courtesy. The Safety Guard refuses it again
+// inside the executor against live state — that is the check that matters.
+func TestExecuteRefusesRedStepsUpFront(t *testing.T) {
+	srv, _ := executableServer(t, allowAll{operator},
+		planStep(1, "a", model.ImpactGreen), planStep(2, "b", model.ImpactRed))
+
+	res, body := postExecute(t, srv, `{"steps":[1,2]}`)
+	if res.StatusCode != http.StatusBadRequest {
+		t.Fatalf("got %d, want 400", res.StatusCode)
+	}
+	msg, _ := body["error"].(string)
+	if !strings.Contains(msg, "maintenance window") || !strings.Contains(msg, "2") {
+		t.Errorf("refusal should name the Red step and why: %s", msg)
+	}
+}
+
+func TestExecuteValidatesTheRequest(t *testing.T) {
+	srv, _ := executableServer(t, allowAll{operator}, planStep(1, "a", model.ImpactGreen))
+
+	for _, tc := range []struct{ name, body, want string }{
+		{"no steps", `{"steps":[]}`, "no steps requested"},
+		{"unknown step", `{"steps":[42]}`, "no step 42"},
+		{"malformed", `not json`, "not valid JSON"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			res, body := postExecute(t, srv, tc.body)
+			if res.StatusCode != http.StatusBadRequest {
+				t.Fatalf("got %d, want 400", res.StatusCode)
+			}
+			if msg, _ := body["error"].(string); !strings.Contains(msg, tc.want) {
+				t.Errorf("error %q does not mention %q", msg, tc.want)
+			}
+		})
+	}
+}
+
+// Two consolidations in flight would each invalidate the other's placement
+// decisions.
+func TestOnlyOneRunMayBeInFlight(t *testing.T) {
+	srv, _ := executableServer(t, allowAll{operator},
+		planStep(1, "a", model.ImpactGreen), planStep(2, "b", model.ImpactGreen))
+
+	if res, _ := postExecute(t, srv, `{"steps":[1]}`); res.StatusCode != http.StatusAccepted {
+		t.Fatalf("first request got %d", res.StatusCode)
+	}
+	res, body := postExecute(t, srv, `{"steps":[2]}`)
+	if res.StatusCode != http.StatusConflict {
+		t.Fatalf("second request got %d, want 409", res.StatusCode)
+	}
+	if body["code"] != "run_in_progress" || body["runId"] == nil {
+		t.Errorf("conflict should identify the run in progress: %v", body)
+	}
+}
+
+func TestDryRunIsCarriedThrough(t *testing.T) {
+	srv, db := executableServer(t, allowAll{operator}, planStep(1, "a", model.ImpactGreen))
+
+	_, body := postExecute(t, srv, `{"steps":[1],"dryRun":true}`)
+	run, err := db.RunByID(context.Background(), body["runId"].(string))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !run.DryRun {
+		t.Error("dryRun was dropped between the request and the queue")
+	}
+}
+
+// An install without an executor must have no working execute path at all,
+// rather than one that queues work nothing will ever claim.
+func TestExecuteIsNotImplementedWithoutAnExecutor(t *testing.T) {
+	db, err := sqlitestore.Open(filepath.Join(t.TempDir(), "no-exec.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := db.Migrate(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	rec := sampleRecord("plan-1")
+	rec.Plan.Steps = []model.PlanStep{planStep(1, "a", model.ImpactGreen)}
+	if _, err := db.Save(context.Background(), rec); err != nil {
+		t.Fatal(err)
+	}
+
+	// Note the missing WithExecution.
+	api := rest.New(db, slog.New(slog.DiscardHandler), "test", allowAll{operator},
+		auth.Config{Enabled: true}.Describe())
+	mux := http.NewServeMux()
+	api.Routes(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	res, _ := postExecute(t, srv, `{"steps":[1]}`)
+	if res.StatusCode != http.StatusNotImplemented {
+		t.Errorf("got %d, want 501", res.StatusCode)
+	}
+}

--- a/internal/api/rest/guarded_test.go
+++ b/internal/api/rest/guarded_test.go
@@ -24,10 +24,13 @@ var openRoutes = map[string]bool{
 //
 // Checked against the source rather than by probing, because probing can only
 // find routes a test already knows about — and the failure that matters is
-// somebody adding a route and not thinking about auth at all. Routes registers
-// guarded endpoints through the read() helper, which builds its pattern by
-// concatenation; anything handed a plain string literal went straight onto the
-// mux and skipped the guard.
+// somebody adding a route and not thinking about auth at all.
+//
+// Routes registers every guarded endpoint through the route() helper, which
+// takes an auth.Resource and so cannot be called without choosing a
+// permission. Its mux.Handle call receives the pattern as a variable, never a
+// literal — so any mux.Handle or mux.HandleFunc here holding a plain string
+// literal went straight onto the mux and skipped the guard entirely.
 //
 // From M10 this file is what stops an execute route shipping unauthenticated,
 // which is the single worst mistake available in this codebase.
@@ -75,7 +78,8 @@ func TestEveryRouteIsGuarded(t *testing.T) {
 	for _, pattern := range direct {
 		if !openRoutes[pattern] {
 			t.Errorf("route %q is registered directly on the mux and is therefore unauthenticated.\n"+
-				"Register it through the read() helper, or add it to openRoutes with a comment "+
+				"Register it through the route() helper with the permission it requires "+
+				"(read() for plain reads), or add it to openRoutes with a comment "+
 				"explaining why it is safe to serve without credentials.", pattern)
 		}
 	}

--- a/internal/api/rest/rest.go
+++ b/internal/api/rest/rest.go
@@ -38,6 +38,7 @@ type Guard interface {
 // Server serves the API over a plan store.
 type Server struct {
 	store    store.Store
+	runs     store.ExecutionStore
 	log      *slog.Logger
 	version  string
 	events   *Broker
@@ -58,13 +59,31 @@ func New(s store.Store, log *slog.Logger, version string, guard Guard, authInfo 
 	}
 }
 
+// WithExecution enables the execution routes.
+//
+// Separate from New and off by default so that a deployment without an
+// executor has no execute endpoint at all — not a disabled one. Phase 1 held
+// that a "not implemented" execute route is an invitation, and that still
+// holds for installs that never turn the executor on.
+func (s *Server) WithExecution(runs store.ExecutionStore) *Server {
+	s.runs = runs
+	return s
+}
+
 // Events exposes the broker so the poller can publish plan changes.
 func (s *Server) Events() *Broker { return s.events }
 
 // Routes registers every endpoint on mux.
 func (s *Server) Routes(mux *http.ServeMux) {
+	// Every route goes through here, and every route must therefore name the
+	// permission it requires. There is no way to register one without
+	// choosing — which is the point: guarded_test.go fails the build if a
+	// handler reaches the mux by any other path.
+	route := func(pattern string, res auth.Resource, h http.HandlerFunc) {
+		mux.Handle(pattern, s.guard.Require(res, h))
+	}
 	read := func(pattern string, h http.HandlerFunc) {
-		mux.Handle("GET "+pattern, s.guard.Require(auth.ReadPlans, h))
+		route("GET "+pattern, auth.ReadPlans, h)
 	}
 
 	// The one open route. It reveals the issuer URL and public client ID a
@@ -86,6 +105,15 @@ func (s *Server) Routes(mux *http.ServeMux) {
 	// frontend consumes this with fetch streaming instead — putting the token
 	// in a query string would write it to every access log in the path.
 	read("/api/v1/events", s.events.ServeHTTP)
+	read("/api/v1/runs/{runId}", s.handleRun)
+	read("/api/v1/runs", s.handleActiveRun)
+	read("/api/v1/plans/{id}/runs", s.handleRunsForPlan)
+
+	// The only route that can change a cluster. It requires a different
+	// permission from every read above — "may look" and "may drain" are
+	// separate grants, which is the entire reason for putting this behind
+	// SubjectAccessReview rather than a single "authenticated" check.
+	route("POST /api/v1/plans/{id}/execute", auth.ExecuteConsolidations, s.handleExecute)
 }
 
 func (s *Server) handleAuthInfo(w http.ResponseWriter, _ *http.Request) {

--- a/internal/cluster/direct.go
+++ b/internal/cluster/direct.go
@@ -1,0 +1,132 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	"github.com/atedgimo/k8s-dencer/internal/model"
+)
+
+// Direct reads cluster state straight from the API server, bypassing any cache.
+//
+// The planner uses the informer-backed Collector, which is right for it: it
+// re-plans on a timer and a few seconds of lag costs nothing. The executor
+// cannot use it. Its whole safety model rests on deciding against state that is
+// true *now* — a cached PodDisruptionBudget would let it authorise an eviction
+// the budget stopped permitting seconds ago.
+//
+// The cost is a full List per read, which is why the executor is idle except
+// during a run and polls on the order of seconds rather than continuously.
+// Conversion is shared with the Collector deliberately: the effective-request
+// rules (init containers, sidecars, overhead) are subtle enough that a second
+// implementation would drift.
+type Direct struct {
+	client kubernetes.Interface
+}
+
+// NewDirect builds an uncached reader.
+func NewDirect(cfg *rest.Config) (*Direct, error) {
+	client, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return &Direct{client: client}, nil
+}
+
+// NewDirectWithClient builds a reader over an existing client, for tests.
+func NewDirectWithClient(client kubernetes.Interface) *Direct {
+	return &Direct{client: client}
+}
+
+// Client exposes the underlying clientset so a caller can perform the
+// mutations the executor needs without opening a second connection.
+func (d *Direct) Client() kubernetes.Interface { return d.client }
+
+// Snapshot builds an immutable view of current cluster state.
+func (d *Direct) Snapshot(ctx context.Context) (*model.ClusterSnapshot, error) {
+	nodes, err := d.client.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("list nodes: %w", err)
+	}
+	pods, err := d.client.CoreV1().Pods("").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("list pods: %w", err)
+	}
+	pdbs, err := d.client.PolicyV1().PodDisruptionBudgets("").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("list poddisruptionbudgets: %w", err)
+	}
+
+	resolver := d.ownerResolver(ctx)
+	snap := &model.ClusterSnapshot{
+		TakenAt: time.Now().UTC(),
+		Nodes:   make([]model.Node, 0, len(nodes.Items)),
+		Pods:    make([]model.Pod, 0, len(pods.Items)),
+		PDBs:    make([]model.PodDisruptionBudget, 0, len(pdbs.Items)),
+	}
+
+	for i := range nodes.Items {
+		snap.Nodes = append(snap.Nodes, convertNode(&nodes.Items[i]))
+	}
+	for i := range pods.Items {
+		p := &pods.Items[i]
+		// Terminated pods hold no resources and would inflate every node.
+		if p.Status.Phase == corev1.PodSucceeded || p.Status.Phase == corev1.PodFailed {
+			continue
+		}
+		snap.Pods = append(snap.Pods, convertPod(p, resolver))
+	}
+	for i := range pdbs.Items {
+		snap.PDBs = append(snap.PDBs, convertPDB(&pdbs.Items[i]))
+	}
+	return snap, nil
+}
+
+// ownerResolver mirrors the Collector's, walking ReplicaSet -> Deployment so a
+// pod's real controller is named.
+func (d *Direct) ownerResolver(ctx context.Context) ownerResolver {
+	// Cached for the life of one snapshot: a node's worth of pods usually
+	// shares a handful of ReplicaSets, and re-fetching each would turn one
+	// read into hundreds.
+	seen := map[string]*model.OwnerRef{}
+
+	return func(p *corev1.Pod) *model.OwnerRef {
+		for _, ref := range p.OwnerReferences {
+			if ref.Controller == nil || !*ref.Controller {
+				continue
+			}
+			if ref.Kind != "ReplicaSet" {
+				return &model.OwnerRef{Kind: ref.Kind, Name: ref.Name}
+			}
+			key := p.Namespace + "/" + ref.Name
+			if cached, ok := seen[key]; ok {
+				return cached
+			}
+
+			owner := &model.OwnerRef{Kind: ref.Kind, Name: ref.Name}
+			var rs *appsv1.ReplicaSet
+			rs, err := d.client.AppsV1().ReplicaSets(p.Namespace).Get(ctx, ref.Name, metav1.GetOptions{})
+			if err == nil {
+				for _, rsRef := range rs.OwnerReferences {
+					if rsRef.Controller != nil && *rsRef.Controller {
+						owner = &model.OwnerRef{Kind: rsRef.Kind, Name: rsRef.Name}
+						break
+					}
+				}
+			}
+			// On error the ReplicaSet itself stands in, rather than dropping
+			// ownership: the classifier still needs to know the pod is
+			// replicated even when the Deployment name is unavailable.
+			seen[key] = owner
+			return owner
+		}
+		return nil
+	}
+}

--- a/internal/executor/cluster.go
+++ b/internal/executor/cluster.go
@@ -1,0 +1,66 @@
+package executor
+
+import (
+	"context"
+
+	"github.com/atedgimo/k8s-dencer/internal/model"
+)
+
+// Cluster is the complete set of mutations the executor is capable of.
+//
+// Deliberately tiny, and deliberately an interface. It is the enumeration of
+// everything this product can do to a cluster: read state, cordon, uncordon,
+// evict. There is no delete, no patch, no scale — and the executor's RBAC in
+// the chart grants exactly these and nothing more, so the interface and the
+// Role can be read against each other.
+//
+// It is also what makes the drain loop testable without a cluster: the fake in
+// executor_test.go can fail an eviction, stall a reschedule, or flip a PDB
+// mid-drain, none of which is convenient to arrange for real.
+type Cluster interface {
+	// Snapshot reads current cluster state. Called repeatedly during a drain —
+	// the whole safety model depends on decisions being made against fresh
+	// state rather than the plan's original snapshot.
+	Snapshot(ctx context.Context) (*model.ClusterSnapshot, error)
+
+	// Cordon marks a node unschedulable.
+	Cordon(ctx context.Context, node string) error
+
+	// Uncordon restores schedulability. This is the abort path: an aborted
+	// drain must leave the node usable, since evicted pods cannot be un-evicted.
+	Uncordon(ctx context.Context, node string) error
+
+	// Evict requests voluntary eviction through the policy/v1 eviction API,
+	// which is what makes the API server enforce PodDisruptionBudgets. A plain
+	// pod delete would bypass them entirely — the single most important
+	// distinction in this package.
+	Evict(ctx context.Context, namespace, name string) error
+}
+
+// PodKey is the namespace/name identifier used in logs and audit events.
+func PodKey(namespace, name string) string { return namespace + "/" + name }
+
+// ownerKey identifies the workload a pod belongs to, so recovery can be
+// verified against the controller rather than the pod.
+//
+// Eviction replaces a pod with a differently-named one, so "did it come back?"
+// can only be asked of the owner. A pod with no owner has no answer, which is
+// exactly why the impact classifier rates those Red.
+func ownerKey(pod model.Pod) string {
+	if pod.Owner == nil {
+		return ""
+	}
+	return pod.Namespace + "/" + pod.Owner.Kind + "/" + pod.Owner.Name
+}
+
+// healthy reports whether a pod counts towards a workload having recovered.
+//
+// The domain model carries no readiness condition — only phase — so recovery
+// is verified at Running rather than Ready. That is weaker than it sounds in
+// one direction and stronger in another: it will not catch a pod that starts
+// and then fails its probes, but it also sidesteps the KWOK trap where
+// stage-fast's pod-ready Stage matches only `phase In [Pending]`, so a fake pod
+// reaching Running never becomes Ready and a Ready-based wait hangs forever.
+func healthy(pod model.Pod) bool {
+	return pod.Phase == model.PodRunning && !pod.Terminating
+}

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -1,0 +1,496 @@
+// Package executor performs the consolidation steps an operator has approved.
+//
+// This is the only package in k8s-dencer that changes a cluster, and it runs as
+// its own workload with its own ServiceAccount holding the only grant of
+// pods/eviction. It has no HTTP surface at all: work arrives by claiming a row
+// from the shared store, so the one component that can drain nodes cannot be
+// reached over the network.
+//
+// The execution model is deliberately pessimistic:
+//
+//   - The Safety Guard is consulted before every step and before every
+//     individual eviction, always against freshly-read state.
+//   - Eviction goes through the policy/v1 eviction API, so the API server
+//     enforces PodDisruptionBudgets. A pod delete would bypass them.
+//   - Reality is verified after every step. The guard predicts that pods will
+//     fit; this confirms they actually landed, and aborts if they did not.
+//   - Abort means cordon-reversal, not rollback. Evicted pods cannot be
+//     un-evicted, and pretending otherwise would be a lie in the docs and a
+//     surprise at three in the morning.
+package executor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/atedgimo/k8s-dencer/internal/model"
+	"github.com/atedgimo/k8s-dencer/internal/safety"
+	"github.com/atedgimo/k8s-dencer/internal/store"
+)
+
+// Options configure an executor.
+type Options struct {
+	// Worker identifies this executor in claims and audit events, so a run can
+	// be traced to a pod.
+	Worker string
+
+	// Limits are the Safety Guard's rails.
+	Limits safety.Limits
+
+	// StepTimeout bounds a single step end to end. Exceeding it aborts.
+	StepTimeout time.Duration
+
+	// SettleTimeout bounds waiting for evicted pods to be replaced.
+	SettleTimeout time.Duration
+
+	// PollInterval is how often cluster state is re-read while waiting.
+	PollInterval time.Duration
+}
+
+// withDefaults fills unset values with conservative ones.
+func (o Options) withDefaults() Options {
+	if o.Worker == "" {
+		o.Worker = "executor"
+	}
+	if o.StepTimeout <= 0 {
+		o.StepTimeout = 10 * time.Minute
+	}
+	if o.SettleTimeout <= 0 {
+		o.SettleTimeout = 5 * time.Minute
+	}
+	if o.PollInterval <= 0 {
+		o.PollInterval = 2 * time.Second
+	}
+	return o
+}
+
+// Executor claims runs and performs them.
+type Executor struct {
+	cluster Cluster
+	runs    store.ExecutionStore
+	plans   store.Store
+	guard   *safety.Guard
+	log     *slog.Logger
+	opts    Options
+}
+
+// New builds an executor.
+func New(cluster Cluster, runs store.ExecutionStore, plans store.Store, log *slog.Logger, opts Options) *Executor {
+	opts = opts.withDefaults()
+	return &Executor{
+		cluster: cluster,
+		runs:    runs,
+		plans:   plans,
+		guard:   safety.New(opts.Limits),
+		log:     log,
+		opts:    opts,
+	}
+}
+
+// Poll claims and performs at most one run, reporting whether it did any work.
+//
+// One at a time, by construction: two consolidations in flight would each be
+// making placement decisions the other invalidates.
+func (e *Executor) Poll(ctx context.Context) (bool, error) {
+	run, err := e.runs.Claim(ctx, e.opts.Worker)
+	if errors.Is(err, store.ErrNotFound) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	e.log.Info("claimed run", "run", run.ID, "plan", run.PlanID,
+		"steps", run.Steps, "dryRun", run.DryRun, "actor", run.Actor)
+	e.perform(ctx, run)
+	return true, nil
+}
+
+// Run polls until the context is cancelled.
+func (e *Executor) Run(ctx context.Context, every time.Duration) {
+	ticker := time.NewTicker(every)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			for {
+				worked, err := e.Poll(ctx)
+				if err != nil {
+					e.log.Error("poll failed", "error", err)
+					break
+				}
+				if !worked {
+					break
+				}
+			}
+		}
+	}
+}
+
+// perform executes a claimed run and closes it out.
+func (e *Executor) perform(ctx context.Context, run store.Run) {
+	e.event(ctx, run, store.RunEvent{
+		Action: "Claim",
+		Message: fmt.Sprintf("run claimed by %s for %s (steps %v of plan %s)%s",
+			e.opts.Worker, run.Actor, run.Steps, run.PlanID, dryRunSuffix(run.DryRun)),
+	})
+
+	rec, err := e.plans.ByID(ctx, run.PlanID)
+	if err != nil {
+		e.fail(ctx, run, fmt.Sprintf("plan %s could not be loaded: %v", run.PlanID, err))
+		return
+	}
+
+	state := safety.RunState{}
+	for _, seq := range run.Steps {
+		step, ok := findStep(rec.Plan, seq)
+		if !ok {
+			e.fail(ctx, run, fmt.Sprintf("plan %s has no step %d", run.PlanID, seq))
+			return
+		}
+
+		stepCtx, cancel := context.WithTimeout(ctx, e.opts.StepTimeout)
+		err := e.performStep(stepCtx, run, step, &state)
+		cancel()
+
+		if err != nil {
+			var blocked *safety.Blocked
+			if errors.As(err, &blocked) {
+				// The rails did their job. Distinct from a failure so an
+				// operator can tell "we protected you" from "something broke".
+				e.finish(ctx, run, store.RunBlocked, fmt.Sprintf(
+					"stopped at step %d: %s", seq, blocked.Reason))
+				return
+			}
+			e.finish(ctx, run, store.RunFailed, fmt.Sprintf(
+				"failed at step %d: %v", seq, err))
+			return
+		}
+	}
+
+	e.finish(ctx, run, store.RunSucceeded, fmt.Sprintf(
+		"completed %d step(s), draining %d node(s)%s",
+		len(run.Steps), state.NodesDrainedSoFar, dryRunSuffix(run.DryRun)))
+}
+
+// performStep drains one node.
+func (e *Executor) performStep(ctx context.Context, run store.Run, step model.PlanStep, state *safety.RunState) error {
+	live, err := e.cluster.Snapshot(ctx)
+	if err != nil {
+		return fmt.Errorf("read cluster state: %w", err)
+	}
+
+	// Gate first, against state read moments ago rather than the plan's.
+	if err := e.guard.CheckStep(step, live, *state); err != nil {
+		e.blocked(ctx, run, step, err)
+		return err
+	}
+
+	if run.DryRun {
+		return e.rehearse(ctx, run, step, live, state)
+	}
+
+	if err := e.cluster.Cordon(ctx, step.TargetNode); err != nil {
+		return fmt.Errorf("cordon %s: %w", step.TargetNode, err)
+	}
+	e.event(ctx, run, store.RunEvent{
+		Step: step.SequenceNumber, Node: step.TargetNode, Action: "Cordon",
+		Message: fmt.Sprintf("%s marked unschedulable", step.TargetNode),
+	})
+
+	// From here the node is cordoned, so every exit path must either finish the
+	// drain or restore schedulability.
+	if err := e.drain(ctx, run, step, state); err != nil {
+		e.abort(ctx, run, step, err)
+		return err
+	}
+
+	state.NodesDrainedSoFar++
+	e.event(ctx, run, store.RunEvent{
+		Step: step.SequenceNumber, Node: step.TargetNode, Action: "Drained",
+		Message: fmt.Sprintf("%s drained and left cordoned", step.TargetNode),
+	})
+	return nil
+}
+
+// rehearse performs a dry run: the full guard chain and the same event stream,
+// with nothing touched.
+//
+// Emitting identical events matters — the UI renders a rehearsal and a real run
+// with the same component, so what an operator previews is what they will see.
+func (e *Executor) rehearse(ctx context.Context, run store.Run, step model.PlanStep,
+	live *model.ClusterSnapshot, state *safety.RunState) error {
+
+	pods := movablePodsOn(live, step.TargetNode)
+	e.event(ctx, run, store.RunEvent{
+		Step: step.SequenceNumber, Node: step.TargetNode, Action: "Cordon",
+		Message: fmt.Sprintf("would mark %s unschedulable (dry run)", step.TargetNode),
+	})
+
+	for _, pod := range pods {
+		if err := e.guard.CheckEviction(pod, live); err != nil {
+			e.blocked(ctx, run, step, err)
+			return err
+		}
+		e.event(ctx, run, store.RunEvent{
+			Step: step.SequenceNumber, Node: step.TargetNode, Pod: pod.Key(),
+			Action:  "Evict",
+			Message: fmt.Sprintf("would evict %s (dry run)", pod.Key()),
+		})
+	}
+
+	state.NodesDrainedSoFar++
+	e.event(ctx, run, store.RunEvent{
+		Step: step.SequenceNumber, Node: step.TargetNode, Action: "Drained",
+		Message: fmt.Sprintf("would drain %s, moving %d pod(s) (dry run)",
+			step.TargetNode, len(pods)),
+	})
+	return nil
+}
+
+// drain evicts every movable pod on the node, one at a time.
+func (e *Executor) drain(ctx context.Context, run store.Run, step model.PlanStep, state *safety.RunState) error {
+	live, err := e.cluster.Snapshot(ctx)
+	if err != nil {
+		return fmt.Errorf("read cluster state: %w", err)
+	}
+
+	// Recorded before anything is evicted, so recovery is measured against the
+	// workloads as they were, not as they became mid-drain.
+	before := healthyByOwner(live)
+	pods := movablePodsOn(live, step.TargetNode)
+	affected := map[string]bool{}
+
+	for _, pod := range pods {
+		// Fresh state per pod: evicting the first of a set changes the PDB
+		// headroom for the rest, so a batch check would authorise disruptions
+		// the budget no longer permits.
+		live, err := e.cluster.Snapshot(ctx)
+		if err != nil {
+			return fmt.Errorf("read cluster state: %w", err)
+		}
+		current, still := findPod(live, pod.Namespace, pod.Name)
+		if !still {
+			continue // already gone; nothing to do
+		}
+		if err := e.guard.CheckEviction(current, live); err != nil {
+			e.blocked(ctx, run, step, err)
+			return err
+		}
+
+		if err := e.cluster.Evict(ctx, pod.Namespace, pod.Name); err != nil {
+			// The API server can refuse on PDB grounds even when the
+			// pre-flight check passed — state can change between the two, and
+			// the API server is the authority. That refusal is a guard verdict,
+			// not a fault, so it is audited as one.
+			var blocked *safety.Blocked
+			if errors.As(err, &blocked) {
+				e.blocked(ctx, run, step, blocked)
+				return blocked
+			}
+			return fmt.Errorf("evict %s: %w", pod.Key(), err)
+		}
+		if k := ownerKey(pod); k != "" {
+			affected[k] = true
+		}
+		e.event(ctx, run, store.RunEvent{
+			Step: step.SequenceNumber, Node: step.TargetNode, Pod: pod.Key(),
+			Action:  "Evict",
+			Message: fmt.Sprintf("evicted %s", pod.Key()),
+		})
+
+		if err := e.waitGone(ctx, pod); err != nil {
+			return err
+		}
+	}
+
+	return e.verifyRecovered(ctx, run, step, before, affected)
+}
+
+// waitGone blocks until the pod has left the API server's view.
+func (e *Executor) waitGone(ctx context.Context, pod model.Pod) error {
+	deadline := time.Now().Add(e.opts.SettleTimeout)
+	for {
+		live, err := e.cluster.Snapshot(ctx)
+		if err != nil {
+			return fmt.Errorf("read cluster state: %w", err)
+		}
+		if p, ok := findPod(live, pod.Namespace, pod.Name); !ok || p.Terminating {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("%s did not terminate within %s", pod.Key(), e.opts.SettleTimeout)
+		}
+		if err := sleep(ctx, e.opts.PollInterval); err != nil {
+			return err
+		}
+	}
+}
+
+// verifyRecovered is the reality check that the design leans on instead of a
+// higher-fidelity simulator.
+//
+// The guard predicted every pod would fit somewhere. This confirms the
+// workloads actually got their replicas back — on some other node — and fails
+// the step if they did not, rather than moving on to drain a second node while
+// the first one's pods are stuck Pending.
+func (e *Executor) verifyRecovered(ctx context.Context, run store.Run, step model.PlanStep,
+	before map[string]int, affected map[string]bool) error {
+
+	if len(affected) == 0 {
+		return nil
+	}
+	deadline := time.Now().Add(e.opts.SettleTimeout)
+	for {
+		live, err := e.cluster.Snapshot(ctx)
+		if err != nil {
+			return fmt.Errorf("read cluster state: %w", err)
+		}
+		now := healthyByOwner(live)
+
+		lagging := ""
+		for owner := range affected {
+			if now[owner] < before[owner] {
+				lagging = fmt.Sprintf("%s has %d/%d healthy pod(s)", owner, now[owner], before[owner])
+				break
+			}
+		}
+		if lagging == "" {
+			e.event(ctx, run, store.RunEvent{
+				Step: step.SequenceNumber, Node: step.TargetNode, Action: "Verify",
+				Message: fmt.Sprintf("all %d affected workload(s) recovered elsewhere", len(affected)),
+			})
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("workloads did not recover within %s: %s", e.opts.SettleTimeout, lagging)
+		}
+		if err := sleep(ctx, e.opts.PollInterval); err != nil {
+			return err
+		}
+	}
+}
+
+// abort restores schedulability and records why.
+//
+// Uncordon uses a context detached from the step's deadline: the usual reason
+// to abort is that the step timed out, and inheriting that expired context
+// would leave the node cordoned — the one outcome abort exists to prevent.
+func (e *Executor) abort(ctx context.Context, run store.Run, step model.PlanStep, cause error) {
+	uncordonCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+	defer cancel()
+
+	if err := e.cluster.Uncordon(uncordonCtx, step.TargetNode); err != nil {
+		e.log.Error("uncordon failed after abort", "node", step.TargetNode, "error", err)
+		e.event(uncordonCtx, run, store.RunEvent{
+			Step: step.SequenceNumber, Node: step.TargetNode, Level: store.EventError,
+			Action: "Uncordon",
+			Message: fmt.Sprintf("could not restore %s to schedulable: %v — it needs "+
+				"`kubectl uncordon %s` by hand", step.TargetNode, err, step.TargetNode),
+		})
+		return
+	}
+	e.event(uncordonCtx, run, store.RunEvent{
+		Step: step.SequenceNumber, Node: step.TargetNode, Action: "Uncordon",
+		Message: fmt.Sprintf("aborted after %v; %s is schedulable again. Pods already "+
+			"evicted were not restored — eviction cannot be undone",
+			cause, step.TargetNode),
+	})
+}
+
+func (e *Executor) blocked(ctx context.Context, run store.Run, step model.PlanStep, err error) {
+	var b *safety.Blocked
+	if !errors.As(err, &b) {
+		return
+	}
+	e.event(ctx, run, store.RunEvent{
+		Step: step.SequenceNumber, Node: step.TargetNode, Level: store.EventBlocked,
+		Action: "Guard", Rule: string(b.Rule), Message: b.Reason,
+	})
+}
+
+func (e *Executor) fail(ctx context.Context, run store.Run, msg string) {
+	e.event(ctx, run, store.RunEvent{Level: store.EventError, Action: "Fail", Message: msg})
+	e.finish(ctx, run, store.RunFailed, msg)
+}
+
+func (e *Executor) finish(ctx context.Context, run store.Run, status store.RunStatus, summary string) {
+	e.log.Info("run finished", "run", run.ID, "status", status, "summary", summary)
+	// Detached: a cancelled context must not leave a run stuck Running forever.
+	closeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 15*time.Second)
+	defer cancel()
+	if err := e.runs.Finish(closeCtx, run.ID, status, summary); err != nil {
+		e.log.Error("could not close run", "run", run.ID, "error", err)
+	}
+}
+
+func (e *Executor) event(ctx context.Context, run store.Run, ev store.RunEvent) {
+	ev.RunID = run.ID
+	if err := e.runs.AppendEvent(ctx, ev); err != nil {
+		// The audit trail is important but must not stop a drain in progress;
+		// leaving a node half-drained to preserve a log entry is the worse
+		// trade.
+		e.log.Error("could not append audit event", "run", run.ID, "action", ev.Action, "error", err)
+	}
+}
+
+func findStep(plan *model.Plan, seq int) (model.PlanStep, bool) {
+	for _, s := range plan.Steps {
+		if s.SequenceNumber == seq {
+			return s, true
+		}
+	}
+	return model.PlanStep{}, false
+}
+
+func findPod(snap *model.ClusterSnapshot, namespace, name string) (model.Pod, bool) {
+	for _, p := range snap.Pods {
+		if p.Namespace == namespace && p.Name == name {
+			return p, true
+		}
+	}
+	return model.Pod{}, false
+}
+
+func movablePodsOn(snap *model.ClusterSnapshot, node string) []model.Pod {
+	var out []model.Pod
+	for _, p := range snap.Pods {
+		if p.NodeName == node && p.IsMovable() {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func healthyByOwner(snap *model.ClusterSnapshot) map[string]int {
+	out := map[string]int{}
+	for _, p := range snap.Pods {
+		if k := ownerKey(p); k != "" && healthy(p) {
+			out[k]++
+		}
+	}
+	return out
+}
+
+func dryRunSuffix(dry bool) string {
+	if dry {
+		return " [dry run]"
+	}
+	return ""
+}
+
+func sleep(ctx context.Context, d time.Duration) error {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -1,0 +1,581 @@
+package executor_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/atedgimo/k8s-dencer/internal/constraints"
+	"github.com/atedgimo/k8s-dencer/internal/executor"
+	"github.com/atedgimo/k8s-dencer/internal/model"
+	"github.com/atedgimo/k8s-dencer/internal/safety"
+	"github.com/atedgimo/k8s-dencer/internal/store"
+	sqlitestore "github.com/atedgimo/k8s-dencer/internal/store/sqlite"
+)
+
+// fakeCluster is an in-memory stand-in that records every mutation in order.
+//
+// The ordering log is the point: "cordon strictly before the first eviction"
+// and "uncordon after an abort" are sequencing guarantees, and only a recorded
+// transcript can prove them.
+type fakeCluster struct {
+	mu    sync.Mutex
+	snap  model.ClusterSnapshot
+	calls []string
+
+	// replaceOnEvict recreates an evicted pod on another node, the way a
+	// ReplicaSet would. Off for tests that need a workload to stay down.
+	replaceOnEvict bool
+	// evictErr fails eviction of a specific pod key.
+	evictErr map[string]error
+	// uncordonErr fails uncordon, to exercise the "needs manual repair" path.
+	uncordonErr error
+	replacement int
+}
+
+func (f *fakeCluster) Snapshot(context.Context) (*model.ClusterSnapshot, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	// Deep-ish copy: the executor must not be able to mutate our state, and
+	// aliasing would hide bugs where it does.
+	out := model.ClusterSnapshot{
+		Nodes: append([]model.Node(nil), f.snap.Nodes...),
+		Pods:  append([]model.Pod(nil), f.snap.Pods...),
+		PDBs:  append([]model.PodDisruptionBudget(nil), f.snap.PDBs...),
+	}
+	return &out, nil
+}
+
+func (f *fakeCluster) Cordon(_ context.Context, node string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, "cordon:"+node)
+	for i := range f.snap.Nodes {
+		if f.snap.Nodes[i].Name == node {
+			f.snap.Nodes[i].Unschedulable = true
+		}
+	}
+	return nil
+}
+
+func (f *fakeCluster) Uncordon(_ context.Context, node string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, "uncordon:"+node)
+	if f.uncordonErr != nil {
+		return f.uncordonErr
+	}
+	for i := range f.snap.Nodes {
+		if f.snap.Nodes[i].Name == node {
+			f.snap.Nodes[i].Unschedulable = false
+		}
+	}
+	return nil
+}
+
+func (f *fakeCluster) Evict(_ context.Context, namespace, name string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	key := namespace + "/" + name
+	f.calls = append(f.calls, "evict:"+key)
+	if err, ok := f.evictErr[key]; ok {
+		return err
+	}
+
+	var evicted *model.Pod
+	kept := f.snap.Pods[:0]
+	for _, p := range f.snap.Pods {
+		if p.Namespace == namespace && p.Name == name {
+			cp := p
+			evicted = &cp
+			continue
+		}
+		kept = append(kept, p)
+	}
+	f.snap.Pods = append([]model.Pod(nil), kept...)
+
+	if evicted != nil && f.replaceOnEvict {
+		// A controller recreates it elsewhere, under a new name.
+		f.replacement++
+		repl := *evicted
+		repl.Name = fmt.Sprintf("%s-r%d", evicted.Name, f.replacement)
+		repl.NodeName = f.someOtherSchedulableNode(evicted.NodeName)
+		repl.Phase = model.PodRunning
+		f.snap.Pods = append(f.snap.Pods, repl)
+	}
+	return nil
+}
+
+func (f *fakeCluster) someOtherSchedulableNode(exclude string) string {
+	for _, n := range f.snap.Nodes {
+		if n.Name != exclude && !n.Unschedulable && n.Ready {
+			return n.Name
+		}
+	}
+	return ""
+}
+
+func (f *fakeCluster) transcript() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.calls...)
+}
+
+func (f *fakeCluster) nodeCordoned(name string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, n := range f.snap.Nodes {
+		if n.Name == name {
+			return n.Unschedulable
+		}
+	}
+	return false
+}
+
+// ---------------------------------------------------------------- fixtures
+
+func testNode(name string) model.Node {
+	return model.Node{
+		Name: name, Ready: true,
+		Labels:      map[string]string{model.LabelZone: "z1"},
+		Allocatable: model.Resources{MilliCPU: 8000, MemoryBytes: 1 << 34, Pods: 110},
+	}
+}
+
+func testPod(ns, name, node, owner string) model.Pod {
+	return model.Pod{
+		Namespace: ns, Name: name, NodeName: node, Phase: model.PodRunning,
+		Labels:   map[string]string{"app": owner},
+		Requests: model.Resources{MilliCPU: 500, MemoryBytes: 1 << 28},
+		Owner:    &model.OwnerRef{Kind: "ReplicaSet", Name: owner},
+	}
+}
+
+type harness struct {
+	cluster *fakeCluster
+	db      *sqlitestore.Store
+	exec    *executor.Executor
+	planID  string
+}
+
+func newHarness(t *testing.T, snap model.ClusterSnapshot, steps []model.PlanStep, limits safety.Limits) *harness {
+	t.Helper()
+
+	db, err := sqlitestore.Open(filepath.Join(t.TempDir(), "exec.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := db.Migrate(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	plan := &model.Plan{
+		ID: "plan-1", Status: model.PlanValid,
+		GeneratedAt: time.Now().UTC(), SnapshotTakenAt: time.Now().UTC(),
+		Steps: steps, NodesBefore: len(snap.Nodes), NodesAfter: len(snap.Nodes) - len(steps),
+	}
+	snapCopy := snap
+	if _, err := db.Save(context.Background(), store.Record{
+		Plan: plan, Snapshot: &snapCopy, Analysis: &constraints.Analysis{}, Strategy: "test",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	cluster := &fakeCluster{snap: snap, replaceOnEvict: true, evictErr: map[string]error{}}
+	return &harness{
+		cluster: cluster,
+		db:      db,
+		planID:  plan.ID,
+		exec: executor.New(cluster, db, db, slog.New(slog.DiscardHandler), executor.Options{
+			Worker: "test-worker", Limits: limits,
+			StepTimeout: 5 * time.Second, SettleTimeout: 2 * time.Second,
+			PollInterval: time.Millisecond,
+		}),
+	}
+}
+
+func (h *harness) request(t *testing.T, steps []int, dryRun bool) store.Run {
+	t.Helper()
+	ctx := context.Background()
+	id, err := h.db.Enqueue(ctx, store.Run{
+		PlanID: h.planID, Steps: steps, DryRun: dryRun, Actor: "alice@example.com",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := h.exec.Poll(ctx); err != nil {
+		t.Fatal(err)
+	}
+	run, err := h.db.RunByID(ctx, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return run
+}
+
+func (h *harness) events(t *testing.T, runID string) []store.RunEvent {
+	t.Helper()
+	ev, err := h.db.Events(context.Background(), runID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ev
+}
+
+func step(seq int, node string, impact model.ImpactRating) model.PlanStep {
+	return model.PlanStep{
+		ID: fmt.Sprintf("s%d", seq), SequenceNumber: seq, TargetNode: node,
+		Impact: impact, Rationale: "because the node is underused",
+	}
+}
+
+func permissive() safety.Limits {
+	return safety.Limits{MaxNodesPerRun: 10, MinReadyNodes: 0}
+}
+
+// ------------------------------------------------------------------- tests
+
+func TestSuccessfulDrainCordonsThenEvictsThenVerifies(t *testing.T) {
+	h := newHarness(t, model.ClusterSnapshot{
+		Nodes: []model.Node{testNode("a"), testNode("b"), testNode("c")},
+		Pods: []model.Pod{
+			testPod("app", "web-1", "a", "web"),
+			testPod("app", "web-2", "b", "web"),
+		},
+	}, []model.PlanStep{step(1, "a", model.ImpactGreen)}, permissive())
+
+	run := h.request(t, []int{1}, false)
+	if run.Status != store.RunSucceeded {
+		t.Fatalf("status = %s (%s)", run.Status, run.Summary)
+	}
+
+	// Cordon must strictly precede the first eviction, or the scheduler can
+	// put a new pod onto a node we are in the middle of emptying.
+	got := h.cluster.transcript()
+	want := []string{"cordon:a", "evict:app/web-1"}
+	if len(got) != len(want) {
+		t.Fatalf("transcript = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("transcript[%d] = %s, want %s", i, got[i], want[i])
+		}
+	}
+
+	// A drained node stays cordoned: it is meant to be removed, and letting
+	// the scheduler refill it would undo the work.
+	if !h.cluster.nodeCordoned("a") {
+		t.Error("node was uncordoned after a successful drain")
+	}
+
+	if !hasEvent(h.events(t, run.ID), "Verify") {
+		t.Error("no Verify event; recovery was never confirmed")
+	}
+}
+
+// The most important refusal in the product. Red must never reach a cordon.
+func TestRedStepIsRefusedWithoutTouchingTheCluster(t *testing.T) {
+	h := newHarness(t, model.ClusterSnapshot{
+		Nodes: []model.Node{testNode("a"), testNode("b")},
+		Pods:  []model.Pod{testPod("app", "web-1", "a", "web")},
+	}, []model.PlanStep{step(1, "a", model.ImpactRed)}, permissive())
+
+	run := h.request(t, []int{1}, false)
+
+	if run.Status != store.RunBlocked {
+		t.Errorf("status = %s, want Blocked", run.Status)
+	}
+	if calls := h.cluster.transcript(); len(calls) != 0 {
+		t.Errorf("a Red step touched the cluster: %v", calls)
+	}
+
+	events := h.events(t, run.ID)
+	blocked := findEvent(events, "Guard")
+	if blocked == nil {
+		t.Fatal("no Guard event recorded")
+	}
+	if blocked.Rule != string(safety.RuleRedRequiresWindow) {
+		t.Errorf("rule = %q, want RedRequiresWindow", blocked.Rule)
+	}
+	// The audit entry has to quote the classifier's own words.
+	if !strings.Contains(blocked.Message, "because the node is underused") {
+		t.Errorf("refusal lost the rationale: %s", blocked.Message)
+	}
+}
+
+// A PDB that runs out of headroom part-way through must stop the drain and
+// leave the node usable.
+func TestPDBExhaustionMidDrainAbortsAndUncordons(t *testing.T) {
+	h := newHarness(t, model.ClusterSnapshot{
+		Nodes: []model.Node{testNode("a"), testNode("b")},
+		Pods: []model.Pod{
+			testPod("app", "web-1", "a", "web"),
+			testPod("app", "db-1", "a", "db"),
+		},
+		PDBs: []model.PodDisruptionBudget{{
+			Namespace: "app", Name: "db",
+			Selector:           &model.LabelSelector{MatchLabels: map[string]string{"app": "db"}},
+			DisruptionsAllowed: 0, CurrentHealthy: 1, DesiredHealthy: 1,
+		}},
+	}, []model.PlanStep{step(1, "a", model.ImpactGreen)}, permissive())
+
+	run := h.request(t, []int{1}, false)
+
+	if run.Status != store.RunBlocked {
+		t.Fatalf("status = %s (%s), want Blocked", run.Status, run.Summary)
+	}
+	transcript := h.cluster.transcript()
+	if transcript[0] != "cordon:a" {
+		t.Errorf("expected a cordon first, got %v", transcript)
+	}
+	// The node must not be left cordoned after an abort — that would strand
+	// capacity nobody asked to remove.
+	if last := transcript[len(transcript)-1]; last != "uncordon:a" {
+		t.Errorf("run aborted without uncordoning: %v", transcript)
+	}
+	if h.cluster.nodeCordoned("a") {
+		t.Error("node left unschedulable after an abort")
+	}
+
+	if ev := findEvent(h.events(t, run.ID), "Guard"); ev == nil ||
+		ev.Rule != string(safety.RulePDBHeadroom) {
+		t.Errorf("PDB refusal not recorded with its rule: %+v", ev)
+	}
+}
+
+// The abort message must be honest: evicted pods are gone for good.
+func TestAbortSaysEvictionCannotBeUndone(t *testing.T) {
+	h := newHarness(t, model.ClusterSnapshot{
+		Nodes: []model.Node{testNode("a"), testNode("b")},
+		Pods:  []model.Pod{testPod("app", "web-1", "a", "web")},
+	}, []model.PlanStep{step(1, "a", model.ImpactGreen)}, permissive())
+	h.cluster.evictErr["app/web-1"] = errors.New("apiserver said no")
+
+	run := h.request(t, []int{1}, false)
+	if run.Status != store.RunFailed {
+		t.Fatalf("status = %s, want Failed", run.Status)
+	}
+
+	ev := findEvent(h.events(t, run.ID), "Uncordon")
+	if ev == nil {
+		t.Fatal("no Uncordon event after a failed eviction")
+	}
+	if !strings.Contains(ev.Message, "cannot be undone") {
+		t.Errorf("abort message oversells recovery: %s", ev.Message)
+	}
+}
+
+// If uncordon itself fails the operator must be told the node needs manual
+// repair, rather than the failure being swallowed.
+func TestFailedUncordonIsReportedAsNeedingManualRepair(t *testing.T) {
+	h := newHarness(t, model.ClusterSnapshot{
+		Nodes: []model.Node{testNode("a"), testNode("b")},
+		Pods:  []model.Pod{testPod("app", "web-1", "a", "web")},
+	}, []model.PlanStep{step(1, "a", model.ImpactGreen)}, permissive())
+	h.cluster.evictErr["app/web-1"] = errors.New("apiserver said no")
+	h.cluster.uncordonErr = errors.New("conflict")
+
+	run := h.request(t, []int{1}, false)
+
+	ev := findEvent(h.events(t, run.ID), "Uncordon")
+	if ev == nil || ev.Level != store.EventError {
+		t.Fatalf("a failed uncordon was not recorded as an error: %+v", ev)
+	}
+	if !strings.Contains(ev.Message, "kubectl uncordon a") {
+		t.Errorf("message does not tell the operator how to fix it: %s", ev.Message)
+	}
+}
+
+// The reality check. The guard predicts pods will fit; if they then do not
+// come back, the run must stop rather than drain a second node.
+func TestWorkloadThatDoesNotRecoverFailsTheStep(t *testing.T) {
+	h := newHarness(t, model.ClusterSnapshot{
+		Nodes: []model.Node{testNode("a"), testNode("b")},
+		Pods:  []model.Pod{testPod("app", "web-1", "a", "web")},
+	}, []model.PlanStep{step(1, "a", model.ImpactGreen)}, permissive())
+	h.cluster.replaceOnEvict = false // nothing recreates the pod
+
+	run := h.request(t, []int{1}, false)
+
+	if run.Status != store.RunFailed {
+		t.Fatalf("status = %s (%s), want Failed", run.Status, run.Summary)
+	}
+	if !strings.Contains(run.Summary, "did not recover") {
+		t.Errorf("summary does not explain the failure: %s", run.Summary)
+	}
+	if h.cluster.nodeCordoned("a") {
+		t.Error("node left cordoned after a failed verification")
+	}
+}
+
+func TestDryRunTouchesNothingButEmitsTheSameEvents(t *testing.T) {
+	h := newHarness(t, model.ClusterSnapshot{
+		Nodes: []model.Node{testNode("a"), testNode("b")},
+		Pods: []model.Pod{
+			testPod("app", "web-1", "a", "web"),
+			testPod("app", "web-2", "a", "web"),
+		},
+	}, []model.PlanStep{step(1, "a", model.ImpactGreen)}, permissive())
+
+	run := h.request(t, []int{1}, true)
+
+	if run.Status != store.RunSucceeded {
+		t.Fatalf("status = %s (%s)", run.Status, run.Summary)
+	}
+	if calls := h.cluster.transcript(); len(calls) != 0 {
+		t.Errorf("a dry run mutated the cluster: %v", calls)
+	}
+
+	// Same event shapes as a real run: the UI renders both with one component,
+	// so a rehearsal must look like the thing it rehearses.
+	events := h.events(t, run.ID)
+	for _, action := range []string{"Cordon", "Evict", "Drained"} {
+		if !hasEvent(events, action) {
+			t.Errorf("dry run emitted no %s event", action)
+		}
+	}
+	if ev := findEvent(events, "Evict"); ev != nil && !strings.Contains(ev.Message, "dry run") {
+		t.Errorf("dry-run event is not labelled as one: %s", ev.Message)
+	}
+}
+
+// A dry run must still be refused by the guard — rehearsing a Red step and
+// being told it would succeed is worse than useless.
+func TestDryRunStillHonoursTheGuard(t *testing.T) {
+	h := newHarness(t, model.ClusterSnapshot{
+		Nodes: []model.Node{testNode("a"), testNode("b")},
+		Pods:  []model.Pod{testPod("app", "web-1", "a", "web")},
+	}, []model.PlanStep{step(1, "a", model.ImpactRed)}, permissive())
+
+	if run := h.request(t, []int{1}, true); run.Status != store.RunBlocked {
+		t.Errorf("dry run of a Red step: status = %s, want Blocked", run.Status)
+	}
+}
+
+// Partial execution, per doc §5: steps 1–3 of many, and a rail that trips
+// part-way leaves the earlier steps done.
+func TestRunStopsAtTheStepThatViolatesACapLeavingEarlierStepsDone(t *testing.T) {
+	h := newHarness(t, model.ClusterSnapshot{
+		Nodes: []model.Node{testNode("a"), testNode("b"), testNode("c"), testNode("d")},
+		Pods: []model.Pod{
+			testPod("app", "web-1", "a", "web"),
+			testPod("app", "web-2", "b", "web"),
+			testPod("app", "web-3", "c", "web"),
+		},
+	}, []model.PlanStep{
+		step(1, "a", model.ImpactGreen),
+		step(2, "b", model.ImpactGreen),
+		step(3, "c", model.ImpactGreen),
+	}, safety.Limits{MaxNodesPerRun: 2})
+
+	run := h.request(t, []int{1, 2, 3}, false)
+
+	if run.Status != store.RunBlocked {
+		t.Fatalf("status = %s (%s), want Blocked", run.Status, run.Summary)
+	}
+	if !strings.Contains(run.Summary, "stopped at step 3") {
+		t.Errorf("summary should name the step that stopped: %s", run.Summary)
+	}
+	// The first two really did happen.
+	if !h.cluster.nodeCordoned("a") || !h.cluster.nodeCordoned("b") {
+		t.Error("earlier steps were rolled back; they should stand")
+	}
+	if h.cluster.nodeCordoned("c") {
+		t.Error("the blocked step touched its node")
+	}
+}
+
+func TestUnknownStepFailsBeforeAnythingIsTouched(t *testing.T) {
+	h := newHarness(t, model.ClusterSnapshot{
+		Nodes: []model.Node{testNode("a"), testNode("b")},
+	}, []model.PlanStep{step(1, "a", model.ImpactGreen)}, permissive())
+
+	run := h.request(t, []int{99}, false)
+	if run.Status != store.RunFailed {
+		t.Errorf("status = %s, want Failed", run.Status)
+	}
+	if calls := h.cluster.transcript(); len(calls) != 0 {
+		t.Errorf("an unknown step touched the cluster: %v", calls)
+	}
+}
+
+func TestPollReportsNoWorkOnAnEmptyQueue(t *testing.T) {
+	h := newHarness(t, model.ClusterSnapshot{Nodes: []model.Node{testNode("a")}},
+		[]model.PlanStep{step(1, "a", model.ImpactGreen)}, permissive())
+
+	worked, err := h.exec.Poll(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if worked {
+		t.Error("Poll claimed work from an empty queue")
+	}
+}
+
+// Every run records who asked for it, so an action stays attributable long
+// after the token that authorized it has expired.
+func TestAuditTrailNamesTheActor(t *testing.T) {
+	h := newHarness(t, model.ClusterSnapshot{
+		Nodes: []model.Node{testNode("a"), testNode("b")},
+		Pods:  []model.Pod{testPod("app", "web-1", "a", "web")},
+	}, []model.PlanStep{step(1, "a", model.ImpactGreen)}, permissive())
+
+	run := h.request(t, []int{1}, false)
+	claim := findEvent(h.events(t, run.ID), "Claim")
+	if claim == nil || !strings.Contains(claim.Message, "alice@example.com") {
+		t.Errorf("claim event does not name the requester: %+v", claim)
+	}
+	if run.Actor != "alice@example.com" {
+		t.Errorf("run lost its actor: %s", run.Actor)
+	}
+}
+
+func findEvent(events []store.RunEvent, action string) *store.RunEvent {
+	for i := range events {
+		if events[i].Action == action {
+			return &events[i]
+		}
+	}
+	return nil
+}
+
+func hasEvent(events []store.RunEvent, action string) bool {
+	return findEvent(events, action) != nil
+}
+
+// The API server is the real PDB authority, and it can refuse an eviction that
+// passed our pre-flight check — state moves between the two. That refusal must
+// be recorded as a guard verdict and end the run as Blocked, not Failed.
+func TestApiServerEvictionRefusalIsTreatedAsAGuardBlock(t *testing.T) {
+	h := newHarness(t, model.ClusterSnapshot{
+		Nodes: []model.Node{testNode("a"), testNode("b")},
+		Pods:  []model.Pod{testPod("app", "web-1", "a", "web")},
+	}, []model.PlanStep{step(1, "a", model.ImpactGreen)}, permissive())
+
+	// No PDB in our snapshot, so the pre-flight check passes; the "API server"
+	// refuses anyway, exactly as a 429 would.
+	h.cluster.evictErr["app/web-1"] = &safety.Blocked{
+		Rule:   safety.RulePDBHeadroom,
+		Reason: "the API server refused to evict app/web-1: a PodDisruptionBudget has no headroom",
+	}
+
+	run := h.request(t, []int{1}, false)
+
+	if run.Status != store.RunBlocked {
+		t.Fatalf("status = %s (%s), want Blocked", run.Status, run.Summary)
+	}
+	ev := findEvent(h.events(t, run.ID), "Guard")
+	if ev == nil || ev.Rule != string(safety.RulePDBHeadroom) {
+		t.Errorf("API-server refusal not audited with its rule: %+v", ev)
+	}
+	if h.cluster.nodeCordoned("a") {
+		t.Error("node left cordoned after an API-server refusal")
+	}
+}

--- a/internal/executor/k8s.go
+++ b/internal/executor/k8s.go
@@ -1,0 +1,98 @@
+package executor
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	policyv1 "k8s.io/api/policy/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/atedgimo/k8s-dencer/internal/cluster"
+	"github.com/atedgimo/k8s-dencer/internal/model"
+	"github.com/atedgimo/k8s-dencer/internal/safety"
+)
+
+// K8sCluster performs the executor's mutations against a real API server.
+type K8sCluster struct {
+	client kubernetes.Interface
+	reader *cluster.Direct
+}
+
+// NewK8sCluster builds the adapter over an uncached reader.
+func NewK8sCluster(reader *cluster.Direct) *K8sCluster {
+	return &K8sCluster{client: reader.Client(), reader: reader}
+}
+
+// Snapshot reads fresh cluster state.
+func (k *K8sCluster) Snapshot(ctx context.Context) (*model.ClusterSnapshot, error) {
+	return k.reader.Snapshot(ctx)
+}
+
+// Cordon marks a node unschedulable.
+func (k *K8sCluster) Cordon(ctx context.Context, node string) error {
+	return k.setUnschedulable(ctx, node, true)
+}
+
+// Uncordon restores schedulability.
+func (k *K8sCluster) Uncordon(ctx context.Context, node string) error {
+	return k.setUnschedulable(ctx, node, false)
+}
+
+// setUnschedulable patches the cordon flag.
+//
+// A merge patch of the single field, not a read-modify-write Update: an Update
+// would carry the whole object and could clobber a concurrent change made by
+// the cluster autoscaler or an operator with kubectl. It also means the
+// executor's RBAC needs only `patch` on nodes, never `update`.
+func (k *K8sCluster) setUnschedulable(ctx context.Context, node string, value bool) error {
+	patch, err := json.Marshal(map[string]any{
+		"spec": map[string]any{"unschedulable": value},
+	})
+	if err != nil {
+		return err
+	}
+	_, err = k.client.CoreV1().Nodes().Patch(ctx, node, types.MergePatchType, patch, metav1.PatchOptions{})
+	if err != nil {
+		return fmt.Errorf("patch node %s: %w", node, err)
+	}
+	return nil
+}
+
+// Evict requests voluntary eviction through the policy/v1 eviction API.
+//
+// This is the single most important line in the package. The eviction
+// subresource is what makes the API server enforce PodDisruptionBudgets; a
+// plain Delete on the pod would succeed regardless and quietly take a service
+// below its minimum. The executor's RBAC grants create on pods/eviction and
+// deliberately does not grant delete on pods.
+//
+// A 429 is the API server refusing on PDB grounds. That is not a failure —
+// it is the same rail the Safety Guard checks, enforced by the authority that
+// actually owns it — so it is translated back into a guard refusal and the run
+// stops as Blocked rather than Failed. The pre-flight check exists to catch
+// this early with a better message; this is the backstop that cannot be raced.
+func (k *K8sCluster) Evict(ctx context.Context, namespace, name string) error {
+	err := k.client.PolicyV1().Evictions(namespace).Evict(ctx, &policyv1.Eviction{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+	})
+	switch {
+	case err == nil:
+		return nil
+	case apierrors.IsNotFound(err):
+		// Already gone — the drain's goal for this pod is met.
+		return nil
+	case apierrors.IsTooManyRequests(err):
+		return &safety.Blocked{
+			Rule: safety.RulePDBHeadroom,
+			Reason: fmt.Sprintf(
+				"the API server refused to evict %s: a PodDisruptionBudget has no headroom (%v)",
+				PodKey(namespace, name), err),
+		}
+	default:
+		return fmt.Errorf("evict %s: %w", PodKey(namespace, name), err)
+	}
+}

--- a/internal/safety/safety.go
+++ b/internal/safety/safety.go
@@ -1,0 +1,242 @@
+// Package safety implements the non-negotiable rails on execution.
+//
+// Architecture doc §9: these are enforced in code, not in prompts and not in
+// API input validation, so no crafted request and no confused LLM can talk
+// them into allowing something. The UI may only ever ask; this package decides.
+//
+// Two properties are deliberate and load-bearing:
+//
+//  1. Every rule is checked immediately before the action it guards, against
+//     freshly-read cluster state — never once at admission for a whole run. A
+//     request for steps 1–10 that becomes unsafe at step 4 stops at step 4.
+//  2. Every refusal names the rule that produced it. The name lands in the
+//     audit trail and in the operator's face, so "why did it stop?" is
+//     answerable without reading logs.
+package safety
+
+import (
+	"fmt"
+
+	"github.com/atedgimo/k8s-dencer/internal/constraints"
+	"github.com/atedgimo/k8s-dencer/internal/model"
+)
+
+// Rule identifies a rail. Stable strings: they appear in audit events, and
+// changing one silently rewrites history.
+type Rule string
+
+const (
+	// RuleRedRequiresWindow blocks Red-rated steps. Until the MaintenanceWindow
+	// CRD exists in Phase 3 there is no window to be inside, so Red is simply
+	// refused — which is the safe reading of "Red may only run inside an
+	// approved window".
+	RuleRedRequiresWindow Rule = "RedRequiresWindow"
+
+	// RuleMaxNodesPerRun caps how much one request may disturb.
+	RuleMaxNodesPerRun Rule = "MaxNodesPerRun"
+
+	// RuleMinReadyNodes keeps a floor of schedulable capacity, so a
+	// consolidation cannot squeeze a cluster to the point where the next
+	// failure has nowhere to go.
+	RuleMinReadyNodes Rule = "MinReadyNodes"
+
+	// RuleStepFreshness rejects a step whose preconditions have drifted since
+	// the plan was computed.
+	RuleStepFreshness Rule = "StepFreshness"
+
+	// RulePDBHeadroom re-reads live disruption headroom immediately before
+	// each individual eviction.
+	RulePDBHeadroom Rule = "PDBHeadroom"
+
+	// RuleNodeNotFound covers a target that has vanished.
+	RuleNodeNotFound Rule = "NodeNotFound"
+)
+
+// Limits are the operator-tunable rails, supplied by the chart.
+type Limits struct {
+	// MaxNodesPerRun caps nodes drained by a single execution request.
+	MaxNodesPerRun int
+
+	// MinReadyNodes is the floor of Ready, schedulable nodes to leave behind.
+	MinReadyNodes int
+
+	// AllowRed is false and stays false until Phase 3 introduces approved
+	// maintenance windows. It exists so the rule reads honestly rather than
+	// being hardcoded, but nothing in Phase 2 sets it true.
+	AllowRed bool
+}
+
+// DefaultLimits are deliberately conservative. An operator who wants to drain
+// more can raise them explicitly; nobody should discover the ceiling by
+// accidentally draining a cluster.
+func DefaultLimits() Limits {
+	return Limits{MaxNodesPerRun: 5, MinReadyNodes: 3, AllowRed: false}
+}
+
+// Blocked is a refusal. It is an error so it cannot be ignored by a caller
+// that forgets to check a boolean.
+type Blocked struct {
+	Rule   Rule
+	Reason string
+}
+
+func (b *Blocked) Error() string { return fmt.Sprintf("%s: %s", b.Rule, b.Reason) }
+
+// block is a small constructor to keep the rules readable.
+func block(rule Rule, format string, args ...any) *Blocked {
+	return &Blocked{Rule: rule, Reason: fmt.Sprintf(format, args...)}
+}
+
+// Guard evaluates the rails.
+type Guard struct {
+	limits Limits
+}
+
+// New builds a Guard.
+func New(limits Limits) *Guard { return &Guard{limits: limits} }
+
+// Limits exposes the configured rails, for reporting.
+func (g *Guard) Limits() Limits { return g.limits }
+
+// RunState is what the guard needs to know about the request in progress.
+type RunState struct {
+	// NodesDrainedSoFar counts nodes already drained by this run, so the cap
+	// applies across the whole request rather than per step.
+	NodesDrainedSoFar int
+}
+
+// CheckStep evaluates every rail that applies before a step begins.
+//
+// live must be a freshly-collected snapshot, not the one the plan was computed
+// from. Checking a step against the state that produced it would confirm only
+// that the planner was self-consistent.
+func (g *Guard) CheckStep(step model.PlanStep, live *model.ClusterSnapshot, run RunState) error {
+	// Impact first: it is the cheapest check and the most absolute.
+	if step.Impact.RequiresMaintenanceWindow() && !g.limits.AllowRed {
+		return block(RuleRedRequiresWindow,
+			"step %d is rated Red and may only run inside an approved maintenance window, "+
+				"which this release does not yet implement. Rated Red because: %s",
+			step.SequenceNumber, step.Rationale)
+	}
+
+	if g.limits.MaxNodesPerRun > 0 && run.NodesDrainedSoFar >= g.limits.MaxNodesPerRun {
+		return block(RuleMaxNodesPerRun,
+			"this run has already drained %d node(s), the configured maximum. "+
+				"Raise safety.maxNodesPerRun or start another run",
+			run.NodesDrainedSoFar)
+	}
+
+	if step.TargetNode == "" {
+		return block(RuleStepFreshness, "step %d names no target node", step.SequenceNumber)
+	}
+
+	node, ok := live.NodeByName(step.TargetNode)
+	if !ok {
+		return block(RuleNodeNotFound,
+			"node %s no longer exists; the plan is stale", step.TargetNode)
+	}
+
+	// Draining below the floor is refused before anything is touched, rather
+	// than discovered when the last node fills up.
+	if err := g.checkNodeFloor(node, live); err != nil {
+		return err
+	}
+
+	return g.checkStepFeasible(step, live)
+}
+
+// checkNodeFloor keeps enough Ready, schedulable capacity in the cluster.
+func (g *Guard) checkNodeFloor(target model.Node, live *model.ClusterSnapshot) error {
+	if g.limits.MinReadyNodes <= 0 {
+		return nil
+	}
+	ready := 0
+	for _, n := range live.Nodes {
+		if n.Ready && !n.Unschedulable {
+			ready++
+		}
+	}
+	// The target is about to leave the schedulable pool, so count it out.
+	if target.Ready && !target.Unschedulable {
+		ready--
+	}
+	if ready < g.limits.MinReadyNodes {
+		return block(RuleMinReadyNodes,
+			"draining %s would leave %d schedulable node(s), below the floor of %d",
+			target.Name, ready, g.limits.MinReadyNodes)
+	}
+	return nil
+}
+
+// checkStepFeasible re-proves that every pod on the target can go somewhere
+// else, against live state.
+//
+// This is the scheduler-simulation half of the design. Rather than importing
+// kube-scheduler's framework, it reuses the Placement evaluator the planner
+// itself was built on — and the executor then verifies reality after each
+// eviction, so a prediction that turns out wrong aborts the run instead of
+// corrupting it.
+func (g *Guard) checkStepFeasible(step model.PlanStep, live *model.ClusterSnapshot) error {
+	placement := constraints.NewPlacement(live).Clone()
+
+	// The target is leaving the pool; nothing may be placed back onto it.
+	// Copied because Occupants aliases the placement's own slice, which Remove
+	// mutates — iterating the live one would skip pods.
+	occupants := append([]model.Pod(nil), placement.Occupants(step.TargetNode)...)
+	for _, pod := range occupants {
+		placement.Remove(pod)
+	}
+
+	for _, pod := range occupants {
+		// DaemonSet, terminating and completed pods leave with the node and
+		// need no home; counting them would make every node undrainable.
+		if !pod.IsMovable() {
+			continue
+		}
+		if !g.hasHome(placement, pod, step.TargetNode) {
+			return block(RuleStepFreshness,
+				"%s/%s on %s has nowhere left to go; the cluster has changed since the plan was computed",
+				pod.Namespace, pod.Name, step.TargetNode)
+		}
+	}
+	return nil
+}
+
+// hasHome reports whether pod fits on some node other than the one draining.
+// The pod is provisionally placed so the search reflects the real end state.
+func (g *Guard) hasHome(placement *constraints.Placement, pod model.Pod, draining string) bool {
+	for _, candidate := range placement.NodeNames() {
+		if candidate == draining {
+			continue
+		}
+		if ok, _ := placement.CanPlace(pod, candidate); ok {
+			placement.Place(pod, candidate)
+			return true
+		}
+	}
+	return false
+}
+
+// CheckEviction is the last gate before a single pod is evicted.
+//
+// Called immediately before each eviction with freshly-read state, never once
+// per step: evicting the first pod of a set changes the headroom for the rest,
+// and a batch check would authorise disruptions the PDB no longer permits.
+func (g *Guard) CheckEviction(pod model.Pod, live *model.ClusterSnapshot) error {
+	for _, pdb := range live.PDBs {
+		if pdb.Namespace != pod.Namespace {
+			continue
+		}
+		if pdb.Selector.IsEmpty() || !pdb.Selector.Matches(pod.Labels) {
+			continue
+		}
+		if pdb.Blocks() {
+			return block(RulePDBHeadroom,
+				"PodDisruptionBudget %s allows %d more disruption(s) (%d/%d healthy); "+
+					"evicting %s/%s would violate it",
+				pdb.Key(), pdb.DisruptionsAllowed, pdb.CurrentHealthy, pdb.DesiredHealthy,
+				pod.Namespace, pod.Name)
+		}
+	}
+	return nil
+}

--- a/internal/safety/safety_test.go
+++ b/internal/safety/safety_test.go
@@ -1,0 +1,264 @@
+package safety_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/atedgimo/k8s-dencer/internal/model"
+	"github.com/atedgimo/k8s-dencer/internal/safety"
+)
+
+func node(name string, cpu int64, opts ...func(*model.Node)) model.Node {
+	n := model.Node{
+		Name: name, Ready: true,
+		Labels:      map[string]string{model.LabelZone: "z1"},
+		Allocatable: model.Resources{MilliCPU: cpu, MemoryBytes: 1 << 34, Pods: 110},
+	}
+	for _, o := range opts {
+		o(&n)
+	}
+	return n
+}
+
+func cordoned(n *model.Node) { n.Unschedulable = true }
+func notReady(n *model.Node) { n.Ready = false }
+
+func pod(ns, name, on string, cpu int64, opts ...func(*model.Pod)) model.Pod {
+	p := model.Pod{
+		Namespace: ns, Name: name, NodeName: on, Phase: model.PodRunning,
+		Labels:   map[string]string{"app": name},
+		Requests: model.Resources{MilliCPU: cpu, MemoryBytes: 1 << 28},
+		Owner:    &model.OwnerRef{Kind: "ReplicaSet", Name: name},
+	}
+	for _, o := range opts {
+		o(&p)
+	}
+	return p
+}
+
+func daemonSet(p *model.Pod) { p.Owner = &model.OwnerRef{Kind: "DaemonSet", Name: "agent"} }
+
+func step(seq int, target string, impact model.ImpactRating) model.PlanStep {
+	return model.PlanStep{
+		ID: "s", SequenceNumber: seq, TargetNode: target, Impact: impact,
+		Rationale: "test rationale",
+	}
+}
+
+// permissive limits isolate the rule under test from the caps.
+func permissive() safety.Limits {
+	return safety.Limits{MaxNodesPerRun: 100, MinReadyNodes: 0, AllowRed: false}
+}
+
+func blockedBy(t *testing.T, err error, want safety.Rule) *safety.Blocked {
+	t.Helper()
+	var b *safety.Blocked
+	if !errors.As(err, &b) {
+		t.Fatalf("expected a %s refusal, got %v", want, err)
+	}
+	if b.Rule != want {
+		t.Fatalf("blocked by %s, want %s: %s", b.Rule, want, b.Reason)
+	}
+	return b
+}
+
+// Red is refused outright. Phase 3 introduces maintenance windows; until then
+// there is no window to be inside, and treating "window-only" as "allowed" is
+// the failure this rule exists to prevent.
+func TestRedStepsAreRefused(t *testing.T) {
+	live := &model.ClusterSnapshot{Nodes: []model.Node{node("a", 4000), node("b", 4000)}}
+	g := safety.New(permissive())
+
+	err := g.CheckStep(step(7, "a", model.ImpactRed), live, safety.RunState{})
+	b := blockedBy(t, err, safety.RuleRedRequiresWindow)
+
+	// The refusal must quote the classifier's own rationale, so the operator
+	// reads the same words the UI and the agent show them.
+	if !strings.Contains(b.Reason, "test rationale") {
+		t.Errorf("refusal does not quote the rationale: %s", b.Reason)
+	}
+	if !strings.Contains(b.Reason, "maintenance window") {
+		t.Errorf("refusal should say why Red is special: %s", b.Reason)
+	}
+}
+
+func TestGreenAndYellowStepsPass(t *testing.T) {
+	live := &model.ClusterSnapshot{Nodes: []model.Node{node("a", 4000), node("b", 4000)}}
+	g := safety.New(permissive())
+
+	for _, impact := range []model.ImpactRating{model.ImpactGreen, model.ImpactYellow} {
+		if err := g.CheckStep(step(1, "a", impact), live, safety.RunState{}); err != nil {
+			t.Errorf("%s step refused: %v", impact, err)
+		}
+	}
+}
+
+func TestMaxNodesPerRunCapsTheWholeRequest(t *testing.T) {
+	live := &model.ClusterSnapshot{Nodes: []model.Node{node("a", 4000), node("b", 4000)}}
+	g := safety.New(safety.Limits{MaxNodesPerRun: 3})
+
+	if err := g.CheckStep(step(1, "a", model.ImpactGreen), live, safety.RunState{NodesDrainedSoFar: 2}); err != nil {
+		t.Fatalf("third node refused early: %v", err)
+	}
+	err := g.CheckStep(step(1, "a", model.ImpactGreen), live, safety.RunState{NodesDrainedSoFar: 3})
+	blockedBy(t, err, safety.RuleMaxNodesPerRun)
+}
+
+// The floor counts schedulable capacity, not raw node count: a cordoned or
+// NotReady node cannot absorb anything and must not prop up the total.
+func TestMinReadyNodesCountsOnlySchedulableCapacity(t *testing.T) {
+	g := safety.New(safety.Limits{MinReadyNodes: 2, MaxNodesPerRun: 100})
+
+	t.Run("enough remain", func(t *testing.T) {
+		live := &model.ClusterSnapshot{Nodes: []model.Node{
+			node("a", 4000), node("b", 4000), node("c", 4000),
+		}}
+		if err := g.CheckStep(step(1, "a", model.ImpactGreen), live, safety.RunState{}); err != nil {
+			t.Errorf("refused with 2 nodes left: %v", err)
+		}
+	})
+
+	t.Run("cordoned and NotReady nodes do not count", func(t *testing.T) {
+		live := &model.ClusterSnapshot{Nodes: []model.Node{
+			node("a", 4000),
+			node("b", 4000, cordoned),
+			node("c", 4000, notReady),
+			node("d", 4000),
+		}}
+		// Only a and d are schedulable; draining a leaves 1, below the floor.
+		err := g.CheckStep(step(1, "a", model.ImpactGreen), live, safety.RunState{})
+		b := blockedBy(t, err, safety.RuleMinReadyNodes)
+		if !strings.Contains(b.Reason, "floor of 2") {
+			t.Errorf("refusal should state the floor: %s", b.Reason)
+		}
+	})
+}
+
+func TestVanishedNodeIsRefused(t *testing.T) {
+	live := &model.ClusterSnapshot{Nodes: []model.Node{node("b", 4000)}}
+	err := safety.New(permissive()).CheckStep(step(1, "gone", model.ImpactGreen), live, safety.RunState{})
+	blockedBy(t, err, safety.RuleNodeNotFound)
+}
+
+// The freshness rule is what catches a plan that was valid when computed and
+// is not any more — the cluster filled up in between.
+func TestStepIsRefusedWhenPodsHaveNowhereToGo(t *testing.T) {
+	g := safety.New(permissive())
+
+	t.Run("feasible", func(t *testing.T) {
+		live := &model.ClusterSnapshot{
+			Nodes: []model.Node{node("a", 4000), node("b", 4000)},
+			Pods:  []model.Pod{pod("app", "x", "a", 1000)},
+		}
+		if err := g.CheckStep(step(1, "a", model.ImpactGreen), live, safety.RunState{}); err != nil {
+			t.Errorf("refused a feasible step: %v", err)
+		}
+	})
+
+	t.Run("destination too full", func(t *testing.T) {
+		live := &model.ClusterSnapshot{
+			Nodes: []model.Node{node("a", 4000), node("b", 4000)},
+			Pods: []model.Pod{
+				pod("app", "big", "a", 3000),
+				pod("app", "filler", "b", 3800), // b has only 200m left
+			},
+		}
+		err := g.CheckStep(step(1, "a", model.ImpactGreen), live, safety.RunState{})
+		b := blockedBy(t, err, safety.RuleStepFreshness)
+		if !strings.Contains(b.Reason, "app/big") {
+			t.Errorf("refusal should name the homeless pod: %s", b.Reason)
+		}
+	})
+
+	// Two pods that each fit alone but not together must be refused: the check
+	// has to model them landing cumulatively, not independently.
+	t.Run("pods fit individually but not collectively", func(t *testing.T) {
+		live := &model.ClusterSnapshot{
+			Nodes: []model.Node{node("a", 4000), node("b", 4000)},
+			Pods: []model.Pod{
+				pod("app", "p1", "a", 2500),
+				pod("app", "p2", "a", 2500),
+			},
+		}
+		err := g.CheckStep(step(1, "a", model.ImpactGreen), live, safety.RunState{})
+		blockedBy(t, err, safety.RuleStepFreshness)
+	})
+}
+
+// DaemonSet pods leave with the node. Counting them would make every node
+// look undrainable and block the product from doing anything at all.
+func TestDaemonSetPodsDoNotBlockADrain(t *testing.T) {
+	live := &model.ClusterSnapshot{
+		Nodes: []model.Node{node("a", 1000), node("b", 1000)},
+		Pods: []model.Pod{
+			pod("kube-system", "agent-a", "a", 900, daemonSet),
+			pod("kube-system", "agent-b", "b", 900, daemonSet),
+		},
+	}
+	if err := safety.New(permissive()).CheckStep(step(1, "a", model.ImpactGreen), live, safety.RunState{}); err != nil {
+		t.Errorf("a node holding only DaemonSet pods should be drainable: %v", err)
+	}
+}
+
+// The eviction gate reads live headroom. A PDB that exists but permits
+// disruption must not block; one at zero must.
+func TestEvictionRespectsLivePDBHeadroom(t *testing.T) {
+	g := safety.New(permissive())
+	target := pod("app", "web-1", "a", 100)
+
+	covering := func(allowed int32) model.PodDisruptionBudget {
+		return model.PodDisruptionBudget{
+			Namespace: "app", Name: "web",
+			Selector:           &model.LabelSelector{MatchLabels: map[string]string{"app": "web-1"}},
+			DisruptionsAllowed: allowed, CurrentHealthy: 3, DesiredHealthy: 3,
+		}
+	}
+
+	t.Run("headroom available", func(t *testing.T) {
+		live := &model.ClusterSnapshot{PDBs: []model.PodDisruptionBudget{covering(1)}}
+		if err := g.CheckEviction(target, live); err != nil {
+			t.Errorf("blocked despite headroom: %v", err)
+		}
+	})
+
+	t.Run("zero headroom", func(t *testing.T) {
+		live := &model.ClusterSnapshot{PDBs: []model.PodDisruptionBudget{covering(0)}}
+		b := blockedBy(t, g.CheckEviction(target, live), safety.RulePDBHeadroom)
+		if !strings.Contains(b.Reason, "app/web") {
+			t.Errorf("refusal should name the PDB: %s", b.Reason)
+		}
+	})
+
+	t.Run("PDB in another namespace is irrelevant", func(t *testing.T) {
+		other := covering(0)
+		other.Namespace = "elsewhere"
+		live := &model.ClusterSnapshot{PDBs: []model.PodDisruptionBudget{other}}
+		if err := g.CheckEviction(target, live); err != nil {
+			t.Errorf("a PDB in another namespace blocked the eviction: %v", err)
+		}
+	})
+
+	t.Run("PDB whose selector does not match is irrelevant", func(t *testing.T) {
+		other := covering(0)
+		other.Selector = &model.LabelSelector{MatchLabels: map[string]string{"app": "something-else"}}
+		live := &model.ClusterSnapshot{PDBs: []model.PodDisruptionBudget{other}}
+		if err := g.CheckEviction(target, live); err != nil {
+			t.Errorf("a non-matching PDB blocked the eviction: %v", err)
+		}
+	})
+}
+
+// AllowRed exists so the rule reads honestly, but nothing in Phase 2 sets it.
+// If a future change flips the default, this fails.
+func TestRedIsNotAllowedByDefault(t *testing.T) {
+	if safety.DefaultLimits().AllowRed {
+		t.Error("DefaultLimits permits Red steps; maintenance windows do not exist yet")
+	}
+	if safety.DefaultLimits().MinReadyNodes <= 0 {
+		t.Error("DefaultLimits has no node floor")
+	}
+	if safety.DefaultLimits().MaxNodesPerRun <= 0 {
+		t.Error("DefaultLimits has no cap on nodes per run")
+	}
+}

--- a/internal/store/execution.go
+++ b/internal/store/execution.go
@@ -1,0 +1,134 @@
+package store
+
+import (
+	"context"
+	"time"
+)
+
+// RunStatus is the lifecycle of an execution request.
+type RunStatus string
+
+const (
+	// RunPending has been accepted and authorized but not yet claimed.
+	RunPending RunStatus = "Pending"
+	// RunRunning has been claimed by an executor.
+	RunRunning RunStatus = "Running"
+	// RunSucceeded completed every requested step.
+	RunSucceeded RunStatus = "Succeeded"
+	// RunBlocked stopped because the Safety Guard refused a step. Not a
+	// failure: the rails worked. Kept distinct from Failed so an operator can
+	// tell "we protected you" from "something broke".
+	RunBlocked RunStatus = "Blocked"
+	// RunFailed stopped on an error.
+	RunFailed RunStatus = "Failed"
+)
+
+// Terminal reports whether a run has finished.
+func (s RunStatus) Terminal() bool {
+	return s == RunSucceeded || s == RunBlocked || s == RunFailed
+}
+
+// Run is one execution request covering a subset of a plan's steps.
+//
+// Bound to a specific plan ID. The planner keeps producing new plans while a
+// run is in flight, and a run must keep executing the steps that were
+// authorized rather than silently following whatever the latest plan says.
+type Run struct {
+	ID     string    `json:"id"`
+	PlanID string    `json:"planId"`
+	Steps  []int     `json:"steps"`
+	DryRun bool      `json:"dryRun"`
+	Status RunStatus `json:"status"`
+
+	// Actor is the authenticated identity that requested the run, captured at
+	// enqueue. Authorization happens once, up front, so a run outlives the
+	// token that authorized it — a 15-minute ID token can start a 40-minute
+	// consolidation. This field is how it stays attributable afterwards.
+	Actor       string   `json:"actor"`
+	ActorGroups []string `json:"actorGroups,omitempty"`
+
+	RequestedAt time.Time  `json:"requestedAt"`
+	StartedAt   *time.Time `json:"startedAt,omitempty"`
+	FinishedAt  *time.Time `json:"finishedAt,omitempty"`
+
+	// Worker identifies the executor that claimed this run.
+	Worker string `json:"worker,omitempty"`
+
+	// Summary is the closing human-readable outcome.
+	Summary string `json:"summary,omitempty"`
+}
+
+// EventLevel separates progress from refusals and errors.
+type EventLevel string
+
+const (
+	EventInfo    EventLevel = "Info"
+	EventBlocked EventLevel = "Blocked"
+	EventError   EventLevel = "Error"
+)
+
+// RunEvent is one entry in the audit trail.
+//
+// Doc §9 requires a full audit log of every action taken, tied to the plan
+// version and the specific step that authorized it. Every field below exists
+// to answer a question someone will ask after an incident: what happened, to
+// what, under whose authority, and which rule stopped it.
+type RunEvent struct {
+	RunID    string     `json:"runId"`
+	Sequence int        `json:"sequence"`
+	At       time.Time  `json:"at"`
+	Level    EventLevel `json:"level"`
+
+	// Step is the plan step this event belongs to, 0 for run-level events.
+	Step int `json:"step,omitempty"`
+	// Node and Pod name what was acted on, when applicable.
+	Node string `json:"node,omitempty"`
+	Pod  string `json:"pod,omitempty"`
+
+	// Action is a stable identifier: Cordon, Evict, Uncordon, Verify, Claim...
+	Action string `json:"action"`
+	// Rule names the Safety Guard rail that refused, for Blocked events.
+	Rule string `json:"rule,omitempty"`
+
+	Message string `json:"message"`
+}
+
+// ExecutionStore persists execution requests and their audit trail.
+//
+// Separate from Store because the writers differ: ui-backend enqueues, the
+// executor claims and appends. Keeping them apart makes it obvious in a
+// deployment which component needs which half.
+type ExecutionStore interface {
+	// Enqueue records an authorized request and returns its run ID.
+	Enqueue(ctx context.Context, run Run) (string, error)
+
+	// Claim atomically takes the oldest pending run for worker, or returns
+	// ErrNotFound when there is nothing to do.
+	//
+	// Atomicity is the whole contract: two executors must never take the same
+	// run, or a node gets drained twice concurrently.
+	Claim(ctx context.Context, worker string) (Run, error)
+
+	// AppendEvent adds one audit entry. The sequence number is assigned by the
+	// store so ordering survives concurrent writers.
+	AppendEvent(ctx context.Context, ev RunEvent) error
+
+	// Finish closes a run with a terminal status and summary.
+	Finish(ctx context.Context, runID string, status RunStatus, summary string) error
+
+	// RunByID returns one run.
+	RunByID(ctx context.Context, runID string) (Run, error)
+
+	// Events returns a run's audit trail in order.
+	Events(ctx context.Context, runID string) ([]RunEvent, error)
+
+	// RunsForPlan lists runs against a plan, newest first.
+	RunsForPlan(ctx context.Context, planID string, limit int) ([]Run, error)
+
+	// ActiveRun returns the run currently pending or running, if any.
+	//
+	// One at a time is a deliberate constraint, not a limitation of the
+	// implementation: concurrent consolidations would each be making placement
+	// decisions the other invalidates.
+	ActiveRun(ctx context.Context) (Run, error)
+}

--- a/internal/store/sqlite/execution.go
+++ b/internal/store/sqlite/execution.go
@@ -1,0 +1,252 @@
+package sqlite
+
+import (
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/atedgimo/k8s-dencer/internal/store"
+)
+
+// Enqueue records an authorized execution request.
+func (s *Store) Enqueue(ctx context.Context, run store.Run) (string, error) {
+	if run.ID == "" {
+		run.ID = newRunID()
+	}
+	if run.Status == "" {
+		run.Status = store.RunPending
+	}
+	if run.RequestedAt.IsZero() {
+		run.RequestedAt = time.Now().UTC()
+	}
+
+	steps, err := json.Marshal(run.Steps)
+	if err != nil {
+		return "", err
+	}
+	groups, err := json.Marshal(run.ActorGroups)
+	if err != nil {
+		return "", err
+	}
+
+	_, err = s.db.ExecContext(ctx, `
+		INSERT INTO runs (id, plan_id, steps, dry_run, status, actor, actor_groups, requested_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		run.ID, run.PlanID, steps, boolToInt(run.DryRun), string(run.Status),
+		run.Actor, groups, run.RequestedAt.UTC().Format(time.RFC3339Nano))
+	if err != nil {
+		return "", fmt.Errorf("enqueue run: %w", err)
+	}
+	return run.ID, nil
+}
+
+// Claim atomically takes the oldest pending run.
+//
+// The UPDATE ... WHERE id = (SELECT ... LIMIT 1) form is what makes this safe:
+// the select and the write are one statement, so two executors racing cannot
+// both win. Doing it as SELECT-then-UPDATE would leave a window in which both
+// see the same pending row and both start draining the same node.
+func (s *Store) Claim(ctx context.Context, worker string) (store.Run, error) {
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+
+	var id string
+	err := s.db.QueryRowContext(ctx, `
+		UPDATE runs
+		SET status = ?, worker = ?, started_at = ?
+		WHERE id = (
+			SELECT id FROM runs
+			WHERE status = ?
+			ORDER BY requested_at, rowid
+			LIMIT 1
+		)
+		RETURNING id`,
+		string(store.RunRunning), worker, now, string(store.RunPending)).Scan(&id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return store.Run{}, store.ErrNotFound
+	}
+	if err != nil {
+		return store.Run{}, fmt.Errorf("claim run: %w", err)
+	}
+	return s.RunByID(ctx, id)
+}
+
+// AppendEvent adds one audit entry, assigning its sequence number.
+//
+// The sequence comes from a subquery rather than the caller so that ordering
+// holds even if the executor is restarted mid-run and resumes numbering.
+func (s *Store) AppendEvent(ctx context.Context, ev store.RunEvent) error {
+	if ev.At.IsZero() {
+		ev.At = time.Now().UTC()
+	}
+	if ev.Level == "" {
+		ev.Level = store.EventInfo
+	}
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO run_events (run_id, sequence, at, level, step, node, pod, action, rule, message)
+		VALUES (
+			?,
+			(SELECT COALESCE(MAX(sequence), 0) + 1 FROM run_events WHERE run_id = ?),
+			?, ?, ?, ?, ?, ?, ?, ?
+		)`,
+		ev.RunID, ev.RunID,
+		ev.At.UTC().Format(time.RFC3339Nano), string(ev.Level),
+		ev.Step, nullable(ev.Node), nullable(ev.Pod), ev.Action, nullable(ev.Rule), ev.Message)
+	if err != nil {
+		return fmt.Errorf("append run event: %w", err)
+	}
+	return nil
+}
+
+// Finish closes a run.
+func (s *Store) Finish(ctx context.Context, runID string, status store.RunStatus, summary string) error {
+	if !status.Terminal() {
+		return fmt.Errorf("cannot finish run %s with non-terminal status %s", runID, status)
+	}
+	res, err := s.db.ExecContext(ctx, `
+		UPDATE runs SET status = ?, summary = ?, finished_at = ? WHERE id = ?`,
+		string(status), summary, time.Now().UTC().Format(time.RFC3339Nano), runID)
+	if err != nil {
+		return fmt.Errorf("finish run: %w", err)
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return store.ErrNotFound
+	}
+	return nil
+}
+
+// RunByID returns one run.
+func (s *Store) RunByID(ctx context.Context, runID string) (store.Run, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT id, plan_id, steps, dry_run, status, actor, actor_groups,
+		       requested_at, started_at, finished_at, worker, summary
+		FROM runs WHERE id = ?`, runID)
+	return scanRun(row)
+}
+
+// ActiveRun returns the pending or running execution, if any.
+func (s *Store) ActiveRun(ctx context.Context) (store.Run, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT id, plan_id, steps, dry_run, status, actor, actor_groups,
+		       requested_at, started_at, finished_at, worker, summary
+		FROM runs WHERE status IN (?, ?)
+		ORDER BY requested_at LIMIT 1`,
+		string(store.RunPending), string(store.RunRunning))
+	return scanRun(row)
+}
+
+// RunsForPlan lists runs against a plan, newest first.
+func (s *Store) RunsForPlan(ctx context.Context, planID string, limit int) ([]store.Run, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, plan_id, steps, dry_run, status, actor, actor_groups,
+		       requested_at, started_at, finished_at, worker, summary
+		FROM runs WHERE plan_id = ? ORDER BY requested_at DESC, rowid DESC LIMIT ?`,
+		planID, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []store.Run
+	for rows.Next() {
+		run, err := scanRun(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, run)
+	}
+	return out, rows.Err()
+}
+
+// Events returns a run's audit trail in order.
+func (s *Store) Events(ctx context.Context, runID string) ([]store.RunEvent, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT sequence, at, level, step, node, pod, action, rule, message
+		FROM run_events WHERE run_id = ? ORDER BY sequence`, runID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []store.RunEvent
+	for rows.Next() {
+		ev := store.RunEvent{RunID: runID}
+		var at, level string
+		var node, pod, rule sql.NullString
+		if err := rows.Scan(&ev.Sequence, &at, &level, &ev.Step, &node, &pod,
+			&ev.Action, &rule, &ev.Message); err != nil {
+			return nil, err
+		}
+		ev.At = parseTime(at)
+		ev.Level = store.EventLevel(level)
+		ev.Node, ev.Pod, ev.Rule = node.String, pod.String, rule.String
+		out = append(out, ev)
+	}
+	return out, rows.Err()
+}
+
+// scanner covers both *sql.Row and *sql.Rows.
+type scanner interface{ Scan(dest ...any) error }
+
+func scanRun(row scanner) (store.Run, error) {
+	var (
+		run                   store.Run
+		steps, groups         []byte
+		dryRun                int
+		status, requestedAt   string
+		startedAt, finishedAt sql.NullString
+		worker, summary       sql.NullString
+	)
+	err := row.Scan(&run.ID, &run.PlanID, &steps, &dryRun, &status, &run.Actor, &groups,
+		&requestedAt, &startedAt, &finishedAt, &worker, &summary)
+	if errors.Is(err, sql.ErrNoRows) {
+		return store.Run{}, store.ErrNotFound
+	}
+	if err != nil {
+		return store.Run{}, err
+	}
+
+	if err := json.Unmarshal(steps, &run.Steps); err != nil {
+		return store.Run{}, fmt.Errorf("decode run steps: %w", err)
+	}
+	if len(groups) > 0 {
+		_ = json.Unmarshal(groups, &run.ActorGroups)
+	}
+	run.DryRun = dryRun != 0
+	run.Status = store.RunStatus(status)
+	run.RequestedAt = parseTime(requestedAt)
+	run.Worker, run.Summary = worker.String, summary.String
+	if startedAt.Valid {
+		t := parseTime(startedAt.String)
+		run.StartedAt = &t
+	}
+	if finishedAt.Valid {
+		t := parseTime(finishedAt.String)
+		run.FinishedAt = &t
+	}
+	return run, nil
+}
+
+func nullable(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
+}
+
+func newRunID() string {
+	var b [8]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// crypto/rand failing is not recoverable and not something a run ID
+		// should paper over with a predictable fallback.
+		panic("crypto/rand unavailable: " + err.Error())
+	}
+	return hex.EncodeToString(b[:])
+}

--- a/internal/store/sqlite/execution_test.go
+++ b/internal/store/sqlite/execution_test.go
@@ -1,0 +1,284 @@
+package sqlite_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/atedgimo/k8s-dencer/internal/store"
+)
+
+func sampleRun(planID string) store.Run {
+	return store.Run{
+		PlanID: planID, Steps: []int{1, 2, 3},
+		Actor: "alice@example.com", ActorGroups: []string{"oidc:platform-sre"},
+	}
+}
+
+func TestEnqueueAndReadBack(t *testing.T) {
+	db := openTemp(t)
+	ctx := context.Background()
+
+	id, err := db.Enqueue(ctx, sampleRun("plan-1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	run, err := db.RunByID(ctx, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.Status != store.RunPending {
+		t.Errorf("status = %s, want Pending", run.Status)
+	}
+	if len(run.Steps) != 3 || run.Steps[2] != 3 {
+		t.Errorf("steps round-tripped wrong: %v", run.Steps)
+	}
+	// The actor is the audit trail's answer to "under whose authority?" and
+	// must survive the token that authorized it.
+	if run.Actor != "alice@example.com" || len(run.ActorGroups) != 1 {
+		t.Errorf("actor lost: %+v", run)
+	}
+}
+
+// The property the whole queue design rests on. Two executors racing must not
+// both take the same run, or a node gets drained twice at once.
+func TestClaimIsAtomicUnderConcurrency(t *testing.T) {
+	db := openTemp(t)
+	ctx := context.Background()
+
+	const runs = 20
+	for i := range runs {
+		if _, err := db.Enqueue(ctx, sampleRun("plan-1")); err != nil {
+			t.Fatal(err)
+		}
+		_ = i
+	}
+
+	const workers = 8
+	var (
+		mu     sync.Mutex
+		claims = map[string]string{} // run ID -> worker that claimed it
+		dupes  []string
+		wg     sync.WaitGroup
+	)
+
+	for w := range workers {
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+			for {
+				run, err := db.Claim(ctx, "worker-"+string(rune('a'+worker)))
+				if errors.Is(err, store.ErrNotFound) {
+					return
+				}
+				if err != nil {
+					t.Errorf("claim: %v", err)
+					return
+				}
+				mu.Lock()
+				if prev, seen := claims[run.ID]; seen {
+					dupes = append(dupes, run.ID+" claimed by "+prev+" and "+run.Worker)
+				}
+				claims[run.ID] = run.Worker
+				mu.Unlock()
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	if len(dupes) > 0 {
+		t.Fatalf("the same run was claimed twice: %v", dupes)
+	}
+	if len(claims) != runs {
+		t.Errorf("claimed %d runs, want %d", len(claims), runs)
+	}
+}
+
+func TestClaimTakesOldestFirstAndMarksItRunning(t *testing.T) {
+	db := openTemp(t)
+	ctx := context.Background()
+
+	first := sampleRun("plan-1")
+	first.RequestedAt = time.Now().UTC().Add(-time.Hour)
+	firstID, err := db.Enqueue(ctx, first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Enqueue(ctx, sampleRun("plan-1")); err != nil {
+		t.Fatal(err)
+	}
+
+	claimed, err := db.Claim(ctx, "worker-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claimed.ID != firstID {
+		t.Errorf("claimed %s, want the oldest run %s", claimed.ID, firstID)
+	}
+	if claimed.Status != store.RunRunning || claimed.Worker != "worker-1" {
+		t.Errorf("claim did not mark the run running: %+v", claimed)
+	}
+	if claimed.StartedAt == nil {
+		t.Error("claim did not set StartedAt")
+	}
+}
+
+func TestClaimOnEmptyQueueReportsNotFound(t *testing.T) {
+	if _, err := openTemp(t).Claim(context.Background(), "worker-1"); !errors.Is(err, store.ErrNotFound) {
+		t.Errorf("got %v, want ErrNotFound", err)
+	}
+}
+
+// Sequence numbers are assigned by the store so the audit trail stays ordered
+// and gap-free regardless of who is writing.
+func TestEventsAreSequencedAndOrdered(t *testing.T) {
+	db := openTemp(t)
+	ctx := context.Background()
+	id, _ := db.Enqueue(ctx, sampleRun("plan-1"))
+
+	for _, ev := range []store.RunEvent{
+		{RunID: id, Action: "Claim", Message: "claimed"},
+		{RunID: id, Step: 1, Node: "kwok-node-3", Action: "Cordon", Message: "cordoned"},
+		{RunID: id, Step: 1, Node: "kwok-node-3", Pod: "app/web", Action: "Evict", Message: "evicted"},
+		{RunID: id, Step: 2, Level: store.EventBlocked, Rule: "PDBHeadroom", Action: "Evict",
+			Message: "blocked by PDB"},
+	} {
+		if err := db.AppendEvent(ctx, ev); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	events, err := db.Events(ctx, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 4 {
+		t.Fatalf("got %d events, want 4", len(events))
+	}
+	for i, ev := range events {
+		if ev.Sequence != i+1 {
+			t.Errorf("event %d has sequence %d", i, ev.Sequence)
+		}
+	}
+	// The refusal must record which rail stopped it — that is the question
+	// asked after an incident.
+	last := events[3]
+	if last.Level != store.EventBlocked || last.Rule != "PDBHeadroom" {
+		t.Errorf("blocked event lost its rule: %+v", last)
+	}
+	if events[2].Pod != "app/web" || events[1].Node != "kwok-node-3" {
+		t.Errorf("event subjects lost: %+v %+v", events[1], events[2])
+	}
+}
+
+func TestFinishRejectsNonTerminalStatus(t *testing.T) {
+	db := openTemp(t)
+	ctx := context.Background()
+	id, _ := db.Enqueue(ctx, sampleRun("plan-1"))
+
+	if err := db.Finish(ctx, id, store.RunRunning, "nope"); err == nil {
+		t.Error("Finish accepted a non-terminal status")
+	}
+	if err := db.Finish(ctx, id, store.RunBlocked, "stopped at step 4"); err != nil {
+		t.Fatal(err)
+	}
+	run, _ := db.RunByID(ctx, id)
+	if run.Status != store.RunBlocked || run.FinishedAt == nil {
+		t.Errorf("run not closed: %+v", run)
+	}
+}
+
+// Blocked is distinct from Failed on purpose: "the rails protected you" and
+// "something broke" call for different responses from an operator.
+func TestBlockedIsTerminalButDistinctFromFailed(t *testing.T) {
+	if !store.RunBlocked.Terminal() || !store.RunFailed.Terminal() || !store.RunSucceeded.Terminal() {
+		t.Error("a terminal status is not reporting as terminal")
+	}
+	if store.RunPending.Terminal() || store.RunRunning.Terminal() {
+		t.Error("an in-flight status is reporting as terminal")
+	}
+	if store.RunBlocked == store.RunFailed {
+		t.Error("Blocked and Failed must stay distinguishable")
+	}
+}
+
+func TestActiveRunFindsPendingAndRunning(t *testing.T) {
+	db := openTemp(t)
+	ctx := context.Background()
+
+	if _, err := db.ActiveRun(ctx); !errors.Is(err, store.ErrNotFound) {
+		t.Errorf("empty store reported an active run: %v", err)
+	}
+
+	id, _ := db.Enqueue(ctx, sampleRun("plan-1"))
+	if run, err := db.ActiveRun(ctx); err != nil || run.ID != id {
+		t.Errorf("pending run not active: %v %+v", err, run)
+	}
+	if _, err := db.Claim(ctx, "worker-1"); err != nil {
+		t.Fatal(err)
+	}
+	if run, err := db.ActiveRun(ctx); err != nil || run.ID != id {
+		t.Errorf("running run not active: %v %+v", err, run)
+	}
+	if err := db.Finish(ctx, id, store.RunSucceeded, "done"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.ActiveRun(ctx); !errors.Is(err, store.ErrNotFound) {
+		t.Errorf("finished run still reported active: %v", err)
+	}
+}
+
+// Doc §9 ties the audit log to the plan version and step IDs that authorized
+// each action. Pruning a plan a run executed would leave that log pointing at
+// nothing.
+func TestPruneNeverDeletesAPlanThatWasExecuted(t *testing.T) {
+	db := openTemp(t)
+	ctx := context.Background()
+
+	// Three plans, oldest first; a run against the oldest.
+	var ids []string
+	for i := range 3 {
+		rec := record(string(rune('a' + i)))
+		if _, err := db.Save(ctx, rec); err != nil {
+			t.Fatal(err)
+		}
+		ids = append(ids, rec.Plan.ID)
+	}
+	if _, err := db.Enqueue(ctx, sampleRun(ids[0])); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := db.Prune(ctx, 1); err != nil {
+		t.Fatal(err)
+	}
+
+	// The executed plan survives even though only 1 was to be kept.
+	if _, err := db.ByID(ctx, ids[0]); err != nil {
+		t.Errorf("pruned a plan with an execution against it: %v", err)
+	}
+	// The untouched middle plan is gone as normal.
+	if _, err := db.ByID(ctx, ids[1]); !errors.Is(err, store.ErrNotFound) {
+		t.Errorf("expected the un-executed plan to be pruned, got %v", err)
+	}
+}
+
+// The v2 tables must be usable after a re-run of Migrate on a current schema,
+// which is what every pod restart does.
+func TestExecutionTablesSurviveReMigration(t *testing.T) {
+	db := openTemp(t)
+	ctx := context.Background()
+
+	rec := record("plan-1")
+	if _, err := db.Save(ctx, rec); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Migrate(ctx); err != nil {
+		t.Fatalf("second Migrate failed: %v", err)
+	}
+	if _, err := db.Enqueue(ctx, sampleRun(rec.Plan.ID)); err != nil {
+		t.Errorf("v2 tables unusable after re-migration: %v", err)
+	}
+}

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -54,7 +54,7 @@ func Open(path string) (*Store, error) {
 // Close releases the database handle.
 func (s *Store) Close() error { return s.db.Close() }
 
-const schemaVersion = 1
+const schemaVersion = 2
 
 // Migrate creates or upgrades the schema.
 func (s *Store) Migrate(ctx context.Context) error {
@@ -75,6 +75,11 @@ func (s *Store) Migrate(ctx context.Context) error {
 	if current < 1 {
 		if _, err := tx.ExecContext(ctx, schemaV1); err != nil {
 			return fmt.Errorf("apply schema v1: %w", err)
+		}
+	}
+	if current < 2 {
+		if _, err := tx.ExecContext(ctx, schemaV2); err != nil {
+			return fmt.Errorf("apply schema v2: %w", err)
 		}
 	}
 
@@ -118,6 +123,50 @@ CREATE TABLE IF NOT EXISTS plan_steps (
     executed_by                 TEXT,
     result                      TEXT,
     PRIMARY KEY (plan_id, sequence_number)
+);
+`
+
+// Phase 2. Execution requests live here rather than in a CRD for the same
+// reason plans do (doc §6): they are written continuously, read almost
+// entirely by the UI, and nothing external "desires" a particular run.
+//
+// The runs table doubles as the work queue between ui-backend and the
+// executor. That keeps the executor free of any inbound network surface —
+// the only workload holding pods/eviction cannot be reached from the network
+// at all — and makes a run survive an executor restart.
+const schemaV2 = `
+CREATE TABLE IF NOT EXISTS runs (
+    id            TEXT PRIMARY KEY,
+    -- No ON DELETE CASCADE, deliberately: see Prune. An audit record that
+    -- vanishes with its plan is not an audit record.
+    plan_id       TEXT NOT NULL,
+    steps         BLOB NOT NULL,
+    dry_run       INTEGER NOT NULL DEFAULT 0,
+    status        TEXT NOT NULL,
+    actor         TEXT NOT NULL,
+    actor_groups  BLOB,
+    requested_at  TEXT NOT NULL,
+    started_at    TEXT,
+    finished_at   TEXT,
+    worker        TEXT,
+    summary       TEXT
+);
+
+CREATE INDEX IF NOT EXISTS runs_status ON runs (status, requested_at);
+CREATE INDEX IF NOT EXISTS runs_plan ON runs (plan_id, requested_at DESC);
+
+CREATE TABLE IF NOT EXISTS run_events (
+    run_id    TEXT NOT NULL REFERENCES runs(id) ON DELETE CASCADE,
+    sequence  INTEGER NOT NULL,
+    at        TEXT NOT NULL,
+    level     TEXT NOT NULL,
+    step      INTEGER NOT NULL DEFAULT 0,
+    node      TEXT,
+    pod       TEXT,
+    action    TEXT NOT NULL,
+    rule      TEXT,
+    message   TEXT NOT NULL,
+    PRIMARY KEY (run_id, sequence)
 );
 `
 
@@ -369,10 +418,16 @@ func (s *Store) Prune(ctx context.Context, keep int) (int, error) {
 	if keep <= 0 {
 		return 0, nil
 	}
+	// A plan that some run executed is never pruned, however old it is.
+	// Doc §9 requires the audit log to be tied to the plan version and the
+	// step IDs that authorized each action — so deleting the plan would leave
+	// the audit trail pointing at nothing, which is worse than keeping a few
+	// extra rows on the volume.
 	res, err := s.db.ExecContext(ctx, `
 		DELETE FROM plans WHERE id NOT IN (
 			SELECT id FROM plans ORDER BY stored_at DESC, rowid DESC LIMIT ?
-		)`, keep)
+		)
+		AND id NOT IN (SELECT DISTINCT plan_id FROM runs)`, keep)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
The first code in this product that can change a cluster. **Off by default** —
`executor.enabled=true` is what creates a ServiceAccount holding
`pods/eviction` and adds a POST route, and nobody should acquire either by
taking a chart bump.

## The shape is a split, not a service

```
browser ──POST /plans/{id}/execute──► ui-backend ──► runs table ──► executor ──► cordon / evict
                                      SAR: create                   atomic claim
                                      consolidations.dencer.io
```

- **The component that answers HTTP cannot evict.** ui-backend holds no write
  verb on nodes or pods; a lint assertion keeps it there.
- **The component that can evict answers nothing.** No Service, no API, no
  inbound path — work arrives as a row in a table.
- **Authorization happens once, at enqueue.** The executor then works under its
  own identity, so a 15-minute ID token can authorize a 40-minute
  consolidation. The requester is recorded on the run.

## Eviction, not delete

Eviction goes through the **policy/v1 eviction subresource**. A pod delete
would bypass PodDisruptionBudgets entirely; that single choice is what makes
every PDB guarantee in this product real. RBAC grants `create pods/eviction`
and deliberately withholds `delete pods`.

## The Safety Guard

`internal/safety`, doc §9 — checked before every step and before **every
individual eviction**, against freshly-read state rather than the plan's
snapshot (which would only confirm the planner was self-consistent). Rules:
`RedRequiresWindow`, `MaxNodesPerRun`, `MinReadyNodes`, `StepFreshness`,
`PDBHeadroom`, `NodeNotFound`. Each refusal names its rule, and that name lands
in the audit trail.

**Red is not configurable.** No value permits it; exposing one would turn a
safety rail into a footgun.

The guard predicts; the executor then **verifies reality** — the deliberate
alternative to importing kube-scheduler's framework (doc §7). After each step
the affected workloads must have regained their replicas elsewhere, or the run
aborts rather than draining a second node while the first one's pods sit
Pending.

**Abort means uncordon, not rollback.** Evicted pods are not restored, and the
docs say so in those words.

## Verified on the KWOK fabric, not only in tests

| Check | Result |
|---|---|
| Two Green steps, real drain | nodes cordoned, pods rehomed, recovery verified per step |
| Dry run of the same steps | full event stream, cluster untouched |
| Red step | refused, quoting the classifier's own rationale |
| Eviction API vs `payments` PDB (allowed=0) | `429 TooManyRequests` |
| Eviction API vs `catalog` PDB (allowed=2) | `201 Success` |

## Two things the cluster taught us that tests could not

- **`kubectl auth can-i create pods/eviction` answers "no" for everyone**,
  including accounts that hold the permission. That check has been in
  NOTES.txt since Phase 1 and *could never have failed*. Replaced with
  `--subresource=eviction`, which distinguishes the three ServiceAccounts
  correctly.
- **Cordoning breaks `make scenario`.** The node controller adds
  `node.kubernetes.io/unschedulable` to `.spec.taints` under its own field
  manager, and the demo chart manages `.spec.taints` too, so server-side apply
  conflicts after the first run. Added `make fabric-reset`, which `scenario`
  now calls first.

## The lint gate narrows rather than disappears

No eviction in any profile that did not ask for one; the grant confined to the
executor ClusterRole; planner and ui-backend holding no write verb on nodes or
pods; the executor rendering no Service; and `executor.enabled` rejected
without `auth.enabled` or `persistence.enabled`.

**189 tests, 22 chart contract assertions.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)