### PR TITLE
Stop sign-in failing silently

### DIFF
--- a/ui/src/auth.ts
+++ b/ui/src/auth.ts
@@ -26,31 +26,48 @@ const STORAGE_KEY = "dencer.token";
  * M12 replaces manual entry with an OIDC redirect flow, at which point this
  * becomes the fallback for installs without an issuer configured.
  */
+// Memory is the source of truth; sessionStorage only lets a token survive a
+// reload.
+//
+// It used to be storage-only, with a swallowed exception. Any browser that
+// blocks storage — private mode, strict privacy settings, an embedded webview
+// — therefore dropped the token silently: you pasted, clicked Continue, and
+// the form came back with no explanation, forever. Holding it in memory means
+// the session works regardless, and only persistence is lost.
+let inMemory: string | null = null;
+
+/** True when the token could not be persisted, so a reload will lose it. */
+export let storageUnavailable = false;
+
 export const token = {
   get(): string | null {
+    if (inMemory !== null) return inMemory;
     try {
-      return sessionStorage.getItem(STORAGE_KEY);
+      inMemory = sessionStorage.getItem(STORAGE_KEY);
     } catch {
-      // Storage can be blocked outright by browser settings. Losing the token
-      // on reload is a far better outcome than failing to render.
-      return null;
+      storageUnavailable = true;
+      inMemory = null;
     }
+    return inMemory;
   },
 
   set(value: string): void {
+    inMemory = value.trim();
     try {
-      sessionStorage.setItem(STORAGE_KEY, value.trim());
+      sessionStorage.setItem(STORAGE_KEY, inMemory);
     } catch {
-      /* non-fatal; see get() */
+      // The session still works; it just will not outlive a reload.
+      storageUnavailable = true;
     }
     notify();
   },
 
   clear(): void {
+    inMemory = null;
     try {
       sessionStorage.removeItem(STORAGE_KEY);
     } catch {
-      /* non-fatal */
+      storageUnavailable = true;
     }
     notify();
   },

--- a/ui/src/components/SignIn.tsx
+++ b/ui/src/components/SignIn.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, useEffect, useState } from "react";
-import { AuthInfo, authInfo, token } from "../auth";
+import { AuthInfo, authInfo, storageUnavailable, token } from "../auth";
 import { completeSignIn, isCallback, restore, signIn } from "../oidc";
 
 /**
@@ -15,6 +15,11 @@ export function SignIn({ onDone }: { onDone: () => void }) {
   const [value, setValue] = useState("");
   const [busy, setBusy] = useState(false);
   const [failure, setFailure] = useState<string | null>(null);
+
+  // Being shown this form while a token is already held means that token was
+  // rejected. Saying so beats re-presenting an identical empty form, which
+  // reads as the button doing nothing.
+  const [rejected] = useState(() => token.get() !== null);
 
   useEffect(() => {
     let live = true;
@@ -88,6 +93,20 @@ export function SignIn({ onDone }: { onDone: () => void }) {
       {failure && (
         <p className="signin-failure" role="alert">
           {failure}
+        </p>
+      )}
+
+      {!failure && rejected && (
+        <p className="signin-failure" role="alert">
+          That credential was rejected — it may have expired, or it may lack
+          permission to read plans. <code>make token</code> mints a fresh one.
+        </p>
+      )}
+
+      {storageUnavailable && (
+        <p className="signin-detail">
+          This browser is blocking session storage, so the token will not
+          survive a reload. Signing in still works for this page.
         </p>
       )}
 


### PR DESCRIPTION
Reported as "sign in stuck". The immediate cause was a stale kubectl context —
`make token` was minting against a throwaway cluster, so the credential was
valid but meaningless to the cluster being asked. That's fixed in #19.

**What made it opaque rather than merely wrong is here.** Two paths swallowed
the failure whole:

**1. The token lived only in `sessionStorage`, and `setItem`'s exception was
caught and discarded.** Any browser blocking storage — private mode, strict
privacy settings, an embedded webview — dropped the token silently. Paste, click
Continue, form returns. Forever, with nothing said.

Memory is now the source of truth; storage only lets a token survive a reload.
The session works either way, and the UI says when persistence is unavailable.

**2. A rejected credential re-presented an identical empty form.** Being shown
the sign-in while a token is already held means that token was refused — worth
saying, since an unchanged form reads as a button that does nothing rather than
an answer of *no*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)