### PR TITLE
Stop the demo chart building a fabric that would break the machine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -300,10 +300,21 @@ kwok-down: ## Remove the KWOK fabric
 # not-ready forever, so --wait turns a cosmetic fabric quirk into a failed
 # install. Use `make demo-wait` to block on pods being *scheduled*, which is
 # what the planner actually cares about.
+# Fabric size tiers. The default is the demo you use daily; medium is the
+# largest that validates the informer and executor read paths without putting
+# the control plane at risk. Scale numbers come from `make bench`, not from
+# standing up a huge fabric — see docs/benchmarks.md.
+ifeq ($(SCALE),medium)
+FABRIC_ARGS := --set nodes.count=200 --set base.replicas=2000
+else
+FABRIC_ARGS :=
+endif
+
 .PHONY: demo-up
-demo-up: ## Install the synthetic topology (SCENARIO=a-fragmented)
+demo-up: ## Install the synthetic topology (SCENARIO=a-fragmented, SCALE=medium)
 	helm upgrade --install $(DEMO_RELEASE) demo/charts/dencer-demo \
 		--namespace $(DEMO_NAMESPACE) --create-namespace \
+		$(FABRIC_ARGS) \
 		--set scenario=$(SCENARIO)
 
 .PHONY: demo-wait
@@ -355,6 +366,7 @@ scenario: ## Switch scenario: make scenario S=b-pdb-blocked
 	@$(MAKE) --no-print-directory fabric-reset
 	helm upgrade --install $(DEMO_RELEASE) demo/charts/dencer-demo \
 		--namespace $(DEMO_NAMESPACE) --create-namespace \
+		$(FABRIC_ARGS) \
 		--set scenario=$(S)
 	@$(MAKE) --no-print-directory demo-wait
 

--- a/README.md
+++ b/README.md
@@ -551,9 +551,32 @@ A node-consolidation planner cannot be tested on a single-node cluster. [KWOK](h
 ```bash
 make kwok-up                        # upstream kwok + stage-fast charts (pinned 0.3.0 / app v0.8.0)
 make demo-up                        # 30 fake nodes across 3 zones + the base workload
+make demo-up SCALE=medium           # 200 nodes / 2000 pods — the largest safe locally
 make scenario S=b-pdb-blocked       # switch constraint scenario
 make demo-down && make kwok-down
 ```
+
+### The fabric has a ceiling, on purpose
+
+KWOK nodes are free — no kubelets — but **the pods on them are not**. Every pod
+is a real API object held in the API server's watch cache and again in
+k8s-dencer's own informer cache, and the planner will try to analyse all of
+them. `constraints.Analyze` is roughly cubic today
+([docs/benchmarks.md](docs/benchmarks.md)), so a fabric of tens of thousands
+does not run slowly — it pegs a core for hours while the executor lists every
+pod every two seconds, and takes the control plane with it.
+
+The chart therefore refuses to build one:
+
+| tier | size | for |
+|---|---|---|
+| default | 30 nodes, 90 pods | the everyday demo |
+| `SCALE=medium` | 200 nodes, 2000 pods | validating informer and executor read paths |
+| ceiling | 200 nodes / 3000 pods | `--set fabric.acknowledgeLarge=true` to override |
+
+**Scale numbers come from `make bench`, not from a large fabric.** It exercises
+the same code paths over generated clusters with no cluster at all, which is why
+5,000 pods can be measured in seconds on a laptop that could not host them.
 
 **After an executor run, reset the fabric before switching scenarios.**
 Cordoning a node makes the node controller add

--- a/demo/charts/dencer-demo/templates/validate.yaml
+++ b/demo/charts/dencer-demo/templates/validate.yaml
@@ -7,3 +7,36 @@ bug rather than a values mistake.
 {{- if not (has .Values.scenario $valid) -}}
 {{- fail (printf "unknown scenario %q; valid scenarios are: %s" .Values.scenario (join ", " $valid)) -}}
 {{- end -}}
+
+{{/*
+Refuse to build a fabric large enough to hurt the machine hosting it.
+
+KWOK nodes are free — no kubelets — but the pods on them are not. Every pod is
+a real API object written through k3s's kine backend, held in the API server's
+watch cache, and then held AGAIN in k8s-dencer's own informer cache. On a
+laptop-sized control plane a few thousand is fine and fifty thousand is not.
+
+Worse than the memory: the planner would immediately try to analyse them.
+constraints.Analyze is roughly cubic today (docs/benchmarks.md), so a fabric
+that large does not merely run slowly — it pegs a core for hours while the
+executor lists every pod every two seconds. The cluster becomes unusable, and
+the cause looks like a k8s-dencer bug rather than a values mistake.
+
+Scale numbers belong in `make bench`, which measures the same code paths over
+generated clusters with no cluster at all.
+
+The ceiling is deliberately awkward to lift: set fabric.acknowledgeLarge=true
+and you are stating you know what you are asking for.
+*/}}
+{{- $nodes := int .Values.nodes.count -}}
+{{- $pods := int .Values.base.replicas -}}
+{{- $maxNodes := int .Values.fabric.maxNodes -}}
+{{- $maxPods := int .Values.fabric.maxPods -}}
+{{- if not .Values.fabric.acknowledgeLarge -}}
+  {{- if gt $nodes $maxNodes -}}
+    {{- fail (printf "nodes.count=%d exceeds the %d-node ceiling for a laptop control plane.\nUse `make bench` for scale numbers — it measures the same code with no cluster.\nTo proceed anyway: --set fabric.acknowledgeLarge=true" $nodes $maxNodes) -}}
+  {{- end -}}
+  {{- if gt $pods $maxPods -}}
+    {{- fail (printf "base.replicas=%d exceeds the %d-pod ceiling for a laptop control plane.\nEvery pod is an API object held in the API server cache and again in the planner's informer cache,\nand the planner will try to analyse all of them (constraints.Analyze is ~cubic; see docs/benchmarks.md).\nTo proceed anyway: --set fabric.acknowledgeLarge=true" $pods $maxPods) -}}
+  {{- end -}}
+{{- end -}}

--- a/demo/charts/dencer-demo/values.yaml
+++ b/demo/charts/dencer-demo/values.yaml
@@ -16,6 +16,24 @@
 # consolidate; the scenario adds the constraint that should change the ratings.
 scenario: a-fragmented
 
+# Ceiling on how large a fabric this chart will build.
+#
+# KWOK nodes are free; the pods on them are not. Each is a real API object in
+# the API server's watch cache and again in k8s-dencer's informer cache — and
+# the planner will try to analyse every one of them, which is roughly cubic
+# today (docs/benchmarks.md). A fabric of tens of thousands does not run
+# slowly, it takes the control plane down.
+#
+# These limits are sized for a laptop. Scale numbers come from `make bench`,
+# which exercises the same code paths over generated clusters with no cluster
+# at all.
+fabric:
+  maxNodes: 200
+  maxPods: 3000
+  # Deliberately awkward: setting this is a statement that you know what you
+  # are asking your machine to do.
+  acknowledgeLarge: false
+
 nodes:
   # 30 fake nodes cost nothing to run (no kubelets) but give the bin-packer a
   # problem worth solving. Each is deliberately larger than the real node.


### PR DESCRIPTION
Prompted by a fair question: does Phase 4's scale work mean deploying 50,000
pods to a laptop? **It does not**, and nothing should let it happen by accident.

## Why a large fabric is actively dangerous, not just slow

KWOK nodes are free — no kubelets. **The pods on them are not.** Each is a real
API object written through k3s's kine backend, held in the API server's watch
cache, and held *again* in k8s-dencer's own informer cache.

The memory is the lesser problem. The planner would immediately try to analyse
them, and `constraints.Analyze` is roughly cubic (M16) — so a fabric that large
pegs a core for hours while the executor lists every pod every two seconds. The
control plane goes with it, and the cause reads as a k8s-dencer bug rather than
a values mistake.

## The tiers

| tier | size | for |
|---|---|---|
| default | 30 nodes, 90 pods | the everyday demo |
| `SCALE=medium` | 200 nodes, 2000 pods | validating informer and executor read paths |
| ceiling | 200 nodes / 3000 pods | refused above this |

The override is deliberately awkward: `--set fabric.acknowledgeLarge=true` is a
statement that you know what you're asking your machine to do.

**Scale numbers come from `make bench`**, which exercises the same code paths
over generated clusters with no cluster at all — which is how 5,000 pods gets
measured in seconds on a machine that could not host them.

The guard sits beside the existing scenario validation, which already exists to
stop a typo looking like a planner bug. Both refusals and the override verified.

## Note

`SCALE=medium` is designed to be safe but is **not yet verified on a real
cluster** — the offline cost estimate needs `model.Synthesize`, which is still
in the unmerged #15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)