### PR TITLE
M12: plan pinning and OIDC sign-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ state on its own.
 | **M9** | AuthN/AuthZ via TokenReview + SubjectAccessReview; OIDC SSO; NetworkPolicy on by default | **done** |
 | **M10** | Executor + Safety Guard, own ServiceAccount, `pods/eviction`, audited runs | **done** |
 | **M11** | UI rebuild: packing view, motion, action-first header | **done** |
-| **M12** | Execution controls, live run, OIDC sign-in flow, plan pinning | planned |
+| **M12** | Execution controls, live run, OIDC sign-in flow, plan pinning | **done** |
 | **M13** | End-to-end on KWOK incl. real SSO against Dex | planned |
 
 Deferred beyond Phase 2: `MaintenanceWindow` CRD and scheduled execution,
@@ -233,6 +233,14 @@ unused** — a request carrying `X-Forwarded-User` is anonymous, not an
 administrator. Turning it on means anything that can reach ui-backend can claim
 to be anyone, so `networkPolicy.enabled` is what makes the proxy unbypassable.
 
+**Signing in.** Where an issuer is configured the UI runs the redirect flow
+itself; `oidc-client-ts` is loaded on demand, so an install using a pasted
+token never downloads it. The credential taken from the flow is the **ID
+token** — an access token means nothing to the Kubernetes API server, and
+confusing the two is the classic way to make this fail with an opaque 401. The
+redirect lands on `/oidc/callback`, which the SPA fallback serves; register that
+URI with your issuer.
+
 **3. Bearer token** — for the POC and CI.
 
 ```bash
@@ -285,8 +293,12 @@ make token     # mints one and prints it; paste into the UI
 
   The value must be the whole header — Kagent substitutes it verbatim. The
   surface is read-only either way, and a test fails if a fifth tool appears.
-- **The UI signs in by pasting a token.** The OIDC redirect flow lands in M12,
-  because M11 rebuilds the header and building the login twice would be waste.
+- **The plan is pinned while you have work in progress.** The planner
+  republishes every resync and again after any drain. Step numbers are
+  positional, so a plan swapped underneath a ticked selection would leave it
+  meaning different nodes — the one path here that could drain something you did
+  not choose. While a selection or run is outstanding the view holds, and a
+  newer plan waits behind a banner.
 
 ---
 

--- a/test/ui/client_test.go
+++ b/test/ui/client_test.go
@@ -16,11 +16,21 @@ import (
 
 const srcDir = "../../ui/src"
 
+func read(t *testing.T, rel string) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(srcDir, rel))
+	if err != nil {
+		t.Fatalf("read %s: %v", rel, err)
+	}
+	return string(b)
+}
+
 // Files permitted to call fetch() directly.
 //
 //	api.ts   — owns the client, and attaches the bearer token
 //	auth.ts  — fetches /authinfo, which is deliberately unauthenticated
 var mayCallFetch = map[string]bool{
+	"oidc.ts": true, // the library owns its own transport
 	"api.ts":  true,
 	"auth.ts": true,
 }
@@ -93,5 +103,49 @@ func TestTokenIsNotPersistedBeyondTheSession(t *testing.T) {
 	}
 	if !regexp.MustCompile(`sessionStorage\s*\.`).Match(body) {
 		t.Error("auth.ts no longer uses sessionStorage; where is the token being kept?")
+	}
+}
+
+// A plan must not be swapped out from under a selection.
+//
+// Step numbers are positional. The planner republishes every resync and again
+// after any drain, so ticking "steps 4 through 9" and pausing to think is
+// enough for the plan to change underneath — and the selection would survive
+// as numbers while quietly coming to mean different nodes. That is the one
+// path in this UI that could drain something the operator did not choose.
+func TestPlanIsPinnedWhileThereIsSomethingToProtect(t *testing.T) {
+	plan := read(t, "usePlan.ts")
+
+	// The subscription must consult the hold before reloading, not after.
+	if !regexp.MustCompile(`subscribePlans\([\s\S]{0,220}holdRef\.current`).MatchString(plan) {
+		t.Error("usePlan reloads on a publish without checking whether the view is held")
+	}
+	if !strings.Contains(plan, "setSuperseded(true)") {
+		t.Error("a withheld plan is dropped silently; the operator is never told a newer one exists")
+	}
+
+	app := read(t, "App.tsx")
+	// Held while a selection exists or a run is in flight.
+	if !regexp.MustCompile(`usePlan\(\s*checked\.size > 0 \|\| runActive\s*\)`).MatchString(app) {
+		t.Error("App does not pin the plan while a selection or run is outstanding")
+	}
+}
+
+// The Kubernetes credential is the ID token. An access token means nothing to
+// the API server, and confusing the two is the classic way to make this
+// integration fail with an opaque 401.
+func TestOidcUsesTheIdTokenAsTheCredential(t *testing.T) {
+	src := read(t, "oidc.ts")
+	if !strings.Contains(src, "user?.id_token") {
+		t.Error("oidc.ts does not take the ID token as the credential")
+	}
+	if regexp.MustCompile(`access_token`).MatchString(src) {
+		t.Error("oidc.ts references an access token; only the ID token is a Kubernetes credential")
+	}
+	// The library defaults to localStorage; both stores must be overridden.
+	for _, store := range []string{"userStore", "stateStore"} {
+		if !regexp.MustCompile(store + `:\s*new WebStorageStateStore\(\{ store: window\.sessionStorage \}\)`).MatchString(src) {
+			t.Errorf("%s is not pinned to sessionStorage; the default is localStorage", store)
+		}
 	}
 }

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -11,6 +11,7 @@
         "@fontsource-variable/archivo": "^5.3.0",
         "@fontsource-variable/ibm-plex-sans": "^5.3.0",
         "@fontsource/ibm-plex-mono": "^5.3.0",
+        "oidc-client-ts": "^3.5.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -1554,6 +1555,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -1608,6 +1618,18 @@
       "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/oidc-client-ts": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/oidc-client-ts/-/oidc-client-ts-3.5.0.tgz",
+      "integrity": "sha512-l2q8l9CTCTOlbX+AnK4p3M+4CEpKpyQhle6blQkdFhm0IsBqsxm15bYaSa11G7pWdsYr6epdsRZxJpCyCRbT8A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jwt-decode": "^4.0.0"
+      },
       "engines": {
         "node": ">=18"
       }

--- a/ui/package.json
+++ b/ui/package.json
@@ -13,6 +13,7 @@
     "@fontsource-variable/archivo": "^5.3.0",
     "@fontsource-variable/ibm-plex-sans": "^5.3.0",
     "@fontsource/ibm-plex-mono": "^5.3.0",
+    "oidc-client-ts": "^3.5.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Impact, PlanStep } from "./api";
 import Inspector, { Selection } from "./components/Inspector";
 import PackingField from "./components/PackingField";
@@ -7,12 +7,19 @@ import Scrubber from "./components/Scrubber";
 import { SignIn } from "./components/SignIn";
 import StepLedger from "./components/StepLedger";
 import Verdict from "./components/Verdict";
+import { authInfo, token as tokenStore } from "./auth";
+import { onRenewed } from "./oidc";
 import { runtimeConfig } from "./runtime-config";
 import { usePlan } from "./usePlan";
 import { useRun } from "./useRun";
 
 export default function App() {
-  const state = usePlan();
+  // Pinned while there is a selection to protect or a run to watch. Step
+  // numbers are positional, so a plan swapped underneath a ticked selection
+  // would leave it meaning different nodes.
+  const [checked, setChecked] = useState<Set<number>>(new Set());
+  const [runActive, setRunActive] = useState(false);
+  const state = usePlan(checked.size > 0 || runActive);
   const { kagentUrl } = runtimeConfig();
 
   const [step, setStep] = useState(0);
@@ -21,7 +28,6 @@ export default function App() {
   const [selection, setSelection] = useState<Selection>(null);
   const [focusedRating, setFocusedRating] = useState<Impact | null>(null);
   const [pending, setPending] = useState<{ steps: PlanStep[]; dryRun: boolean } | null>(null);
-  const [checked, setChecked] = useState<Set<number>>(new Set());
   const lastToggled = useRef<number | null>(null);
 
   const planId = state.status === "ready" ? state.plan.plan.id : null;
@@ -91,6 +97,19 @@ export default function App() {
 
   const busy = run.state.status === "starting" || run.state.status === "active";
 
+  // Keep the pin in step with the run's lifetime.
+  useEffect(() => setRunActive(busy), [busy]);
+
+  // A silently renewed ID token has to replace the one requests are carrying,
+  // or the session expires mid-consolidation despite having been refreshed.
+  useEffect(() => {
+    let stop = () => {};
+    void authInfo().then(async (i) => {
+      stop = await onRenewed(i, (idToken) => tokenStore.set(idToken));
+    });
+    return () => stop();
+  }, []);
+
   const handleSelectStep = useCallback((seq: number | null) => {
     setSelectedStep(seq);
     // Selecting a step moves the field to the moment just before it runs, so
@@ -147,6 +166,18 @@ export default function App() {
             picked={pickedSteps}
             onClearPicked={() => setChecked(new Set())}
           />
+
+          {state.superseded && (
+            <div className="supersede" role="status">
+              <span>
+                The planner has published a newer plan. This one is pinned while you have a
+                selection or a run in progress.
+              </span>
+              <button className="btn" onClick={state.showLatest}>
+                Show the new plan
+              </button>
+            </div>
+          )}
 
           <RunTrail state={run.state} onDismiss={run.dismiss} />
 

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -242,6 +242,11 @@ async function post<T>(path: string, body: unknown): Promise<T> {
 
 export const api = {
   latestPlan: (signal?: AbortSignal) => get<PlanResponse>("/api/v1/plans/latest", signal),
+
+  /** A specific plan by id. Used to keep a pinned view on the plan an operator
+   *  is actually working against, rather than whatever is newest. */
+  plan: (planId: string, signal?: AbortSignal) =>
+    get<PlanResponse>(`/api/v1/plans/${encodeURIComponent(planId)}`, signal),
   graph: (planId: string, signal?: AbortSignal) =>
     get<GraphPayload>(`/api/v1/plans/${planId}/graph`, signal),
   step: (planId: string, seq: number, signal?: AbortSignal) =>

--- a/ui/src/components/SignIn.tsx
+++ b/ui/src/components/SignIn.tsx
@@ -1,27 +1,73 @@
 import { FormEvent, useEffect, useState } from "react";
 import { AuthInfo, authInfo, token } from "../auth";
+import { completeSignIn, isCallback, restore, signIn } from "../oidc";
 
 /**
- * Collects a bearer token when the backend has rejected the request.
+ * Gets the operator a credential.
  *
- * Deliberately plain. M11 rebuilds the header and M12 replaces this with an
- * OIDC redirect flow, so anything more elaborate here would be built twice —
- * but an install with auth on and no way to present a credential is unusable,
- * so it cannot simply wait.
+ * Single sign-on when the install has an issuer configured, a pasted token
+ * otherwise. Both end in the same place — a bearer token on every request,
+ * which ui-backend hands to TokenReview — so the rest of the app never learns
+ * which path was taken.
  */
 export function SignIn({ onDone }: { onDone: () => void }) {
   const [info, setInfo] = useState<AuthInfo | null>(null);
   const [value, setValue] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [failure, setFailure] = useState<string | null>(null);
 
   useEffect(() => {
     let live = true;
-    void authInfo().then((i) => live && setInfo(i));
+
+    void (async () => {
+      const i = await authInfo();
+      if (!live) return;
+      setInfo(i);
+
+      try {
+        // Returning from the issuer with a code to exchange.
+        if (isCallback()) {
+          setBusy(true);
+          const idToken = await completeSignIn(i);
+          if (idToken) {
+            token.set(idToken);
+            onDone();
+            return;
+          }
+          setFailure("The issuer redirected back without a usable token.");
+          return;
+        }
+        // A session from earlier in this tab.
+        const existing = await restore(i);
+        if (existing) {
+          token.set(existing);
+          onDone();
+        }
+      } catch (err) {
+        if (live) setFailure(err instanceof Error ? err.message : String(err));
+      } finally {
+        if (live) setBusy(false);
+      }
+    })();
+
     return () => {
       live = false;
     };
-  }, []);
+  }, [onDone]);
 
-  const submit = (e: FormEvent) => {
+  const start = async () => {
+    if (!info) return;
+    setFailure(null);
+    setBusy(true);
+    try {
+      await signIn(info);
+    } catch (err) {
+      setFailure(err instanceof Error ? err.message : String(err));
+      setBusy(false);
+    }
+  };
+
+  const submitToken = (e: FormEvent) => {
     e.preventDefault();
     if (!value.trim()) return;
     token.set(value);
@@ -29,22 +75,33 @@ export function SignIn({ onDone }: { onDone: () => void }) {
     onDone();
   };
 
+  const sso = info?.oidc.enabled && info.oidc.issuerUrl;
+
   return (
     <div className="signin">
       <h2>Sign in</h2>
       <p className="signin-detail">
-        This install requires a Kubernetes credential. Permission to view plans is granted by RBAC,
-        so any token your cluster already trusts will work.
+        This install requires a Kubernetes credential. Permission is granted by RBAC, so any
+        identity your cluster already trusts will work.
       </p>
 
-      {info?.oidc.enabled && info.oidc.issuerUrl && (
-        <p className="signin-detail">
-          Single sign-on is configured against <code>{info.oidc.issuerUrl}</code>. Browser sign-in
-          arrives in the next release; until then, paste a token below.
+      {failure && (
+        <p className="signin-failure" role="alert">
+          {failure}
         </p>
       )}
 
-      <form onSubmit={submit}>
+      {sso && (
+        <>
+          <button className="signin-sso" onClick={start} disabled={busy}>
+            {busy ? "Signing in…" : "Sign in with single sign-on"}
+          </button>
+          <p className="signin-issuer mono">{info.oidc.issuerUrl}</p>
+          <p className="signin-or">or paste a token</p>
+        </>
+      )}
+
+      <form onSubmit={submitToken}>
         <label htmlFor="token">Bearer token</label>
         <input
           id="token"
@@ -62,7 +119,7 @@ export function SignIn({ onDone }: { onDone: () => void }) {
 
       <details className="signin-help">
         <summary>How do I get one?</summary>
-        <pre>kubectl create token dencer-viewer -n k8s-dencer</pre>
+        <pre>kubectl create token dencer-operator -n k8s-dencer</pre>
         <p>
           Or run <code>make token</code> from the repository, which mints one and prints it.
         </p>

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1117,3 +1117,77 @@
   gap: 0.5rem;
   margin-top: 1.1rem;
 }
+
+/* ------------------------------------------------------- superseded plan */
+
+.supersede {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  padding: 0.55rem 1.75rem;
+  font-size: 0.78rem;
+  color: var(--graphite);
+  background: var(--panel-raised);
+  border-bottom: 1px solid var(--edge);
+  /* Deliberately uncoloured. A newer plan is information, not risk, and
+     colour on this page only ever means risk. */
+}
+
+.supersede button {
+  margin-left: auto;
+  padding: 0.3rem 0.7rem;
+  font-size: 0.76rem;
+  white-space: nowrap;
+}
+
+.signin-sso {
+  width: 100%;
+  padding: 0.6rem 1rem;
+  font-family: var(--font-body);
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--ink);
+  background: var(--chalk);
+  border: 0;
+  border-radius: var(--radius-sm);
+}
+
+.signin-sso:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.signin-issuer {
+  margin: 0.4rem 0 0;
+  overflow-wrap: anywhere;
+  font-size: 0.7rem;
+  color: var(--graphite-dim);
+  text-align: center;
+}
+
+.signin-or {
+  display: flex;
+  gap: 0.6rem;
+  align-items: center;
+  margin: 1.1rem 0 0.7rem;
+  font-size: 0.72rem;
+  color: var(--graphite-dim);
+}
+
+.signin-or::before,
+.signin-or::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: var(--edge);
+}
+
+.signin-failure {
+  margin: 0 0 0.9rem;
+  padding: 0.5rem 0.65rem;
+  font-size: 0.78rem;
+  color: var(--risk-red);
+  background: var(--panel-sunken);
+  border-left: 2px solid var(--risk-red);
+  border-radius: var(--radius-sm);
+}

--- a/ui/src/oidc.ts
+++ b/ui/src/oidc.ts
@@ -1,0 +1,127 @@
+import type { User, UserManager } from "oidc-client-ts";
+import { AuthInfo } from "./auth";
+
+/**
+ * Single sign-on against the cluster's own OIDC issuer.
+ *
+ * The whole trick is that we validate nothing ourselves. When the API server
+ * runs with --oidc-issuer-url, an ID token from that issuer is *already* a
+ * Kubernetes credential — so the browser obtains one and hands it to
+ * ui-backend, which passes it to TokenReview, and the API server does the
+ * verification. No session store, no user database, no client secret.
+ *
+ * Which means the token we care about is the **ID token**, not the access
+ * token. An access token means nothing to the Kubernetes API server; the ID
+ * token is the credential. Getting this backwards is the classic way to make
+ * this integration fail with a confusing 401.
+ *
+ * oidc-client-ts is loaded on demand rather than bundled into the entry: it is
+ * ~19 kB gzipped, single sign-on is off by default, and an install using a
+ * pasted token should not pay for a library it never calls.
+ */
+
+const REDIRECT_PATH = "/oidc/callback";
+
+let manager: UserManager | null = null;
+
+/** Builds the manager, or returns null when OIDC is not configured. */
+export async function oidcManager(info: AuthInfo): Promise<UserManager | null> {
+  if (!info.oidc.enabled || !info.oidc.issuerUrl || !info.oidc.clientId) return null;
+  if (manager) return manager;
+
+  const { UserManager, WebStorageStateStore } = await import("oidc-client-ts");
+
+  manager = new UserManager({
+    authority: info.oidc.issuerUrl,
+    client_id: info.oidc.clientId,
+    redirect_uri: window.location.origin + REDIRECT_PATH,
+    post_logout_redirect_uri: window.location.origin,
+    response_type: "code",
+    scope: (info.oidc.scopes ?? ["openid", "profile", "email", "groups"]).join(" "),
+
+    // A public client using Authorization Code + PKCE. There is no secret,
+    // because a secret shipped to a browser is not a secret.
+    // oidc-client-ts enables PKCE for response_type=code by default.
+    //
+    // sessionStorage, not the default localStorage: a credential that can
+    // drain nodes should not outlive the tab, and test/ui fails the build if
+    // this changes.
+    userStore: new WebStorageStateStore({ store: window.sessionStorage }),
+    stateStore: new WebStorageStateStore({ store: window.sessionStorage }),
+
+    // Renew quietly before expiry so a long consolidation is not interrupted
+    // by a sign-in prompt. Only the interactive session needs this — a run
+    // already in flight is authorized once at enqueue and finishes under the
+    // executor's own identity.
+    automaticSilentRenew: true,
+    accessTokenExpiringNotificationTimeInSeconds: 60,
+
+    // We never call a userinfo endpoint: everything we need about the caller
+    // comes back from TokenReview, named by the API server rather than
+    // self-reported by the browser.
+    loadUserInfo: false,
+  });
+
+  return manager;
+}
+
+/** True when the current URL is the redirect landing. */
+export function isCallback(): boolean {
+  return window.location.pathname === REDIRECT_PATH;
+}
+
+/** Starts the redirect. */
+export async function signIn(info: AuthInfo): Promise<void> {
+  const m = await oidcManager(info);
+  if (!m) throw new Error("single sign-on is not configured for this install");
+  await m.signinRedirect();
+}
+
+/**
+ * Completes the redirect and returns the ID token.
+ *
+ * Clears the query string afterwards so a reload does not replay a consumed
+ * authorization code, which the issuer will refuse.
+ */
+export async function completeSignIn(info: AuthInfo): Promise<string | null> {
+  const m = await oidcManager(info);
+  if (!m) return null;
+  const user = await m.signinRedirectCallback();
+  window.history.replaceState({}, "", "/");
+  return idTokenOf(user);
+}
+
+/** Restores a session from storage on load, if one is still valid. */
+export async function restore(info: AuthInfo): Promise<string | null> {
+  const m = await oidcManager(info);
+  if (!m) return null;
+  const user = await m.getUser();
+  if (!user || user.expired) return null;
+  return idTokenOf(user);
+}
+
+/** Calls back with a fresh ID token whenever one is issued. */
+export async function onRenewed(
+  info: AuthInfo,
+  fn: (idToken: string) => void,
+): Promise<() => void> {
+  const m = await oidcManager(info);
+  if (!m) return () => {};
+  const handler = (user: User) => {
+    const t = idTokenOf(user);
+    if (t) fn(t);
+  };
+  m.events.addUserLoaded(handler);
+  return () => m.events.removeUserLoaded(handler);
+}
+
+export async function signOut(info: AuthInfo): Promise<void> {
+  const m = await oidcManager(info);
+  if (!m) return;
+  await m.removeUser();
+}
+
+/** The ID token is the Kubernetes credential; the access token is not. */
+function idTokenOf(user: User | null): string | null {
+  return user?.id_token ?? null;
+}

--- a/ui/src/usePlan.ts
+++ b/ui/src/usePlan.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { ApiError, GraphPayload, PlanResponse, api, subscribePlans } from "./api";
 import { onTokenChange } from "./auth";
 
@@ -9,33 +9,73 @@ export type PlanState =
   | { status: "ready"; plan: PlanResponse; graph: GraphPayload };
 
 /**
- * Loads the latest plan and its graph, and reloads when the planner publishes
- * a new one.
+ * Loads a plan and its graph, and decides when to swap it for a newer one.
  *
  * The plan and graph are fetched together and swapped together: rendering a
  * graph against a different plan's steps would put the scrubber out of step
- * with the canvas, which is worse than a moment of staleness.
+ * with the field, which is worse than a moment of staleness.
+ *
+ * `hold` pins the displayed plan. The planner republishes continuously — every
+ * resync, and again immediately after any drain — so without pinning, ticking
+ * "steps 4 through 9" and pausing to think is enough to have the plan swapped
+ * underneath you. Step numbers are positional, so the selection would survive
+ * as numbers while silently coming to mean different nodes. That is the one
+ * failure in this UI that could cause an operator to drain something they did
+ * not choose.
+ *
+ * While held, a newer plan sets `superseded` and waits to be asked for.
  */
-export function usePlan(): PlanState & { reload: () => void } {
+export function usePlan(hold: boolean): PlanState & {
+  reload: () => void;
+  /** A newer plan exists and is being withheld because the view is pinned. */
+  superseded: boolean;
+  /** Drop the pin and move to the latest plan. */
+  showLatest: () => void;
+} {
   const [state, setState] = useState<PlanState>({ status: "loading" });
   const [nonce, setNonce] = useState(0);
+  const [superseded, setSuperseded] = useState(false);
+
+  // The plan being displayed, so a refresh can re-fetch *this* one rather than
+  // whatever is newest.
+  const pinnedID = useRef<string | null>(null);
+  const holdRef = useRef(hold);
+  holdRef.current = hold;
 
   const reload = useCallback(() => setNonce((n) => n + 1), []);
+
+  const showLatest = useCallback(() => {
+    pinnedID.current = null;
+    setSuperseded(false);
+    reload();
+  }, [reload]);
 
   useEffect(() => {
     const controller = new AbortController();
 
     (async () => {
       try {
-        const plan = await api.latestPlan(controller.signal);
+        const id = pinnedID.current;
+        const plan = id
+          ? await api.plan(id, controller.signal)
+          : await api.latestPlan(controller.signal);
         const graph = await api.graph(plan.plan.id, controller.signal);
-        if (!controller.signal.aborted) {
-          setState({ status: "ready", plan, graph });
-        }
+        if (controller.signal.aborted) return;
+
+        pinnedID.current = holdRef.current ? plan.plan.id : null;
+        setState({ status: "ready", plan, graph });
       } catch (err) {
         if (controller.signal.aborted) return;
         if (err instanceof ApiError && err.isEmpty) {
-          // No plan yet is a normal state for a fresh install, not a fault.
+          // A pinned plan can be pruned out from under us; falling back to the
+          // latest beats showing "no plan" on a cluster that has one.
+          if (pinnedID.current) {
+            pinnedID.current = null;
+            setSuperseded(false);
+            setNonce((n) => n + 1);
+            return;
+          }
+          // No plan at all is a normal state for a fresh install, not a fault.
           setState({ status: "empty" });
           return;
         }
@@ -51,13 +91,33 @@ export function usePlan(): PlanState & { reload: () => void } {
     return () => controller.abort();
   }, [nonce]);
 
+  // Pin the plan on screen the moment the view is held, so a publish arriving
+  // a millisecond later cannot swap it.
   useEffect(() => {
-    return subscribePlans(() => reload());
-  }, [reload]);
+    if (hold) {
+      if (state.status === "ready" && !pinnedID.current) {
+        pinnedID.current = state.plan.plan.id;
+      }
+    } else {
+      pinnedID.current = null;
+    }
+  }, [hold, state]);
+
+  useEffect(
+    () =>
+      subscribePlans(() => {
+        if (holdRef.current) {
+          setSuperseded(true);
+          return;
+        }
+        reload();
+      }),
+    [reload],
+  );
 
   // Signing in has to re-drive the fetch: without this the operator enters a
   // valid token and stares at the same 401 until they reload the page.
   useEffect(() => onTokenChange(reload), [reload]);
 
-  return { ...state, reload };
+  return { ...state, reload, superseded, showLatest };
 }


### PR DESCRIPTION
## Plan pinning

Closes the one path in this UI that could have drained something the operator
did not choose.

The planner republishes every resync and again immediately after any drain, and
**step numbers are positional** — so ticking "steps 4 through 9" and pausing to
think was enough for the plan to be swapped underneath, leaving the selection
intact as numbers while quietly coming to mean different nodes.

The view now holds while a selection or run is outstanding; a newer plan waits
behind a banner. A pinned plan that gets pruned falls back to the latest rather
than claiming the cluster has none.

## OIDC sign-in

Completes the tier-1 story M9 designed. Authorization Code + PKCE against the
cluster's own issuer, and the credential taken from the flow is the **ID
token** — an access token means nothing to the Kubernetes API server, and
confusing the two is the classic way to make this fail with an opaque 401.

We validate nothing ourselves; `TokenReview` does. That is the whole reason this
costs no session store and no user database.

**Loaded on demand.** `oidc-client-ts` is ~18 kB gzipped, SSO is off by default,
and an install using a pasted token should not pay for a library it never calls.

| | entry | lazy chunk |
|---|---|---|
| before | 57.5 kB gzip | — |
| naive | 76.0 kB gzip | — |
| **code-split** | **58.8 kB gzip** | 17.8 kB, only when configured |

**Both stores pinned to sessionStorage.** The library defaults to localStorage,
which outlives the browsing session and sits readable by every script on the
origin — not the right home for a credential that can drain nodes.

Silent renewal feeds the refreshed ID token back into the request header;
without it the session expires mid-consolidation despite having been renewed.

## Tests

Four new guards, each verified by reverting the behaviour it describes: the
publish subscription consults the hold before reloading, App pins on selection
or run, the ID token is the credential, and neither OIDC store falls back to
localStorage.

**199 tests across 13 packages, 22 chart assertions, typecheck clean.**

Verified on the fabric: `/oidc/callback` serves through the SPA fallback, the
OIDC chunk is absent from `index.html`, and the planner produces a fresh
16-step plan (30 → 14) after a fabric reset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)