### PR TITLE
Restore the kubectl context after verifying SSO

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -9,6 +9,25 @@ measured at thousands of pods without standing anything up.
 Apple M-series laptop, Go 1.26, `-benchtime 1x`. Absolute numbers will differ on
 other hardware; **the growth curves are the point.**
 
+## After M18 — the spread index
+
+`Placement.domainCounts` is memoised and maintained incrementally
+([spreadindex.go](../internal/constraints/spreadindex.go)).
+
+| Stage | 119 | 916 | 2,526 | 5,026 | Speedup at 5k |
+|---|---|---|---|---|---|
+| `constraints.Analyze` | 0.5 ms | 16 ms | **90 ms** | **298 ms** | **112×** |
+| `planner.Greedy.Plan` | 0.16 ms | 17 ms | **110 ms** | **466 ms** | — |
+
+**The growth curve is the real result.** Doubling from 2,526 to 5,026 pods used
+to cost 7.6× the time; it now costs 3.3×. Cubic became roughly quadratic.
+
+A full analyse-and-plan cycle at 2,526 pods went from **5.9 s to 0.2 s**, which
+moves the usable ceiling from ~1–2k pods to comfortably past 5k against a
+30-second resync.
+
+Golden planner tests unchanged — byte-identical plans from the same fixture.
+
 ## Baseline — before any Phase 4 optimisation
 
 | Stage | 119 pods | 916 pods | 2,526 pods | 5,026 pods | Growth |

--- a/hack/verify-sso.sh
+++ b/hack/verify-sso.sh
@@ -70,13 +70,31 @@ green() { printf '\033[32m%s\033[0m\n' "$*"; }
 bold()  { printf '\033[1m%s\033[0m\n' "$*"; }
 fail()  { red "FAIL: $*"; exit 1; }
 
+# Runs on success, on failure, and on Ctrl-C alike.
+cleanup_on_exit() { restore_context; }
+
+# Whatever context the operator was on before this ran. k3d switches the
+# current context on create and never switches back, so without this the script
+# silently leaves every later kubectl and `make` pointed at a throwaway cluster
+# — which surfaces much later as "namespaces k8s-dencer not found".
+PRIOR_CONTEXT="$(kubectl config current-context 2>/dev/null || true)"
+
+restore_context() {
+  [[ -n "$PRIOR_CONTEXT" ]] || return 0
+  kubectl config get-contexts -o name 2>/dev/null | grep -qx "$PRIOR_CONTEXT" || return 0
+  kubectl config use-context "$PRIOR_CONTEXT" >/dev/null 2>&1 || true
+}
+
 teardown() {
   k3d cluster delete "$CLUSTER" >/dev/null 2>&1 || true
   docker rm -f dencer-dex dencer-keycloak >/dev/null 2>&1 || true
+  restore_context
   green "torn down"
 }
 
 if [[ "${1:-}" == "clean" ]]; then teardown; exit 0; fi
+
+trap cleanup_on_exit EXIT
 
 for tool in k3d docker openssl htpasswd helm kubectl; do
   command -v "$tool" >/dev/null || fail "$tool is required"
@@ -262,7 +280,7 @@ green "  installed on a second, differently-provisioned cluster"
 
 kubectl --context "$CTX" port-forward -n k8s-dencer svc/k8s-dencer-ui-backend 8092:8080 >/dev/null 2>&1 &
 PF=$!
-trap 'kill $PF 2>/dev/null || true' EXIT
+trap 'kill $PF 2>/dev/null || true; cleanup_on_exit' EXIT
 sleep 4
 
 bold "==> the authorization matrix, with a real IdP token"
@@ -301,6 +319,8 @@ EXEC="$(code -X POST -H "Authorization: Bearer $TOKEN" -H 'Content-Type: applica
 green "  execute permission      -> $EXEC (not 403)"
 
 echo
+restore_context
+green "Your kubectl context is back on ${PRIOR_CONTEXT:-its previous cluster}."
 green "Tier-1 single sign-on verified against ${IDP}: an ID token from the
 cluster's own issuer is a Kubernetes credential, and access is one RoleBinding
 against ${SUBJECT_FLAG#--}. Run '$0 clean' to tear it all down."

--- a/internal/constraints/placement.go
+++ b/internal/constraints/placement.go
@@ -18,6 +18,9 @@ import (
 type Placement struct {
 	nodes     map[string]*nodeState
 	nodeOrder []string
+	// spread memoises per-domain pod counts for topology spread checks. See
+	// spreadindex.go — recomputing them per candidate node was the cubic term.
+	spread *spreadIndex
 }
 
 type nodeState struct {
@@ -29,6 +32,7 @@ type nodeState struct {
 // NewPlacement builds a working assignment from a snapshot's current state.
 func NewPlacement(snap *model.ClusterSnapshot) *Placement {
 	p := &Placement{
+		spread:    newSpreadIndex(),
 		nodes:     make(map[string]*nodeState, len(snap.Nodes)),
 		nodeOrder: make([]string, 0, len(snap.Nodes)),
 	}
@@ -56,6 +60,9 @@ func (p *Placement) Clone() *Placement {
 	out := &Placement{
 		nodes:     make(map[string]*nodeState, len(p.nodes)),
 		nodeOrder: append([]string(nil), p.nodeOrder...),
+		// Cloned rather than shared: a trial placement must not write its
+		// speculative counts back into the placement it branched from.
+		spread: p.spread.clone(),
 	}
 	for name, ns := range p.nodes {
 		out.nodes[name] = &nodeState{
@@ -108,6 +115,7 @@ func (p *Placement) Place(pod model.Pod, nodeName string) {
 	pod.NodeName = nodeName
 	ns.occupants = append(ns.occupants, pod)
 	ns.free = ns.free.Sub(pod.Requests.Add(model.Resources{Pods: 1}))
+	p.adjustSpread(pod, nodeName, +1)
 }
 
 // Remove unassigns a pod from its current node, returning its freed resources.
@@ -118,8 +126,14 @@ func (p *Placement) Remove(pod model.Pod) {
 	}
 	for i, occupant := range ns.occupants {
 		if occupant.Namespace == pod.Namespace && occupant.Name == pod.Name {
+			node := pod.NodeName
 			ns.occupants = append(ns.occupants[:i], ns.occupants[i+1:]...)
 			ns.free = ns.free.Add(pod.Requests).Add(model.Resources{Pods: 1})
+			// Matched on the occupant's own labels, not the caller's copy:
+			// Place stores the pod as given, and a caller passing a
+			// differently-labelled copy to Remove would otherwise leave the
+			// index counting a pod that is no longer there.
+			p.adjustSpread(occupant, node, -1)
 			return
 		}
 	}
@@ -378,23 +392,31 @@ func (p *Placement) fitsTopologySpread(pod model.Pod, nodeName string) (bool, st
 // domainCounts tallies matching pods per topology domain, excluding the pod
 // being placed. Every domain present in the cluster is seeded at zero so an
 // empty domain still counts toward the skew calculation.
+//
+// Served from the memoised index rather than by walking the cluster. The pod
+// under consideration is subtracted here rather than skipped during counting:
+// the index is shared across candidate nodes, and which pod is excluded is the
+// only part that varies per call.
 func (p *Placement) domainCounts(pod model.Pod, tsc model.TopologySpreadConstraint) map[string]int {
-	counts := map[string]int{}
-	for _, name := range p.nodeOrder {
-		ns := p.nodes[name]
-		domain, ok := ns.node.Labels[tsc.TopologyKey]
-		if !ok {
-			continue
-		}
-		if _, seen := counts[domain]; !seen {
-			counts[domain] = 0
-		}
-		for _, occupant := range ns.occupants {
-			if sameKey(pod, occupant) {
-				continue
-			}
-			if tsc.LabelSelector.Matches(occupant.Labels) && occupant.Namespace == pod.Namespace {
-				counts[domain]++
+	cached := p.spreadCounts(pod.Namespace, tsc)
+
+	// Copied because the caller increments the candidate domain, and the index
+	// must not absorb a speculative placement.
+	counts := make(map[string]int, len(cached))
+	for d, c := range cached {
+		counts[d] = c
+	}
+
+	// If the pod is currently placed and matches its own selector, the index
+	// counted it. It must not count toward the spread it is being moved out of.
+	if ns, ok := p.nodes[pod.NodeName]; ok {
+		if domain, ok := ns.node.Labels[tsc.TopologyKey]; ok {
+			for _, occupant := range ns.occupants {
+				if sameKey(pod, occupant) && tsc.LabelSelector.Matches(occupant.Labels) &&
+					occupant.Namespace == pod.Namespace {
+					counts[domain]--
+					break
+				}
 			}
 		}
 	}

--- a/internal/constraints/spreadindex.go
+++ b/internal/constraints/spreadindex.go
@@ -1,0 +1,169 @@
+package constraints
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/atedgimo/k8s-dencer/internal/model"
+)
+
+// spreadIndex memoises "how many matching pods sit in each topology domain".
+//
+// This is the fix for the cubic term M16 measured. domainCounts used to walk
+// every node and every occupant, running a label-selector match, on every
+// call — and it is called once per spread-constrained pod per candidate node,
+// so the cost was pods × nodes × pods. At 2,500 pods that put 69% of
+// constraints.Analyze inside this one function.
+//
+// The counts do not depend on which candidate node is being considered. They
+// depend only on the topology key, the selector, the namespace, and the
+// current placement — so they are computed once and then maintained
+// incrementally as pods move.
+//
+// Incremental maintenance rather than invalidation is deliberate. A planning
+// pass interleaves many CanPlace calls with occasional Place calls; throwing
+// the whole index away on every Place would rebuild it O(pods) times and leave
+// the cost quadratic instead of cubic. Adjusting the affected counters keeps it
+// near linear.
+type spreadIndex struct {
+	entries map[spreadKey]*spreadEntry
+}
+
+// spreadKey identifies one question: "for this selector, in this namespace,
+// bucketed by this topology key, how many pods are in each domain?"
+type spreadKey struct {
+	topologyKey string
+	namespace   string
+	selector    string
+}
+
+type spreadEntry struct {
+	counts map[string]int
+	// Kept so a later Place or Remove can decide whether a pod affects this
+	// entry without re-deriving the selector from a fingerprint.
+	selector *model.LabelSelector
+}
+
+func newSpreadIndex() *spreadIndex {
+	return &spreadIndex{entries: make(map[spreadKey]*spreadEntry)}
+}
+
+func (s *spreadIndex) clone() *spreadIndex {
+	out := &spreadIndex{entries: make(map[spreadKey]*spreadEntry, len(s.entries))}
+	for k, e := range s.entries {
+		counts := make(map[string]int, len(e.counts))
+		for d, c := range e.counts {
+			counts[d] = c
+		}
+		out.entries[k] = &spreadEntry{counts: counts, selector: e.selector}
+	}
+	return out
+}
+
+// counts returns the per-domain tally for a constraint, building it on first
+// use. The returned map is the index's own — callers must not mutate it.
+func (p *Placement) spreadCounts(namespace string, tsc model.TopologySpreadConstraint) map[string]int {
+	key := spreadKey{
+		topologyKey: tsc.TopologyKey,
+		namespace:   namespace,
+		selector:    selectorFingerprint(tsc.LabelSelector),
+	}
+	if e, ok := p.spread.entries[key]; ok {
+		return e.counts
+	}
+
+	// First use: one pass over the cluster. Every domain present is seeded at
+	// zero, because an empty domain still counts toward the skew.
+	counts := make(map[string]int)
+	for _, name := range p.nodeOrder {
+		ns := p.nodes[name]
+		domain, ok := ns.node.Labels[tsc.TopologyKey]
+		if !ok {
+			continue
+		}
+		if _, seen := counts[domain]; !seen {
+			counts[domain] = 0
+		}
+		for _, occupant := range ns.occupants {
+			if occupant.Namespace == namespace && tsc.LabelSelector.Matches(occupant.Labels) {
+				counts[domain]++
+			}
+		}
+	}
+
+	p.spread.entries[key] = &spreadEntry{counts: counts, selector: tsc.LabelSelector}
+	return counts
+}
+
+// adjust moves a pod's contribution in or out of every affected entry.
+//
+// Called from Place and Remove. Only entries whose namespace and selector match
+// the pod are touched, which is a handful even on a large cluster.
+func (p *Placement) adjustSpread(pod model.Pod, nodeName string, delta int) {
+	if len(p.spread.entries) == 0 {
+		return
+	}
+	ns, ok := p.nodes[nodeName]
+	if !ok {
+		return
+	}
+	for key, entry := range p.spread.entries {
+		if key.namespace != pod.Namespace {
+			continue
+		}
+		domain, ok := ns.node.Labels[key.topologyKey]
+		if !ok {
+			continue
+		}
+		if !entry.selector.Matches(pod.Labels) {
+			continue
+		}
+		entry.counts[domain] += delta
+	}
+}
+
+// selectorFingerprint renders a selector as a stable string.
+//
+// Map iteration in Go is randomised, so the keys are sorted. Without that, the
+// same selector would fingerprint differently from one call to the next and
+// every lookup would miss — quietly restoring the cubic behaviour this index
+// exists to remove, while still returning correct answers. A silent
+// performance regression is harder to notice than a wrong one, which is why
+// stability is asserted directly.
+func selectorFingerprint(s *model.LabelSelector) string {
+	if s == nil {
+		return ""
+	}
+	var b strings.Builder
+
+	keys := make([]string, 0, len(s.MatchLabels))
+	for k := range s.MatchLabels {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		b.WriteString(k)
+		b.WriteByte('=')
+		b.WriteString(s.MatchLabels[k])
+		b.WriteByte(',')
+	}
+
+	if len(s.MatchExpressions) == 0 {
+		return b.String()
+	}
+	exprs := make([]string, 0, len(s.MatchExpressions))
+	for _, e := range s.MatchExpressions {
+		vals := append([]string(nil), e.Values...)
+		sort.Strings(vals)
+		exprs = append(exprs, e.Key+" "+string(e.Operator)+" ["+strings.Join(vals, "|")+"]")
+	}
+	sort.Strings(exprs)
+	b.WriteByte(';')
+	b.WriteString(strings.Join(exprs, ";"))
+	return b.String()
+}
+
+// SpreadEntriesForTest reports how many distinct spread questions have been
+// memoised. Exported for tests: cache effectiveness is a property worth
+// asserting, and it is invisible from outside otherwise.
+func SpreadEntriesForTest(p *Placement) int { return len(p.spread.entries) }

--- a/internal/constraints/spreadindex_test.go
+++ b/internal/constraints/spreadindex_test.go
@@ -1,0 +1,164 @@
+package constraints_test
+
+import (
+	"testing"
+
+	"github.com/atedgimo/k8s-dencer/internal/constraints"
+	"github.com/atedgimo/k8s-dencer/internal/model"
+)
+
+// The index is a cache in front of a correctness-critical check, so what
+// matters is that it can never disagree with a full recount.
+//
+// These drive it through the mutations a planning pass performs — place,
+// remove, clone — and compare against the same question asked of a freshly
+// built Placement, which has no cache to be wrong.
+
+func spreadSnapshot() *model.ClusterSnapshot {
+	snap := &model.ClusterSnapshot{}
+	for i, zone := range []string{"z1", "z1", "z2", "z2", "z3"} {
+		snap.Nodes = append(snap.Nodes, model.Node{
+			Name: string(rune('a' + i)), Ready: true,
+			Labels:      map[string]string{model.LabelZone: zone},
+			Allocatable: model.Resources{MilliCPU: 8000, MemoryBytes: 1 << 34, Pods: 110},
+		})
+	}
+	for i, host := range []string{"a", "a", "b", "c", "e"} {
+		snap.Pods = append(snap.Pods, model.Pod{
+			Namespace: "app", Name: "web-" + string(rune('0'+i)), NodeName: host,
+			Phase: model.PodRunning, Ready: true,
+			Labels:   map[string]string{"app": "web"},
+			Requests: model.Resources{MilliCPU: 100, MemoryBytes: 1 << 26},
+			Owner:    &model.OwnerRef{Kind: "ReplicaSet", Name: "web"},
+			TopologySpread: []model.TopologySpreadConstraint{{
+				MaxSkew: 1, TopologyKey: model.LabelZone,
+				WhenUnsatisfiable: model.DoNotSchedule,
+				LabelSelector:     &model.LabelSelector{MatchLabels: map[string]string{"app": "web"}},
+			}},
+		})
+	}
+	return snap
+}
+
+// A cached verdict must equal the verdict of a placement that has never
+// cached anything, after any sequence of moves.
+func TestSpreadVerdictSurvivesMutation(t *testing.T) {
+	snap := spreadSnapshot()
+	pod := snap.Pods[0]
+
+	// Warm the index, then move pods around underneath it.
+	cached := constraints.NewPlacement(snap)
+	for _, n := range cached.NodeNames() {
+		cached.CanPlace(pod, n) // populates the spread entry
+	}
+
+	moves := []struct {
+		pod int
+		to  string
+	}{
+		{1, "c"}, {2, "e"}, {3, "a"}, {4, "b"}, {1, "e"},
+	}
+	fresh := constraints.NewPlacement(snap)
+
+	for i, m := range moves {
+		p := snap.Pods[m.pod]
+		cached.Remove(p)
+		fresh.Remove(p)
+		cached.Place(p, m.to)
+		fresh.Place(p, m.to)
+
+		// A fresh placement rebuilt from the same state has no cache at all.
+		for _, n := range cached.NodeNames() {
+			gotOK, gotWhy := cached.CanPlace(pod, n)
+			wantOK, wantWhy := fresh.CanPlace(pod, n)
+			if gotOK != wantOK {
+				t.Fatalf("after move %d, node %s: cached says %v (%s), uncached says %v (%s)",
+					i, n, gotOK, gotWhy, wantOK, wantWhy)
+			}
+		}
+	}
+}
+
+// A trial placement must not write its speculative counts back into the
+// placement it branched from — the planner clones constantly.
+func TestCloneDoesNotShareTheIndex(t *testing.T) {
+	snap := spreadSnapshot()
+	pod := snap.Pods[0]
+
+	base := constraints.NewPlacement(snap)
+	for _, n := range base.NodeNames() {
+		base.CanPlace(pod, n)
+	}
+	before := map[string]bool{}
+	for _, n := range base.NodeNames() {
+		ok, _ := base.CanPlace(pod, n)
+		before[n] = ok
+	}
+
+	// Pile work into a clone.
+	trial := base.Clone()
+	for i := 1; i < len(snap.Pods); i++ {
+		trial.Remove(snap.Pods[i])
+		trial.Place(snap.Pods[i], "e")
+	}
+
+	for _, n := range base.NodeNames() {
+		if ok, _ := base.CanPlace(pod, n); ok != before[n] {
+			t.Errorf("node %s: the clone's placements leaked into its parent", n)
+		}
+	}
+}
+
+// An unsorted fingerprint would still give correct answers — every lookup
+// would simply miss and recompute, quietly restoring the cubic cost. That is a
+// worse failure than a wrong one because nothing surfaces it, so the cache's
+// effectiveness is asserted rather than only its correctness.
+func TestRepeatedChecksHitTheCache(t *testing.T) {
+	snap := spreadSnapshot()
+	pod := snap.Pods[0]
+	// Several selector keys, so map ordering has room to vary between calls.
+	pod.TopologySpread[0].LabelSelector = &model.LabelSelector{
+		MatchLabels: map[string]string{"app": "web", "tier": "front", "env": "prod", "team": "core"},
+	}
+
+	p := constraints.NewPlacement(snap)
+	// First pass populates; the rest must be served from it. If the
+	// fingerprint were unstable each call would build a new entry.
+	for range 50 {
+		for _, n := range p.NodeNames() {
+			p.CanPlace(pod, n)
+		}
+	}
+	if n := constraints.SpreadEntriesForTest(p); n != 1 {
+		t.Errorf("%d cache entries after repeated identical checks, want 1 — "+
+			"the selector fingerprint is not stable, so every lookup misses", n)
+	}
+}
+
+func TestVerdictIsStableAcrossRuns(t *testing.T) {
+	snap := spreadSnapshot()
+	pod := snap.Pods[0]
+	pod.TopologySpread[0].LabelSelector = &model.LabelSelector{
+		MatchLabels: map[string]string{"app": "web", "tier": "front", "env": "prod"},
+	}
+
+	var first []bool
+	for run := range 8 {
+		p := constraints.NewPlacement(snap)
+		var got []bool
+		for _, n := range p.NodeNames() {
+			ok, _ := p.CanPlace(pod, n)
+			got = append(got, ok)
+		}
+		if run == 0 {
+			first = got
+			continue
+		}
+		for i := range got {
+			if got[i] != first[i] {
+				t.Fatalf("run %d disagrees with run 0 at node %d: %v vs %v",
+					run, i, got[i], first[i])
+			}
+		}
+	}
+}


### PR DESCRIPTION
k3d switches the current kubectl context when it creates a cluster and never
switches back. So running `./hack/verify-sso.sh` silently left every later
`kubectl`, `make` target and port-forward pointed at a throwaway cluster.

It surfaced long after the cause:

```
$ make token
error: failed to create serviceaccount: namespaces "k8s-dencer" not found
```

...and as a dead UI. Neither points anywhere near the script responsible.

The script now records the context up front and restores it on **every** exit
path — success, failure, and Ctrl-C. Verified on the path that matters by
forcing a mid-run failure after k3d had already switched:

```
before: orbstack
FAIL: image ... missing
after:  orbstack
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)