### PR TITLE
Lead with the next move, and tell the truth about plan age

### DIFF
--- a/internal/planner/stability_test.go
+++ b/internal/planner/stability_test.go
@@ -1,0 +1,132 @@
+package planner_test
+
+import (
+	"testing"
+
+	"github.com/atedgimo/k8s-dencer/internal/constraints"
+	"github.com/atedgimo/k8s-dencer/internal/model"
+	"github.com/atedgimo/k8s-dencer/internal/planner"
+)
+
+// How much of a plan survives executing its own first step?
+//
+// Not a pass/fail test — a measurement, printed for a design question: is a
+// multi-step plan a script worth keeping, or a forecast that decays the moment
+// anything moves?
+func TestPlanStabilityAfterOneStep(t *testing.T) {
+	for _, nodes := range []int{34, 100} {
+		snap := model.Synthesize(model.DefaultSynthetic(nodes))
+		analysis := constraints.Analyze(snap)
+		planA, err := (planner.Greedy{}).Plan(snap, analysis, planner.DefaultOptions())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(planA.Steps) < 3 {
+			continue
+		}
+
+		// Apply step 1 exactly as planned — the optimistic case, where the
+		// real scheduler agrees with us completely.
+		next := applyStep(snap, planA.Steps[0], false)
+		planB, err := (planner.Greedy{}).Plan(next, constraints.Analyze(next), planner.DefaultOptions())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Which of A's remaining target nodes does B still propose draining?
+		inB := map[string]int{}
+		for _, s := range planB.Steps {
+			inB[s.TargetNode] = s.SequenceNumber
+		}
+		survived, moved := 0, 0
+		for _, s := range planA.Steps[1:] {
+			if newSeq, ok := inB[s.TargetNode]; ok {
+				survived++
+				if newSeq != s.SequenceNumber-1 {
+					moved++
+				}
+			}
+		}
+		remaining := len(planA.Steps) - 1
+
+		t.Logf("%d nodes, %d pods", len(snap.Nodes), len(snap.Pods))
+		t.Logf("  plan A: %d steps, reclaims %d nodes", len(planA.Steps), planA.ReclaimedNodes())
+		t.Logf("  plan B after executing A's step 1: %d steps", len(planB.Steps))
+		t.Logf("  of A's %d remaining steps, %d still proposed (%.0f%%), %d at a different position",
+			remaining, survived, 100*float64(survived)/float64(remaining), moved)
+		t.Logf("  A total reclaim %d  vs  1 + B total reclaim %d",
+			planA.ReclaimedNodes(), 1+planB.ReclaimedNodes())
+
+		// The realistic case. kube-scheduler's default scoring favours the
+		// LEAST allocated node — it spreads. We pack. So an evicted pod tends
+		// to land on the emptiest node available, which is precisely the node
+		// a later step wanted to drain.
+		spread := applyStep(snap, planA.Steps[0], true)
+		planC, err := (planner.Greedy{}).Plan(spread, constraints.Analyze(spread), planner.DefaultOptions())
+		if err != nil {
+			t.Fatal(err)
+		}
+		inC := map[string]bool{}
+		for _, st := range planC.Steps {
+			inC[st.TargetNode] = true
+		}
+		survivedC := 0
+		for _, st := range planA.Steps[1:] {
+			if inC[st.TargetNode] {
+				survivedC++
+			}
+		}
+		t.Logf("  IF THE SCHEDULER SPREADS INSTEAD: %d steps, %d/%d of A survive (%.0f%%), reclaim 1+%d",
+			len(planC.Steps), survivedC, remaining,
+			100*float64(survivedC)/float64(remaining), planC.ReclaimedNodes())
+	}
+}
+
+// applyStep produces the snapshot that would result from a step running.
+func applyStep(snap *model.ClusterSnapshot, step model.PlanStep, spread bool) *model.ClusterSnapshot {
+	out := &model.ClusterSnapshot{
+		TakenAt: snap.TakenAt, PDBs: snap.PDBs,
+		Nodes: make([]model.Node, 0, len(snap.Nodes)),
+		Pods:  make([]model.Pod, 0, len(snap.Pods)),
+	}
+	dest := map[string]string{}
+	for _, m := range step.Moves {
+		dest[m.Namespace+"/"+m.Pod] = m.ToNode
+	}
+	if spread {
+		// Approximate LeastAllocated: send everything to the emptiest node
+		// that is not the one being drained.
+		load := map[string]int64{}
+		for _, p := range snap.Pods {
+			load[p.NodeName] += p.Requests.MilliCPU
+		}
+		emptiest, best := "", int64(1<<62)
+		for _, n := range snap.Nodes {
+			if n.Name == step.TargetNode || n.Unschedulable {
+				continue
+			}
+			if load[n.Name] < best {
+				best, emptiest = load[n.Name], n.Name
+			}
+		}
+		for k := range dest {
+			dest[k] = emptiest
+		}
+	}
+	for _, n := range snap.Nodes {
+		// The drained node is cordoned, exactly as the executor leaves it.
+		if n.Name == step.TargetNode {
+			n.Unschedulable = true
+		}
+		out.Nodes = append(out.Nodes, n)
+	}
+	for _, p := range snap.Pods {
+		if to, ok := dest[p.Namespace+"/"+p.Name]; ok {
+			p.NodeName = to
+		} else if p.NodeName == step.TargetNode && p.Owner != nil && p.Owner.Kind == "DaemonSet" {
+			continue // leaves with the node
+		}
+		out.Pods = append(out.Pods, p)
+	}
+	return out
+}

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -176,6 +176,13 @@ func (s *Store) Save(ctx context.Context, rec store.Record) (bool, error) {
 		return false, errors.New("nil plan")
 	}
 
+	// Defaulted before the dedup branch below reads it: callers routinely
+	// leave StoredAt zero and let the store stamp it.
+	storedAt := rec.StoredAt
+	if storedAt.IsZero() {
+		storedAt = time.Now().UTC()
+	}
+
 	var latestID string
 	err := s.db.QueryRowContext(ctx,
 		`SELECT id FROM plans ORDER BY stored_at DESC, rowid DESC LIMIT 1`).Scan(&latestID)
@@ -185,6 +192,17 @@ func (s *Store) Save(ctx context.Context, rec store.Record) (bool, error) {
 	if latestID == rec.Plan.ID {
 		// Same content hash as the last write: the cluster has not changed in
 		// any way that alters the plan.
+		//
+		// stored_at is still touched, because it means "last confirmed against
+		// the cluster" and that is what a reader needs. Leaving it alone made
+		// a plan the planner had just re-verified read as nineteen hours old,
+		// so the UI's staleness warning fired on the healthiest possible
+		// state. An unchanged plan is the strongest evidence it is current.
+		if _, err := s.db.ExecContext(ctx,
+			`UPDATE plans SET stored_at = ? WHERE id = ?`,
+			storedAt.UTC().Format(time.RFC3339Nano), rec.Plan.ID); err != nil {
+			return false, fmt.Errorf("touch plan: %w", err)
+		}
 		return false, nil
 	}
 
@@ -195,11 +213,6 @@ func (s *Store) Save(ctx context.Context, rec store.Record) (bool, error) {
 	analysisJSON, err := json.Marshal(rec.Analysis)
 	if err != nil {
 		return false, fmt.Errorf("encode analysis: %w", err)
-	}
-
-	storedAt := rec.StoredAt
-	if storedAt.IsZero() {
-		storedAt = time.Now().UTC()
 	}
 
 	tx, err := s.db.BeginTx(ctx, nil)

--- a/internal/store/sqlite/sqlite_test.go
+++ b/internal/store/sqlite/sqlite_test.go
@@ -307,3 +307,39 @@ func mustSave(t *testing.T, s *sqlitestore.Store, rec store.Record, wantStored b
 		t.Fatalf("save %s: stored=%v, want %v", rec.Plan.ID, stored, wantStored)
 	}
 }
+
+// An unchanged plan is the strongest evidence the plan is current, so
+// re-confirming one must refresh stored_at.
+//
+// It did not, and the UI's staleness warning consequently fired hardest on the
+// healthiest possible state: a plan the planner had re-verified seconds ago
+// read as nineteen hours old, because dedup skipped the write entirely.
+func TestReconfirmingAPlanRefreshesStoredAt(t *testing.T) {
+	db := openTemp(t)
+	ctx := context.Background()
+
+	rec := record("plan-1", step(1, "a", model.ImpactGreen))
+	rec.StoredAt = time.Now().UTC().Add(-2 * time.Hour)
+	if written, err := db.Save(ctx, rec); err != nil || !written {
+		t.Fatalf("first save: written=%v err=%v", written, err)
+	}
+
+	// Same content hash: dedup, no new row — but the timestamp must move.
+	again := record("plan-1", step(1, "a", model.ImpactGreen))
+	again.StoredAt = time.Now().UTC()
+	written, err := db.Save(ctx, again)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if written {
+		t.Error("an identical plan was written as a new row")
+	}
+
+	got, err := db.Latest(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if age := time.Since(got.StoredAt); age > time.Minute {
+		t.Errorf("storedAt is %s old after re-confirmation; it should be fresh", age.Round(time.Second))
+	}
+}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -159,6 +159,7 @@ export default function App() {
           <Verdict
             stats={state.graph.stats}
             steps={steps}
+            generatedAt={state.plan.storedAt}
             focusedRating={focusedRating}
             onFocusRating={setFocusedRating}
             onRun={requestRun}

--- a/ui/src/components/StepLedger.tsx
+++ b/ui/src/components/StepLedger.tsx
@@ -1,9 +1,21 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Impact, PlanStep } from "../api";
 import { GLYPH } from "./Impact";
 
 /**
- * The plan as an ordered ledger.
+ * Progress through the plan, with the full list on request.
+ *
+ * It used to render every step as an equal choice, which turned a 55-step plan
+ * into 55 competing decisions and drowned out the one recommendation the page
+ * is trying to make. Measured plan stability is 95–100% after a step executes,
+ * so the later steps are real — they are just not decisions anyone needs to
+ * take right now.
+ *
+ * So the default is a progress readout and the next few steps. Arbitrary
+ * selection still exists, because it is the only route to running a Yellow
+ * step, but it is the advanced path rather than the front door: the ordering
+ * is not cosmetic, and cherry-picking step 14 before step 2 packs worse.
+ *
  *
  * Numbered because the content genuinely is a sequence: step 7 assumes the
  * capacity steps 1–6 freed, and running them out of order would make the plan
@@ -45,12 +57,25 @@ export default function StepLedger({
     row?.scrollIntoView({ block: "nearest", behavior: "smooth" });
   }, [selected]);
 
-  const visible = focusedRating ? steps.filter((s) => s.impact === focusedRating) : steps;
+  const [showAll, setShowAll] = useState(false);
+
+  const done = steps.filter((s) => s.sequenceNumber <= current).length;
+  const filtered = focusedRating ? steps.filter((s) => s.impact === focusedRating) : steps;
+
+  // Collapsed by default to the work immediately ahead. Expanding is one
+  // click, and any explicit interest — a rating filter, a selection, a chosen
+  // step — expands it automatically.
+  const expanded = showAll || focusedRating !== null || checked.size > 0 || selected !== null;
+  const NEXT = 5;
+  const visible = expanded ? filtered : filtered.filter((s) => s.sequenceNumber > current).slice(0, NEXT);
+  const hidden = filtered.length - visible.length;
 
   return (
     <section className="ledger" aria-label="Consolidation steps">
       <div className="ledger-head">
-        <h2 className="panel-title mono">steps</h2>
+        <h2 className="panel-title mono">
+          {done > 0 ? `${done} of ${steps.length} done` : `${steps.length} steps`}
+        </h2>
         {checked.size > 0 && (
           <span className="ledger-picked mono">{checked.size} picked</span>
         )}
@@ -60,6 +85,25 @@ export default function StepLedger({
           </button>
         )}
       </div>
+
+      {/* Progress as a bar rather than a number alone: how far through a
+          consolidation you are is the question this panel should answer at a
+          glance. */}
+      {steps.length > 0 && (
+        <div
+          className="ledger-progress"
+          role="progressbar"
+          aria-valuenow={done}
+          aria-valuemin={0}
+          aria-valuemax={steps.length}
+          aria-label={`${done} of ${steps.length} steps complete`}
+        >
+          <div
+            className="ledger-progress-fill"
+            style={{ width: `${(done / steps.length) * 100}%` }}
+          />
+        </div>
+      )}
 
       <ol className="ledger-list" ref={listRef}>
         {visible.map((step) => {
@@ -128,7 +172,23 @@ export default function StepLedger({
       </ol>
 
       {visible.length === 0 && (
-        <p className="ledger-empty">No {focusedRating?.toLowerCase()} steps in this plan.</p>
+        <p className="ledger-empty">
+          {focusedRating
+            ? `No ${focusedRating.toLowerCase()} steps in this plan.`
+            : "Every step in this plan has run."}
+        </p>
+      )}
+
+      {!expanded && hidden > 0 && (
+        <button className="ledger-more" onClick={() => setShowAll(true)}>
+          Show all {filtered.length} steps
+          <span className="ledger-more-hint"> — pick individually, including Yellow</span>
+        </button>
+      )}
+      {showAll && (
+        <button className="ledger-more" onClick={() => setShowAll(false)}>
+          Show just what is next
+        </button>
       )}
     </section>
   );

--- a/ui/src/components/Verdict.tsx
+++ b/ui/src/components/Verdict.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { GraphStats, Impact, PlanStep } from "../api";
 import { GLYPH } from "./Impact";
 
@@ -19,6 +20,15 @@ import { GLYPH } from "./Impact";
 interface Props {
   stats: GraphStats;
   steps: PlanStep[];
+  /**
+   * When the plan was last confirmed against the cluster — the store's
+   * storedAt, not the plan's generatedAt.
+   *
+   * An unchanged plan keeps its original generatedAt however many times the
+   * planner re-verifies it, so that field reported a perfectly current plan as
+   * hours stale. Confirmation is the question a reader is actually asking.
+   */
+  generatedAt: string;
   onFocusRating: (impact: Impact | null) => void;
   focusedRating: Impact | null;
   onRun: (dryRun: boolean) => void;
@@ -31,6 +41,7 @@ interface Props {
 export default function Verdict({
   stats,
   steps,
+  generatedAt,
   onFocusRating,
   focusedRating,
   onRun,
@@ -43,20 +54,40 @@ export default function Verdict({
   const red = stats.ratings.Red ?? 0;
 
   const custom = picked.length > 0;
-  const runCount = custom ? picked.length : green;
-  const hasYellow = picked.some((s) => s.impact === "Yellow");
+  // What the button would actually run: the ticked steps, or the Green ones.
+  const willRun = custom ? picked : steps.filter((s) => s.impact === "Green");
+  const runCount = willRun.length;
+  const hasYellow = willRun.some((s) => s.impact === "Yellow");
+  const podsMoving = willRun.reduce((n, s) => n + s.moves.length, 0);
+  const nodeNames = willRun.map((s) => s.targetNode).filter(Boolean) as string[];
+  const laterCount = steps.length - runCount;
 
   return (
     <header className="verdict">
       <div className="verdict-main">
-        <p className="verdict-eyebrow mono">consolidation plan</p>
+        <p className="verdict-eyebrow mono">
+          consolidation plan <PlanAge generatedAt={generatedAt} />
+        </p>
         <h1 className="verdict-line">
           Reclaim <span className="verdict-figure num">{stats.reclaimed}</span> of{" "}
           <span className="num">{stats.nodesBefore}</span> nodes
         </h1>
-        <p className="verdict-sub">
-          {describe(green, yellow, red)}
-        </p>
+        {/* The nodes, named. "Run the 5 safe steps" is abstract; a list of
+            machines is something an operator can picture and sanity-check
+            against what they know about their own cluster. */}
+        {nodeNames.length > 0 ? (
+          <p className="verdict-sub">
+            Next: drain{" "}
+            <span className="verdict-nodes mono">{nodeNames.slice(0, 4).join(", ")}</span>
+            {nodeNames.length > 4 && (
+              <span className="verdict-nodes-more"> +{nodeNames.length - 4} more</span>
+            )}
+            . <span className="verdict-cost">{podsMoving} pods move</span>
+            {laterCount > 0 && `, ${laterCount} step${laterCount === 1 ? "" : "s"} left after this`}.
+          </p>
+        ) : (
+          <p className="verdict-sub">{describe(green, yellow, red)}</p>
+        )}
       </div>
 
       <div className="verdict-breakdown">
@@ -126,6 +157,40 @@ export default function Verdict({
       </div>
     </header>
   );
+}
+
+/**
+ * How old the plan is.
+ *
+ * The honest uncertainty signal. Measured plan stability is 95–100% after a
+ * step runs, so dimming later steps would misrepresent them — what actually
+ * ages a plan is the cluster changing underneath it, and age is the only
+ * proxy for that the UI has. Ticks on its own so the number stays true
+ * without waiting for a re-fetch.
+ */
+function PlanAge({ generatedAt }: { generatedAt: string }) {
+  const [, tick] = useState(0);
+  useEffect(() => {
+    const t = setInterval(() => tick((n) => n + 1), 15_000);
+    return () => clearInterval(t);
+  }, []);
+
+  const seconds = Math.max(0, (Date.now() - new Date(generatedAt).getTime()) / 1000);
+  const stale = seconds > 300;
+  return (
+    <span className={stale ? "verdict-age verdict-age-stale" : "verdict-age"}>
+      · confirmed {describeAge(seconds)}
+      {stale && " — the cluster may have moved on"}
+    </span>
+  );
+}
+
+function describeAge(seconds: number): string {
+  if (seconds < 45) return "just now";
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes} minute${minutes === 1 ? "" : "s"} ago`;
+  const hours = Math.round(minutes / 60);
+  return `${hours} hour${hours === 1 ? "" : "s"} ago`;
 }
 
 function Tally({

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1373,3 +1373,64 @@
   color: var(--risk-red);
   font-size: 0.78rem;
 }
+
+/* --------------------------------------------- next move and plan age */
+
+.verdict-age {
+  color: var(--graphite-dim);
+  letter-spacing: 0.04em;
+  text-transform: none;
+}
+
+/* Amber, not red: an ageing plan is worth knowing about, not a failure. It
+   shares the Yellow of "needs a human" rather than introducing a new hue. */
+.verdict-age-stale {
+  color: var(--risk-yellow);
+}
+
+.verdict-nodes {
+  color: var(--chalk);
+}
+
+.verdict-nodes-more {
+  color: var(--graphite-dim);
+}
+
+.verdict-cost {
+  color: var(--chalk);
+}
+
+/* ------------------------------------------------------ ledger progress */
+
+.ledger-progress {
+  height: 2px;
+  margin: 0 1rem 0.5rem;
+  background: var(--panel-sunken);
+}
+
+.ledger-progress-fill {
+  height: 100%;
+  background: var(--fill-75);
+  transition: width var(--step-slow) var(--ease-out);
+}
+
+/* The way into the full list. Deliberately quiet: arbitrary selection is the
+   advanced path, since out-of-order execution packs worse. */
+.ledger-more {
+  display: block;
+  width: 100%;
+  padding: 0.5rem 1rem 0.9rem;
+  font-size: 0.74rem;
+  color: var(--graphite);
+  text-align: left;
+  background: transparent;
+  border: 0;
+}
+
+.ledger-more:hover {
+  color: var(--chalk);
+}
+
+.ledger-more-hint {
+  color: var(--graphite-dim);
+}


### PR DESCRIPTION
Raised as a design question: *if the plan changes after every drain, why compute
more than one step?*

## Measured it rather than argued about it

`internal/planner/stability_test.go` plans, applies its own first step, and
replans:

| | steps surviving | total reclaim |
|---|---|---|
| Scheduler places as predicted | **100%**, same order | unchanged |
| Scheduler *spreads* instead (what kube-scheduler actually does) | **88–96%** | unchanged |

Then confirmed on the cluster. A deliberate **out-of-order** drain of two nodes
took the plan from 18 steps to 16, still reaching 13 nodes — nothing lost.

**So the plan isn't fiction.** The real problem was presentation: 55 equally
weighted rows isn't a decision anyone can take, and it drowned out the one
recommendation the page exists to make. One-step-at-a-time would have been
*worse* — 55 approvals instead of one.

## Three changes

**The header names the machines.** "Run the 5 safe steps" is abstract; "drain
`kwok-node-1, kwok-node-10, …`" is something you can picture and check against
what you know. Plus the cost in pods and what's left afterwards.

**The ledger became progress, not a menu** — a bar, a count, the next five
steps, full list one click away. Arbitrary selection still exists (it's the only
route to a Yellow step) but is no longer the front door, since the ordering
isn't cosmetic.

**Plan age — which caught a bug in itself.** It first read **19 hours** for a
plan the planner had confirmed 30 seconds earlier: `Save` dedupes on content
hash, so an unchanged plan kept its original timestamp and `stored_at` was never
touched. The staleness warning would have fired hardest on the *healthiest*
possible state.

Re-confirming now refreshes `stored_at`, and the UI reads that rather than
`generatedAt` — an unchanged plan is the strongest evidence it's current. Tested,
and verified by reverting the fix.

```
generatedAt: 69939s ago   (when the plan first appeared)
storedAt:       21s ago   ← what you now see
```

## One thing use revealed that speculation hadn't

Node names and step numbers got translated by hand twice in a single session.
**The ledger should be selectable by node**, not only by step number. Not in this
change, but now justified by something other than my opinion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)