### PR TITLE
M16: measure the ceiling before optimising anything

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -238,6 +238,19 @@ logs: ## Tail the planner log
 TOKEN_SA       ?= dencer-operator
 TOKEN_DURATION ?= 8h
 
+.PHONY: bench
+bench: ## Scale benchmarks over synthesised clusters (no cluster required)
+	@# Runs entirely offline. internal/model has no Kubernetes imports, which
+	@# is what makes it possible to measure the planner at thousands of pods
+	@# without standing anything up.
+	go test ./internal/planner -run XXX -bench Scale -benchtime 1x -timeout 30m
+
+.PHONY: bench-baseline
+bench-baseline: ## Rewrite docs/benchmarks.md from a fresh run
+	@go test ./internal/planner -run XXX -bench Scale -benchtime 1x -timeout 30m \
+		| tee /tmp/dencer-bench.txt
+	@echo "==> raw output in /tmp/dencer-bench.txt; update docs/benchmarks.md from it"
+
 .PHONY: crds
 crds: ## Regenerate CRD manifests from the Go types
 	$(CONTROLLER_GEN) object paths=./api/...

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ Phase 3 — maintenance windows.
 |---|---|---|
 | **M14** | `MaintenanceWindow` CRD; Red steps unlocked by an open window | **done** |
 | **M15** | Readiness verification — the executor waits for Ready, not Running | **done** |
-| **M16–M21** | Scale to 1000 nodes / 50k pods; metrics; published images; local hardening | planned |
+| **M16** | Measured ceiling — synthesised clusters, `make bench`, [docs/benchmarks.md](docs/benchmarks.md) | **done** |
+| **M17–M21** | Scale to 1000 nodes / 50k pods; metrics; published images; local hardening | planned |
 
 Deferred: scheduled automatic execution,
 Postgres store, multi-agent orchestration, and **closing the reclamation loop**

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,0 +1,68 @@
+# Measured ceiling
+
+Where k8s-dencer stops being usable, measured rather than estimated.
+
+Produced by `make bench`, which runs entirely offline over synthesised clusters
+— `internal/model` has no Kubernetes imports, so the whole pipeline can be
+measured at thousands of pods without standing anything up.
+
+Apple M-series laptop, Go 1.26, `-benchtime 1x`. Absolute numbers will differ on
+other hardware; **the growth curves are the point.**
+
+## Baseline — before any Phase 4 optimisation
+
+| Stage | 119 pods | 916 pods | 2,526 pods | 5,026 pods | Growth |
+|---|---|---|---|---|---|
+| `constraints.Analyze` | 1.6 ms | 190 ms | **4.4 s** | **33.5 s** | **≈ cubic** |
+| `planner.Greedy.Plan` | 0.17 ms | 77 ms | **1.5 s** | — | **≈ cubic** |
+| `impact.ClassifyPlan` | 0.04 ms | 2.2 ms | 17 ms | — | ≈ quadratic |
+| `graph.Build` + marshal | 0.43 ms | 2.5 ms | 11 ms | 28 ms | ≈ linear |
+| `store.Save` | 0.74 ms | 5.3 ms | 29 ms | 83 ms | ≈ linear-ish |
+| `constraints.NewPlacement` | 0.06 ms | 0.09 ms | 0.19 ms | 0.74 ms | **linear** |
+
+Graph payload size: 0.05 MB → 0.44 MB → 1.17 MB → 2.30 MB. Linear, ~0.46 KB per
+pod.
+
+## What this means
+
+**The usable ceiling today is roughly 1,000–2,000 pods.** At 2,500 pods a single
+analyse-and-plan cycle costs ~6 seconds, against a default 30-second resync. At
+5,000 pods the analyser alone takes 34 seconds and the planner never gets a
+coherent turn.
+
+Extrapolating the cubic term to the 50,000-pod target gives **hours per
+analysis**. That is not a tuning problem.
+
+## Where the cubic comes from
+
+`constraints.Analyze` is 69% `Placement.domainCounts`, of which 44% is
+`LabelSelector.Matches` (CPU profile at 2,526 pods).
+
+`domainCounts` walks **every node and every occupant**, running a label-selector
+match, to count how many matching pods sit in each topology domain. It is called
+once per spread-constrained pod per candidate node — so
+`pods × nodes × pods`.
+
+The counts do not vary per candidate node. They depend only on the selector, the
+topology key, and the current placement, so they can be computed once and
+memoised. That is M18's job.
+
+## What was expected, and what was actually true
+
+The Phase 4 plan predicted the planner's four-deep nesting in `greedy.go` would
+be the first wall. It is a wall, but **the analyser hits it sooner** — and the
+shared cause is in `internal/constraints`, not `internal/planner`.
+
+Worth recording because it is the reason M16 exists: the fix that looked obvious
+from reading the code would have optimised the wrong package.
+
+## Running it
+
+```bash
+make bench                  # up to ~2,500 pods, about 40 seconds
+SCALE_LARGE=1 make bench    # adds the 5,000-pod point, several minutes
+```
+
+Sizes stop at 2,500 on purpose. A benchmark nobody will sit through is a
+benchmark nobody maintains; the larger points are opt-in until the growth curve
+is fixed.

--- a/internal/model/synthetic.go
+++ b/internal/model/synthetic.go
@@ -1,0 +1,207 @@
+package model
+
+import (
+	"fmt"
+	"math/rand"
+	"time"
+)
+
+// SyntheticOptions shapes a generated cluster.
+//
+// The defaults aim at a plausible mid-size cluster rather than a convenient
+// one. Benchmarks over a uniform cluster — every pod the same size, no PDBs, no
+// affinity — would make the constraint work look far cheaper than it is, since
+// most of the cost lives in the checks that uniform data never triggers.
+type SyntheticOptions struct {
+	Nodes int
+	// PodsPerNode is the mean; actual counts vary around it.
+	PodsPerNode int
+	// Zones spreads nodes across topology domains.
+	Zones int
+	// PDBFraction is the share of workloads carrying a PodDisruptionBudget.
+	PDBFraction float64
+	// AntiAffinityFraction is the share of workloads with required pod
+	// anti-affinity, which is the most expensive predicate to evaluate.
+	AntiAffinityFraction float64
+	// SpreadFraction is the share carrying a topology spread constraint.
+	SpreadFraction float64
+	// DaemonSetsPerNode are pinned pods that can never move.
+	DaemonSetsPerNode int
+	// Utilization is the mean fraction of each node's CPU that is requested.
+	Utilization float64
+	// Seed makes generation deterministic, so a benchmark measures a change in
+	// the code rather than a change in the data.
+	Seed int64
+}
+
+// DefaultSynthetic returns options for a cluster of the given node count.
+func DefaultSynthetic(nodes int) SyntheticOptions {
+	return SyntheticOptions{
+		Nodes:                nodes,
+		PodsPerNode:          30,
+		Zones:                3,
+		PDBFraction:          0.30,
+		AntiAffinityFraction: 0.10,
+		SpreadFraction:       0.15,
+		DaemonSetsPerNode:    2,
+		Utilization:          0.45,
+		Seed:                 1,
+	}
+}
+
+// Synthesize builds a deterministic cluster snapshot of arbitrary size.
+//
+// Test-only in practice, but it lives in the production package because it
+// depends on every field of the domain model and would drift instantly if it
+// were kept beside the tests. It has no Kubernetes imports, like the rest of
+// this package — which is precisely what makes it possible to benchmark the
+// planner at fifty thousand pods without a cluster.
+func Synthesize(o SyntheticOptions) *ClusterSnapshot {
+	if o.Nodes <= 0 {
+		o.Nodes = 1
+	}
+	if o.PodsPerNode <= 0 {
+		o.PodsPerNode = 10
+	}
+	if o.Zones <= 0 {
+		o.Zones = 1
+	}
+	rng := rand.New(rand.NewSource(o.Seed))
+
+	// A node's capacity, fixed so utilisation is easy to reason about.
+	const nodeCPU int64 = 8000
+	const nodeMem int64 = 32 << 30
+
+	snap := &ClusterSnapshot{
+		TakenAt: time.Unix(1_750_000_000, 0).UTC(),
+		Nodes:   make([]Node, 0, o.Nodes),
+		Pods:    make([]Pod, 0, o.Nodes*o.PodsPerNode),
+	}
+
+	for i := range o.Nodes {
+		snap.Nodes = append(snap.Nodes, Node{
+			Name:  fmt.Sprintf("node-%05d", i),
+			Ready: true,
+			Labels: map[string]string{
+				LabelZone:     fmt.Sprintf("zone-%d", i%o.Zones),
+				LabelHostname: fmt.Sprintf("node-%05d", i),
+				"pool":        pool(i),
+			},
+			Allocatable: Resources{MilliCPU: nodeCPU, MemoryBytes: nodeMem, Pods: 110},
+			Capacity:    Resources{MilliCPU: nodeCPU, MemoryBytes: nodeMem, Pods: 110},
+			CreatedAt:   snap.TakenAt.Add(-24 * time.Hour),
+		})
+	}
+
+	// Pod sizes are scaled to the requested density rather than fixed, so
+	// PodsPerNode is actually honoured. With a fixed ladder the CPU budget
+	// filled long before the pod count did, and asking for 50 pods per node
+	// quietly produced 9 — which would have made a "50k pod" benchmark
+	// measure something else entirely.
+	perNodeBudget := int64(float64(nodeCPU) * o.Utilization)
+	base := max64(10, perNodeBudget/int64(o.PodsPerNode))
+	// A long tail: many small pods, a few large. That spread is what makes
+	// first-fit-decreasing do real work.
+	ladder := []int64{base / 2, base / 2, base, base, base, base * 2, base * 3}
+
+	// Workloads are shared across nodes, which is what makes anti-affinity and
+	// spread constraints meaningful — a per-node workload would never conflict
+	// with anything.
+	workloads := max(1, (o.Nodes*o.PodsPerNode)/12)
+	type workload struct {
+		name         string
+		namespace    string
+		hasPDB       bool
+		antiAffinity bool
+		spread       bool
+		cpu          int64
+	}
+	kinds := make([]workload, workloads)
+	for w := range workloads {
+		kinds[w] = workload{
+			name:         fmt.Sprintf("app-%04d", w),
+			namespace:    fmt.Sprintf("ns-%02d", w%20),
+			hasPDB:       rng.Float64() < o.PDBFraction,
+			cpu:          ladder[rng.Intn(len(ladder))],
+			antiAffinity: rng.Float64() < o.AntiAffinityFraction,
+			spread:       rng.Float64() < o.SpreadFraction,
+		}
+	}
+
+	for i := range o.Nodes {
+		node := snap.Nodes[i].Name
+
+		for d := range o.DaemonSetsPerNode {
+			snap.Pods = append(snap.Pods, Pod{
+				Namespace: "kube-system",
+				Name:      fmt.Sprintf("agent-%d-%s", d, node),
+				NodeName:  node, Phase: PodRunning, Ready: true,
+				Labels:   map[string]string{"app": fmt.Sprintf("agent-%d", d)},
+				Requests: Resources{MilliCPU: 50, MemoryBytes: 64 << 20},
+				Owner:    &OwnerRef{Kind: "DaemonSet", Name: fmt.Sprintf("agent-%d", d)},
+			})
+		}
+
+		var used int64
+		for n := 0; n < o.PodsPerNode; n++ {
+			w := kinds[rng.Intn(len(kinds))]
+			// Overshooting the budget slightly is realistic; refusing to place
+			// the pod at all would make density depend on the size draw.
+			if used+w.cpu > perNodeBudget && n > 0 {
+				break
+			}
+			used += w.cpu
+
+			pod := Pod{
+				Namespace: w.namespace,
+				Name:      fmt.Sprintf("%s-%s-%d", w.name, node, n),
+				NodeName:  node, Phase: PodRunning, Ready: true,
+				Labels:   map[string]string{"app": w.name},
+				Requests: Resources{MilliCPU: w.cpu, MemoryBytes: w.cpu * (1 << 20) * 2},
+				Owner:    &OwnerRef{Kind: "ReplicaSet", Name: w.name},
+			}
+			if w.antiAffinity {
+				pod.PodAffinity = &PodAffinity{
+					RequiredAntiAffinity: []PodAffinityTerm{{
+						TopologyKey:   LabelHostname,
+						LabelSelector: &LabelSelector{MatchLabels: map[string]string{"app": w.name}},
+					}},
+				}
+			}
+			if w.spread {
+				pod.TopologySpread = []TopologySpreadConstraint{{
+					MaxSkew:           1,
+					TopologyKey:       LabelZone,
+					WhenUnsatisfiable: DoNotSchedule,
+					LabelSelector:     &LabelSelector{MatchLabels: map[string]string{"app": w.name}},
+				}}
+			}
+			snap.Pods = append(snap.Pods, pod)
+		}
+	}
+
+	for _, w := range kinds {
+		if !w.hasPDB {
+			continue
+		}
+		snap.PDBs = append(snap.PDBs, PodDisruptionBudget{
+			Namespace: w.namespace, Name: w.name,
+			Selector:           &LabelSelector{MatchLabels: map[string]string{"app": w.name}},
+			DisruptionsAllowed: 1,
+			CurrentHealthy:     3, DesiredHealthy: 2, ExpectedPods: 3,
+		})
+	}
+
+	return snap
+}
+
+func pool(i int) string {
+	switch i % 4 {
+	case 0:
+		return "batch"
+	case 1:
+		return "web"
+	default:
+		return "general"
+	}
+}

--- a/internal/model/synthetic_test.go
+++ b/internal/model/synthetic_test.go
@@ -1,0 +1,59 @@
+package model_test
+
+import (
+	"testing"
+
+	"github.com/atedgimo/k8s-dencer/internal/model"
+)
+
+// The generator's output has to be worth benchmarking. A uniform cluster with
+// no PDBs and no affinity would make the constraint work look far cheaper than
+// it is, since most of the cost lives in checks that uniform data never fires.
+func TestSynthesizeProducesAClusterWorthMeasuring(t *testing.T) {
+	for _, nodes := range []int{4, 34, 334, 1667} {
+		snap := model.Synthesize(model.DefaultSynthetic(nodes))
+
+		anti, spread, sizes := 0, 0, map[int64]bool{}
+		for _, p := range snap.Pods {
+			if p.PodAffinity != nil {
+				anti++
+			}
+			if len(p.TopologySpread) > 0 {
+				spread++
+			}
+			sizes[p.Requests.MilliCPU] = true
+		}
+		t.Logf("%5d nodes -> %6d pods, %4d pdbs, %5d anti-affinity, %5d spread, %d distinct sizes",
+			len(snap.Nodes), len(snap.Pods), len(snap.PDBs), anti, spread, len(sizes))
+
+		if len(snap.Nodes) != nodes {
+			t.Errorf("got %d nodes, want %d", len(snap.Nodes), nodes)
+		}
+		if len(snap.Pods) < nodes {
+			t.Errorf("only %d pods for %d nodes", len(snap.Pods), nodes)
+		}
+		if len(snap.PDBs) == 0 || anti == 0 || spread == 0 {
+			t.Errorf("cluster is too uniform: %d pdbs, %d anti-affinity, %d spread",
+				len(snap.PDBs), anti, spread)
+		}
+		// First-fit-decreasing only does interesting work with a range of sizes.
+		if len(sizes) < 4 {
+			t.Errorf("only %d distinct pod sizes; the packer needs a spread", len(sizes))
+		}
+	}
+}
+
+// A benchmark must measure a change in the code, never a change in the data.
+func TestSynthesizeIsDeterministic(t *testing.T) {
+	a := model.Synthesize(model.DefaultSynthetic(50))
+	b := model.Synthesize(model.DefaultSynthetic(50))
+
+	if len(a.Pods) != len(b.Pods) {
+		t.Fatalf("pod counts differ across runs: %d vs %d", len(a.Pods), len(b.Pods))
+	}
+	for i := range a.Pods {
+		if a.Pods[i].Name != b.Pods[i].Name || a.Pods[i].Requests != b.Pods[i].Requests {
+			t.Fatalf("pod %d differs across runs: %+v vs %+v", i, a.Pods[i], b.Pods[i])
+		}
+	}
+}

--- a/internal/planner/scale_bench_test.go
+++ b/internal/planner/scale_bench_test.go
@@ -1,0 +1,187 @@
+package planner_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/atedgimo/k8s-dencer/internal/api/graph"
+	"github.com/atedgimo/k8s-dencer/internal/constraints"
+	"github.com/atedgimo/k8s-dencer/internal/impact"
+	"github.com/atedgimo/k8s-dencer/internal/model"
+	"github.com/atedgimo/k8s-dencer/internal/planner"
+	"github.com/atedgimo/k8s-dencer/internal/store"
+	sqlitestore "github.com/atedgimo/k8s-dencer/internal/store/sqlite"
+)
+
+// Scale benchmarks over synthesised clusters.
+//
+// The whole pipeline is measured from generated fixtures with no cluster
+// involved, which is possible only because internal/model has zero Kubernetes
+// imports — a decision from M2 that pays for itself here.
+//
+// Sizes are chosen to bracket the stated target of 1000 nodes / 50k pods, and
+// to make the growth curve visible: if a stage is quadratic, four points will
+// say so far more clearly than one.
+//
+// Run with `make bench`.
+//
+// Sizes stop at ~2500 pods deliberately. Analyze is roughly cubic today, so
+// 5000 pods already costs 34 seconds and the stated target of 50k would take
+// hours — and a benchmark nobody will sit through is a benchmark nobody
+// maintains. Raise these once M18 has fixed the growth curve. The ceiling is
+// the finding, not an accident of the harness.
+//
+//	SCALE_LARGE=1 make bench   adds the 5000-pod point
+var sizes = func() []size {
+	s := []size{
+		{"120pods", 4},
+		{"900pods", 34},
+		{"2500pods", 100},
+	}
+	if os.Getenv("SCALE_LARGE") != "" {
+		s = append(s, size{"5000pods", 200})
+	}
+	return s
+}()
+
+type size struct {
+	name  string
+	nodes int
+}
+
+func snapshotFor(nodes int) *model.ClusterSnapshot {
+	return model.Synthesize(model.DefaultSynthetic(nodes))
+}
+
+func BenchmarkScaleAnalyze(b *testing.B) {
+	for _, s := range sizes {
+		snap := snapshotFor(s.nodes)
+		b.Run(fmt.Sprintf("%s/%dpods", s.name, len(snap.Pods)), func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				constraints.Analyze(snap)
+			}
+		})
+	}
+}
+
+func BenchmarkScalePlacement(b *testing.B) {
+	for _, s := range sizes {
+		snap := snapshotFor(s.nodes)
+		b.Run(fmt.Sprintf("%s/%dpods", s.name, len(snap.Pods)), func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				constraints.NewPlacement(snap)
+			}
+		})
+	}
+}
+
+// The one most likely to be intractable: greedy nests candidate nodes over
+// occupants over candidate nodes again, with an occupant scan inside CanPlace.
+func BenchmarkScalePlan(b *testing.B) {
+	for _, s := range sizes {
+		snap := snapshotFor(s.nodes)
+		analysis := constraints.Analyze(snap)
+		b.Run(fmt.Sprintf("%s/%dpods", s.name, len(snap.Pods)), func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				if _, err := (planner.Greedy{}).Plan(snap, analysis, planner.DefaultOptions()); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkScaleClassify(b *testing.B) {
+	for _, s := range sizes {
+		snap := snapshotFor(s.nodes)
+		analysis := constraints.Analyze(snap)
+		plan, err := (planner.Greedy{}).Plan(snap, analysis, planner.DefaultOptions())
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.Run(fmt.Sprintf("%s/%dpods", s.name, len(snap.Pods)), func(b *testing.B) {
+			classifier := impact.New(impact.DefaultThresholds())
+			b.ReportAllocs()
+			for b.Loop() {
+				classifier.ClassifyPlan(plan, snap, analysis)
+			}
+		})
+	}
+}
+
+// The payload the browser is asked to parse. Reported in bytes as well as
+// time, because the size is the part that breaks first.
+func BenchmarkScaleGraphPayload(b *testing.B) {
+	for _, s := range sizes {
+		snap := snapshotFor(s.nodes)
+		analysis := constraints.Analyze(snap)
+		plan, err := (planner.Greedy{}).Plan(snap, analysis, planner.DefaultOptions())
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.Run(fmt.Sprintf("%s/%dpods", s.name, len(snap.Pods)), func(b *testing.B) {
+			b.ReportAllocs()
+			var size int
+			for b.Loop() {
+				payload := graph.Build(plan, snap, analysis)
+				raw, err := json.Marshal(payload)
+				if err != nil {
+					b.Fatal(err)
+				}
+				size = len(raw)
+			}
+			b.ReportMetric(float64(size)/1024/1024, "MB/response")
+		})
+	}
+}
+
+// Every plan change writes the whole snapshot and analysis as JSON blobs.
+// Reported in megabytes per row, which is the number that decides how quickly
+// the volume fills.
+func BenchmarkScaleStoreSave(b *testing.B) {
+	for _, s := range sizes {
+		snap := snapshotFor(s.nodes)
+		analysis := constraints.Analyze(snap)
+		plan, err := (planner.Greedy{}).Plan(snap, analysis, planner.DefaultOptions())
+		if err != nil {
+			b.Fatal(err)
+		}
+		snapJSON, _ := json.Marshal(snap)
+		analysisJSON, _ := json.Marshal(analysis)
+
+		b.Run(fmt.Sprintf("%s/%dpods", s.name, len(snap.Pods)), func(b *testing.B) {
+			db, err := sqlitestore.Open(filepath.Join(b.TempDir(), "bench.db"))
+			if err != nil {
+				b.Fatal(err)
+			}
+			b.Cleanup(func() { _ = db.Close() })
+			if err := db.Migrate(context.Background()); err != nil {
+				b.Fatal(err)
+			}
+
+			b.ReportAllocs()
+			b.ReportMetric(float64(len(snapJSON)+len(analysisJSON))/1024/1024, "MB/row")
+
+			n := 0
+			for b.Loop() {
+				// A distinct ID each time: Save deduplicates on content hash,
+				// and measuring the dedup path would measure nothing.
+				n++
+				p := *plan
+				p.ID = fmt.Sprintf("plan-%d", n)
+				if _, err := db.Save(context.Background(), store.Record{
+					Plan: &p, Snapshot: snap, Analysis: analysis, Strategy: "bench",
+				}); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Phase 4 targets 1000 nodes / 50k pods. Everything until now has run on 30 fake
nodes and 120 pods, so the first step is finding out where it actually stops
working rather than guessing.

## The finding contradicts the plan

The plan predicted the planner's four-deep nesting in `greedy.go` would be the
first wall. It **is** a wall — but `constraints.Analyze` hits it sooner, and both
share a cause in `internal/constraints`, not `internal/planner`.

| pods | `Analyze` | `Plan` |
|---|---|---|
| 119 | 1.6 ms | 0.17 ms |
| 916 | 190 ms | 77 ms |
| 2,526 | **4.4 s** | **1.5 s** |
| 5,026 | **33.5 s** | — |

Doubling pods costs ~8× the work. Extrapolated to 50k: **hours per analysis.**

**Usable ceiling today: roughly 1,000–2,000 pods.** At 2,500 a single
analyse-and-plan cycle costs ~6 s against a 30-second resync.

## Where the cubic comes from

CPU profile at 2,526 pods: **69% of `Analyze` is `Placement.domainCounts`**, of
which 44% is `LabelSelector.Matches`.

`domainCounts` walks every node and every occupant running a selector match, and
is called once per spread-constrained pod per candidate node — `pods × nodes ×
pods`. The counts don't vary per candidate node, so they can be computed once
and memoised. That's M18, now aimed at the right package.

By contrast `NewPlacement` is **linear** and the graph payload is linear at
~0.46 KB/pod. Neither is the problem.

## What's in this PR

- `model.Synthesize` — deterministic clusters of arbitrary size with realistic
  shape (long tail of pod sizes, PDBs, anti-affinity, spread, DaemonSets).
  Uniform data would make the constraint work look far cheaper than it is.
- Benchmarks over the whole pipeline, running **entirely offline** —
  `internal/model` has no Kubernetes imports, an M2 decision that pays for
  itself here.
- `make bench`, and [docs/benchmarks.md](docs/benchmarks.md) with the numbers and
  the diagnosis.

## Two bugs in the generator, caught by its own test

It **ignored `PodsPerNode`** — the CPU budget filled before the pod count did, so
asking for 50 pods/node quietly produced 9. A "50k pod" benchmark would have
measured something else entirely. Pod sizes now scale to the requested density.
It also redeclared a `max64` that already existed in `resources.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)