### PR TITLE
M17: hold and keep a 50k-pod cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,25 @@ Phase 3 — maintenance windows.
 | Milestone | Scope | State |
 |---|---|---|
 | **M14** | `MaintenanceWindow` CRD; Red steps unlocked by an open window | **done** |
+
+Phase 4 — production hardening. Target: 1000+ nodes, 50k pods. Measured, not
+estimated — every milestone here starts from a number in
+[docs/benchmarks.md](docs/benchmarks.md).
+
+| Milestone | Scope | State |
+|---|---|---|
 | **M15** | Readiness verification — the executor waits for Ready, not Running | **done** |
-| **M16** | Measured ceiling — synthesised clusters, `make bench`, [docs/benchmarks.md](docs/benchmarks.md) | **done** |
-| **M17–M21** | Scale to 1000 nodes / 50k pods; metrics; published images; local hardening | planned |
+| **M16** | Measured ceiling — synthesised clusters, `make bench` | **done** |
+| **M17** | Data volume — gzipped plan blobs (23.8× at 5k pods), informer cache transform (−30% heap), paginated reads | **done** |
+| **M18** | Planner cost — memoised topology-spread counts, **112×** faster analysis at 5k pods | **done** |
+| **M19** | UI at scale — density rendering, virtualised field, aggregated graph payload | planned |
+| **M20** | `/metrics` on all three components; honest `serviceMonitor`; published images | planned |
+| **M21** | Multi-node k3d, PodSecurity enforcing, real ingress and StorageClass | planned |
+
+High availability and a Postgres store were **dropped, not deferred**: a
+consolidation planner is not a serving path. The run queue is already crash-safe
+and resumes, the planner replans on restart, and a minute of UI downtime costs
+nothing.
 
 Deferred: scheduled automatic execution,
 Postgres store, multi-agent orchestration, and **closing the reclamation loop**
@@ -58,12 +74,12 @@ The planner watches the cluster through informers and publishes an immutable
 `ClusterSnapshot` every resync period:
 
 ```
-snapshot:    nodes=31 nodesOccupied=29 pods=120 pdbs=0 pdbsBlocking=0
+snapshot:    nodes=31 nodesOccupied=29 pods=121 pdbs=0 pdbsBlocking=0
              cpuRequestedPct=38.6% memRequestedPct=19.6% usageData=false
-constraints: movable=119 blocked=1 stuck=25 antiAffinity=0 spreadBound=1
+constraints: movable=120 blocked=1 stuck=26 antiAffinity=0 spreadBound=1
              controllerPinned=1 nodesUndrainable=1
-plan:        id=dcdd608cf7c9 steps=16 nodesBefore=29 nodesAfter=13 reclaims=16
-             green=7 yellow=4 red=5
+plan:        id=283ba43a9d15 steps=16 nodesBefore=29 nodesAfter=13 reclaims=16
+             green=12 yellow=1 red=3
 ```
 
 Plans are rated, explained, persisted, visualised, and answerable in natural

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -9,6 +9,67 @@ measured at thousands of pods without standing anything up.
 Apple M-series laptop, Go 1.26, `-benchtime 1x`. Absolute numbers will differ on
 other hardware; **the growth curves are the point.**
 
+## After M17 — memory and stored bytes
+
+M18 made the planner fast enough; M17 addresses what it costs to *hold* and
+*keep* a cluster this size. Three changes, each measured.
+
+**Stored plans are gzipped** ([sqlite.go](../internal/store/sqlite/sqlite.go)).
+JSON of a cluster snapshot is extremely repetitive, and the snapshot and
+analysis BLOBs compress accordingly. The encoding is self-describing via the
+gzip magic bytes, so no migration was needed and rows written before this change
+still read back.
+
+| Pods | JSON in | Stored on disk | Ratio | `Save` time |
+|---|---|---|---|---|
+| 119 | 0.10 MB | 5.3 KB | 19.1× | 1.5 ms |
+| 916 | 1.00 MB | 54 KB | 19.2× | 4.7 ms |
+| 2,526 | 4.44 MB | 197 KB | 23.1× | 18 ms |
+| 5,026 | 14.1 MB | **609 KB** | **23.8×** | 54 ms |
+
+The ratio improves with size, which is what you would expect: more pods means
+more repetition of the same key names and label values. At the 50,000-pod target
+this is the difference between a retention policy measured in gigabytes and one
+measured in tens of megabytes.
+
+Compressing did not cost time at the sizes that matter. Against the
+pre-compression baseline below, `Save` is slower at 119 pods (0.74 → 1.5 ms) and
+*faster* from 2,526 up (29 → 18 ms, 83 → 54 ms): past a certain size, writing
+20× fewer bytes to SQLite more than pays for the gzip.
+
+`BenchmarkScaleStoreSave` now reports the bytes actually on disk. It previously
+reported the marshalled JSON length, which after this change would have
+overstated retention by ~20× — the exact quantity the benchmark exists to
+track.
+
+**The informer cache is transformed on the way in**
+([collector.go](../internal/cluster/collector.go)). Managed fields, pod
+annotations and container statuses are discarded before anything is cached.
+
+| | Heap per pod | 50,000 pods |
+|---|---|---|
+| Untransformed | 9,183 B | 459 MB |
+| Transformed | 6,423 B | **321 MB** |
+
+**30% off the planner's dominant memory cost** — 138 MB at the 50k target. The
+number depends entirely on how large real managed fields are, so it was
+calibrated rather than assumed: on the development cluster,
+`kubectl get pods -A -o json --show-managed-fields` reports a mean 3,505 B of
+managed fields on kubelet-run pods, about 40% of the serialised object. (The
+flag matters — kubectl hides the section by default, which is why a first pass
+measured 2 B and made the transform look worthless.)
+
+The correctness risk here is stripping something the converter reads, so
+`transform_test.go` asserts the property directly rather than by inspection: it
+converts an object, transforms it, converts it again, and requires the two
+domain objects to be identical. Three mutations were run against it — stripping
+node annotations, pod conditions, and pod labels — and each fails the test.
+
+**Reads are paginated and scoped**
+([direct.go](../internal/cluster/direct.go)). Every List now pages at 500, and
+the drain loop's "has this pod gone yet" poll — which listed every pod in the
+cluster every 2 seconds to ask about one — is a single Get.
+
 ## After M18 — the spread index
 
 `Placement.domainCounts` is memoised and maintained incrementally

--- a/internal/cluster/collector.go
+++ b/internal/cluster/collector.go
@@ -77,6 +77,15 @@ func New(cfg *rest.Config, opts Options) (*Collector, error) {
 		}
 	}
 
+	// Strip what is never read before anything is cached.
+	//
+	// On a pod-heavy cluster the informer cache is the planner's dominant
+	// memory cost, and most of what it holds is managed fields, annotations
+	// and container detail this product never looks at. Transforming on the
+	// way in is the standard remedy, and it applies to every pod for the life
+	// of the process rather than per read.
+	applyTransform(&cacheOpts)
+
 	c, err := cache.New(cfg, cacheOpts)
 	if err != nil {
 		return nil, fmt.Errorf("build informer cache: %w", err)
@@ -215,4 +224,61 @@ func (c *Collector) ownerResolver(ctx context.Context) ownerResolver {
 		}
 		return nil
 	}
+}
+
+// applyTransform installs cache transforms that discard unread fields.
+//
+// Deliberately conservative: anything convert.go reads must survive. That means
+// keeping labels, the owner references, node assignment, the full container
+// list (effective requests are computed from it), conditions, tolerations and
+// affinity. What goes is managed fields — often the largest single part of a
+// pod object — annotations, and the container statuses, which carry image
+// digests and restart history that nothing here consults.
+func applyTransform(opts *cache.Options) {
+	if opts.ByObject == nil {
+		opts.ByObject = map[client.Object]cache.ByObject{}
+	}
+
+	pod := opts.ByObject[&corev1.Pod{}]
+	pod.Transform = func(obj any) (any, error) {
+		p, ok := obj.(*corev1.Pod)
+		if !ok {
+			return obj, nil
+		}
+		p.ManagedFields = nil
+		p.Annotations = nil
+		p.Status.ContainerStatuses = nil
+		p.Status.InitContainerStatuses = nil
+		p.Status.EphemeralContainerStatuses = nil
+		return p, nil
+	}
+	opts.ByObject[&corev1.Pod{}] = pod
+
+	node := opts.ByObject[&corev1.Node{}]
+	node.Transform = func(obj any) (any, error) {
+		n, ok := obj.(*corev1.Node)
+		if !ok {
+			return obj, nil
+		}
+		n.ManagedFields = nil
+		// Node labels and taints are load-bearing for placement, so only the
+		// image inventory goes — which on a busy node is most of the object.
+		n.Status.Images = nil
+		return n, nil
+	}
+	opts.ByObject[&corev1.Node{}] = node
+
+	rs := opts.ByObject[&appsv1.ReplicaSet{}]
+	rs.Transform = func(obj any) (any, error) {
+		r, ok := obj.(*appsv1.ReplicaSet)
+		if !ok {
+			return obj, nil
+		}
+		r.ManagedFields = nil
+		r.Annotations = nil
+		// Only the owner chain is read, to name a pod's real controller.
+		r.Spec.Template = corev1.PodTemplateSpec{}
+		return r, nil
+	}
+	opts.ByObject[&appsv1.ReplicaSet{}] = rs
 }

--- a/internal/cluster/direct.go
+++ b/internal/cluster/direct.go
@@ -7,6 +7,8 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -49,44 +51,109 @@ func NewDirectWithClient(client kubernetes.Interface) *Direct {
 // mutations the executor needs without opening a second connection.
 func (d *Direct) Client() kubernetes.Interface { return d.client }
 
+// pageSize bounds a single List response.
+//
+// Without it the API server assembles every pod in the cluster into one reply —
+// tens of megabytes at fifty thousand pods, allocated in full on both sides.
+// Paging trades a few more round trips for a bounded footprint, which is the
+// right trade for a component that reads repeatedly during a drain.
+const pageSize = 500
+
 // Snapshot builds an immutable view of current cluster state.
 func (d *Direct) Snapshot(ctx context.Context) (*model.ClusterSnapshot, error) {
-	nodes, err := d.client.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
-	if err != nil {
+	resolver := d.ownerResolver(ctx)
+	snap := &model.ClusterSnapshot{TakenAt: time.Now().UTC()}
+
+	if err := d.eachNodePage(ctx, func(items []corev1.Node) {
+		for i := range items {
+			snap.Nodes = append(snap.Nodes, convertNode(&items[i]))
+		}
+	}); err != nil {
 		return nil, fmt.Errorf("list nodes: %w", err)
 	}
-	pods, err := d.client.CoreV1().Pods("").List(ctx, metav1.ListOptions{})
-	if err != nil {
+
+	if err := d.eachPodPage(ctx, "", func(items []corev1.Pod) {
+		for i := range items {
+			p := &items[i]
+			// Terminated pods hold no resources and would inflate every node.
+			if p.Status.Phase == corev1.PodSucceeded || p.Status.Phase == corev1.PodFailed {
+				continue
+			}
+			snap.Pods = append(snap.Pods, convertPod(p, resolver))
+		}
+	}); err != nil {
 		return nil, fmt.Errorf("list pods: %w", err)
 	}
-	pdbs, err := d.client.PolicyV1().PodDisruptionBudgets("").List(ctx, metav1.ListOptions{})
-	if err != nil {
+
+	if err := d.eachPDBPage(ctx, func(items []policyv1.PodDisruptionBudget) {
+		for i := range items {
+			snap.PDBs = append(snap.PDBs, convertPDB(&items[i]))
+		}
+	}); err != nil {
 		return nil, fmt.Errorf("list poddisruptionbudgets: %w", err)
 	}
-
-	resolver := d.ownerResolver(ctx)
-	snap := &model.ClusterSnapshot{
-		TakenAt: time.Now().UTC(),
-		Nodes:   make([]model.Node, 0, len(nodes.Items)),
-		Pods:    make([]model.Pod, 0, len(pods.Items)),
-		PDBs:    make([]model.PodDisruptionBudget, 0, len(pdbs.Items)),
-	}
-
-	for i := range nodes.Items {
-		snap.Nodes = append(snap.Nodes, convertNode(&nodes.Items[i]))
-	}
-	for i := range pods.Items {
-		p := &pods.Items[i]
-		// Terminated pods hold no resources and would inflate every node.
-		if p.Status.Phase == corev1.PodSucceeded || p.Status.Phase == corev1.PodFailed {
-			continue
-		}
-		snap.Pods = append(snap.Pods, convertPod(p, resolver))
-	}
-	for i := range pdbs.Items {
-		snap.PDBs = append(snap.PDBs, convertPDB(&pdbs.Items[i]))
-	}
 	return snap, nil
+}
+
+// PodPresent reports whether a pod still exists and is not terminating.
+//
+// A single Get, because the alternative was listing every pod in the cluster
+// every two seconds to answer a question about one of them. On a large cluster
+// that dominated the entire drain.
+func (d *Direct) PodPresent(ctx context.Context, namespace, name string) (bool, error) {
+	pod, err := d.client.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("get pod %s/%s: %w", namespace, name, err)
+	}
+	return pod.DeletionTimestamp == nil, nil
+}
+
+func (d *Direct) eachNodePage(ctx context.Context, fn func([]corev1.Node)) error {
+	opts := metav1.ListOptions{Limit: pageSize}
+	for {
+		page, err := d.client.CoreV1().Nodes().List(ctx, opts)
+		if err != nil {
+			return err
+		}
+		fn(page.Items)
+		if page.Continue == "" {
+			return nil
+		}
+		opts.Continue = page.Continue
+	}
+}
+
+func (d *Direct) eachPodPage(ctx context.Context, namespace string, fn func([]corev1.Pod)) error {
+	opts := metav1.ListOptions{Limit: pageSize}
+	for {
+		page, err := d.client.CoreV1().Pods(namespace).List(ctx, opts)
+		if err != nil {
+			return err
+		}
+		fn(page.Items)
+		if page.Continue == "" {
+			return nil
+		}
+		opts.Continue = page.Continue
+	}
+}
+
+func (d *Direct) eachPDBPage(ctx context.Context, fn func([]policyv1.PodDisruptionBudget)) error {
+	opts := metav1.ListOptions{Limit: pageSize}
+	for {
+		page, err := d.client.PolicyV1().PodDisruptionBudgets("").List(ctx, opts)
+		if err != nil {
+			return err
+		}
+		fn(page.Items)
+		if page.Continue == "" {
+			return nil
+		}
+		opts.Continue = page.Continue
+	}
 }
 
 // ownerResolver mirrors the Collector's, walking ReplicaSet -> Deployment so a

--- a/internal/cluster/transform_bench_test.go
+++ b/internal/cluster/transform_bench_test.go
@@ -1,0 +1,56 @@
+package cluster
+
+import (
+	"runtime"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// The informer cache holds decoded Go objects, so the number that matters is
+// resident heap per pod, not serialised bytes. This measures it by holding a
+// large population live and reading the heap, which is crude but honest — and
+// it is the same measurement an operator would make with a memory limit.
+func TestTransformHeapSaving(t *testing.T) {
+	if testing.Short() {
+		t.Skip("allocates ~100k pods")
+	}
+	const n = 50000
+
+	measure := func(transform bool) uint64 {
+		fn := transformFor(t, &corev1.Pod{})
+		pods := make([]*corev1.Pod, 0, n)
+		for i := 0; i < n; i++ {
+			p := fullyPopulatedPod()
+			if transform {
+				out, err := fn(p)
+				if err != nil {
+					t.Fatal(err)
+				}
+				p = out.(*corev1.Pod)
+			}
+			pods = append(pods, p)
+		}
+		runtime.GC()
+		var m runtime.MemStats
+		runtime.ReadMemStats(&m)
+		runtime.KeepAlive(pods)
+		return m.HeapAlloc
+	}
+
+	var base runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&base)
+
+	raw := measure(false) - base.HeapAlloc
+	runtime.GC()
+	kept := measure(true) - base.HeapAlloc
+
+	t.Logf("untransformed: %d bytes/pod (%.1f MB for %d pods)", raw/n, float64(raw)/1e6, n)
+	t.Logf("transformed:   %d bytes/pod (%.1f MB for %d pods)", kept/n, float64(kept)/1e6, n)
+	t.Logf("saving:        %.1f%%", 100*(1-float64(kept)/float64(raw)))
+
+	if kept >= raw {
+		t.Errorf("transform did not reduce heap: %d -> %d", raw, kept)
+	}
+}

--- a/internal/cluster/transform_test.go
+++ b/internal/cluster/transform_test.go
@@ -1,0 +1,331 @@
+package cluster
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/atedgimo/k8s-dencer/internal/model"
+)
+
+// The transform exists to shrink the informer cache, and the only way it can
+// hurt is by discarding something the converter reads. Grepping convert.go
+// would catch today's reads and miss tomorrow's, so these tests assert the
+// property directly: convert the object, transform it, convert it again, and
+// require the two domain objects to be identical.
+//
+// A field added to convert.go that the transform strips fails this test on the
+// next run, without anyone remembering to update a list.
+
+func transformFor(t *testing.T, obj client.Object) func(any) (any, error) {
+	t.Helper()
+	opts := &cache.Options{}
+	applyTransform(opts)
+	for k, v := range opts.ByObject {
+		if reflect.TypeOf(k) == reflect.TypeOf(obj) {
+			if v.Transform == nil {
+				t.Fatalf("no transform registered for %T", obj)
+			}
+			return v.Transform
+		}
+	}
+	t.Fatalf("no ByObject entry for %T", obj)
+	return nil
+}
+
+func TestPodTransformPreservesEverythingTheConverterReads(t *testing.T) {
+	pod := fullyPopulatedPod()
+	before := convertPod(pod.DeepCopy(), func(*corev1.Pod) *model.OwnerRef { return nil })
+
+	out, err := transformFor(t, &corev1.Pod{})(pod.DeepCopy())
+	if err != nil {
+		t.Fatalf("transform: %v", err)
+	}
+	stripped, ok := out.(*corev1.Pod)
+	if !ok {
+		t.Fatalf("transform returned %T, want *corev1.Pod", out)
+	}
+
+	// Guard against a vacuous comparison: if the fixture carried none of the
+	// fields the transform removes, the equality below would prove nothing.
+	original := fullyPopulatedPod()
+	if len(original.ManagedFields) == 0 || len(original.Annotations) == 0 || len(original.Status.ContainerStatuses) == 0 {
+		t.Fatal("fixture does not populate the fields the transform strips; the comparison would be vacuous")
+	}
+	if len(stripped.ManagedFields) != 0 || len(stripped.Annotations) != 0 || len(stripped.Status.ContainerStatuses) != 0 {
+		t.Error("transform left behind fields it is supposed to strip")
+	}
+
+	after := convertPod(stripped, func(*corev1.Pod) *model.OwnerRef { return nil })
+	if !reflect.DeepEqual(before, after) {
+		t.Errorf("transform changed what the planner sees:\n before: %+v\n  after: %+v", before, after)
+	}
+}
+
+func TestNodeTransformPreservesEverythingTheConverterReads(t *testing.T) {
+	node := fullyPopulatedNode()
+	before := convertNode(node.DeepCopy())
+
+	out, err := transformFor(t, &corev1.Node{})(node.DeepCopy())
+	if err != nil {
+		t.Fatalf("transform: %v", err)
+	}
+	stripped, ok := out.(*corev1.Node)
+	if !ok {
+		t.Fatalf("transform returned %T, want *corev1.Node", out)
+	}
+
+	original := fullyPopulatedNode()
+	if len(original.ManagedFields) == 0 || len(original.Status.Images) == 0 {
+		t.Fatal("fixture does not populate the fields the transform strips; the comparison would be vacuous")
+	}
+	if len(stripped.ManagedFields) != 0 || len(stripped.Status.Images) != 0 {
+		t.Error("transform left behind fields it is supposed to strip")
+	}
+
+	// Node annotations are load-bearing — the KWOK fabric marks fake nodes with
+	// one — so they are deliberately not stripped, unlike a pod's.
+	if len(stripped.Annotations) == 0 {
+		t.Error("node annotations were stripped; convertNode reads them")
+	}
+
+	after := convertNode(stripped)
+	if !reflect.DeepEqual(before, after) {
+		t.Errorf("transform changed what the planner sees:\n before: %+v\n  after: %+v", before, after)
+	}
+}
+
+// The ReplicaSet transform blanks the pod template, which is by far the largest
+// part of the object and is never read: the resolver walks owner references
+// only.
+func TestReplicaSetTransformKeepsTheOwnerChain(t *testing.T) {
+	yes := true
+	rs := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:          "web-7d9f",
+			Namespace:     "shop",
+			Annotations:   map[string]string{"deployment.kubernetes.io/revision": "4"},
+			ManagedFields: []metav1.ManagedFieldsEntry{{Manager: "kube-controller-manager"}},
+			OwnerReferences: []metav1.OwnerReference{
+				{Kind: "Deployment", Name: "web", Controller: &yes},
+			},
+		},
+		Spec: appsv1.ReplicaSetSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "app", Image: "nginx"}}},
+			},
+		},
+	}
+
+	out, err := transformFor(t, &appsv1.ReplicaSet{})(rs.DeepCopy())
+	if err != nil {
+		t.Fatalf("transform: %v", err)
+	}
+	stripped := out.(*appsv1.ReplicaSet)
+
+	if len(stripped.OwnerReferences) != 1 || stripped.OwnerReferences[0].Name != "web" {
+		t.Fatalf("owner chain lost: %+v", stripped.OwnerReferences)
+	}
+	if len(stripped.Spec.Template.Spec.Containers) != 0 {
+		t.Error("pod template survived the transform")
+	}
+	if len(stripped.ManagedFields) != 0 || len(stripped.Annotations) != 0 {
+		t.Error("transform left behind fields it is supposed to strip")
+	}
+}
+
+// A tombstone or an unexpected type must pass through rather than panic: the
+// informer hands transforms whatever it has, including DeletedFinalStateUnknown.
+func TestTransformsPassThroughUnexpectedTypes(t *testing.T) {
+	for _, obj := range []client.Object{&corev1.Pod{}, &corev1.Node{}, &appsv1.ReplicaSet{}} {
+		fn := transformFor(t, obj)
+		got, err := fn("not an object")
+		if err != nil {
+			t.Errorf("%T: unexpected error %v", obj, err)
+		}
+		if got != "not an object" {
+			t.Errorf("%T: passthrough changed the value", obj)
+		}
+	}
+}
+
+func fullyPopulatedPod() *corev1.Pod {
+	yes := true
+	prio := int32(100)
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "web-7d9f-abcde",
+			Namespace:         "shop",
+			Labels:            map[string]string{"app": "web", "tier": "front"},
+			Annotations:       map[string]string{"checksum/config": "deadbeef"},
+			CreationTimestamp: metav1.NewTime(time.Unix(1700000000, 0)),
+			ManagedFields:     realisticManagedFields(),
+			OwnerReferences: []metav1.OwnerReference{
+				{Kind: "ReplicaSet", Name: "web-7d9f", Controller: &yes},
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName:          "node-3",
+			NodeSelector:      map[string]string{"role": "app"},
+			Priority:          &prio,
+			PriorityClassName: "high",
+			Tolerations:       []corev1.Toleration{{Key: "dedicated", Operator: corev1.TolerationOpExists}},
+			Overhead:          corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("10m")},
+			Volumes:           []corev1.Volume{{Name: "data"}},
+			Containers: []corev1.Container{{
+				Name: "app",
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("250m"),
+						corev1.ResourceMemory: resource.MustParse("512Mi"),
+					},
+				},
+			}},
+			InitContainers: []corev1.Container{{
+				Name: "init",
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")},
+				},
+			}},
+			TopologySpreadConstraints: []corev1.TopologySpreadConstraint{{
+				MaxSkew:           1,
+				TopologyKey:       "topology.kubernetes.io/zone",
+				WhenUnsatisfiable: corev1.DoNotSchedule,
+				LabelSelector:     &metav1.LabelSelector{MatchLabels: map[string]string{"app": "web"}},
+			}},
+			Affinity: &corev1.Affinity{
+				PodAntiAffinity: &corev1.PodAntiAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{{
+						TopologyKey:   "kubernetes.io/hostname",
+						LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "web"}},
+					}},
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+			},
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name:         "app",
+				RestartCount: 3,
+				Image:        "registry.example.com/shop/web:1.42.0",
+				ImageID:      "registry.example.com/shop/web@sha256:9f2c4d1e7a3b5c8d0e6f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d",
+				ContainerID:  "containerd://3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d",
+				Ready:        true,
+				Started:      &yes,
+				State: corev1.ContainerState{
+					Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(time.Unix(1700000100, 0))},
+				},
+				LastTerminationState: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{
+						ExitCode: 137, Reason: "OOMKilled",
+						ContainerID: "containerd://ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100",
+					},
+				},
+			}},
+			InitContainerStatuses: []corev1.ContainerStatus{{
+				Name:    "init",
+				Image:   "registry.example.com/shop/init:3.1",
+				ImageID: "registry.example.com/shop/init@sha256:1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b",
+				State:   corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: 0}},
+			}},
+		},
+	}
+}
+
+func fullyPopulatedNode() *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "node-3",
+			Labels:            map[string]string{"topology.kubernetes.io/zone": "a"},
+			Annotations:       map[string]string{"kwok.x-k8s.io/node": "fake"},
+			CreationTimestamp: metav1.NewTime(time.Unix(1700000000, 0)),
+			ManagedFields:     realisticManagedFields(),
+		},
+		Spec: corev1.NodeSpec{
+			Unschedulable: true,
+			Taints:        []corev1.Taint{{Key: "dedicated", Value: "app", Effect: corev1.TaintEffectNoSchedule}},
+		},
+		Status: corev1.NodeStatus{
+			Capacity: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("4"),
+				corev1.ResourceMemory: resource.MustParse("16Gi"),
+			},
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("3800m"),
+				corev1.ResourceMemory: resource.MustParse("15Gi"),
+			},
+			Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}},
+			Images: []corev1.ContainerImage{
+				{Names: []string{"nginx@sha256:abc", "nginx:1.25"}, SizeBytes: 187000000},
+			},
+		},
+	}
+}
+
+// realisticManagedFields reproduces the shape and size of managed fields on a
+// real pod, because the earlier version of this fixture carried a token
+// single-field entry and made the transform look nearly worthless.
+//
+// Measured on the development cluster with `kubectl get pods -A -o json
+// --show-managed-fields` (the flag matters — kubectl hides the section by
+// default): kubelet-run pods carry two entries totalling ~3.5 KB of fieldsV1,
+// roughly 40% of the serialised object. Two entries of ~2.0 KB and ~0.9 KB is
+// what that looks like.
+func realisticManagedFields() []metav1.ManagedFieldsEntry {
+	spec := []byte(`{"f:metadata":{"f:annotations":{".":{},"f:checksum/config":{}},` +
+		`"f:labels":{".":{},"f:app":{},"f:tier":{}},"f:ownerReferences":{".":{},` +
+		`"k:{\"uid\":\"3f2b1a0c-9d8e-4f7a-b6c5-d4e3f2a1b0c9\"}":{}}},` +
+		`"f:spec":{"f:containers":{"k:{\"name\":\"app\"}":{".":{},"f:image":{},` +
+		`"f:imagePullPolicy":{},"f:name":{},"f:resources":{".":{},"f:requests":{".":{},` +
+		`"f:cpu":{},"f:memory":{}}},"f:terminationMessagePath":{},` +
+		`"f:terminationMessagePolicy":{},"f:volumeMounts":{".":{},` +
+		`"k:{\"mountPath\":\"/data\"}":{".":{},"f:mountPath":{},"f:name":{}}}}},` +
+		`"f:dnsPolicy":{},"f:enableServiceLinks":{},"f:nodeSelector":{},` +
+		`"f:priorityClassName":{},"f:restartPolicy":{},"f:schedulerName":{},` +
+		`"f:securityContext":{},"f:terminationGracePeriodSeconds":{},` +
+		`"f:tolerations":{},"f:topologySpreadConstraints":{},"f:volumes":{".":{},` +
+		`"k:{\"name\":\"data\"}":{".":{},"f:name":{},"f:emptyDir":{}}}}}`)
+	status := []byte(`{"f:status":{"f:conditions":{"k:{\"type\":\"ContainersReady\"}":` +
+		`{".":{},"f:lastProbeTime":{},"f:lastTransitionTime":{},"f:status":{},"f:type":{}},` +
+		`"k:{\"type\":\"Initialized\"}":{".":{},"f:lastProbeTime":{},` +
+		`"f:lastTransitionTime":{},"f:status":{},"f:type":{}},` +
+		`"k:{\"type\":\"Ready\"}":{".":{},"f:lastProbeTime":{},` +
+		`"f:lastTransitionTime":{},"f:status":{},"f:type":{}}},` +
+		`"f:containerStatuses":{},"f:hostIP":{},"f:phase":{},"f:podIP":{},` +
+		`"f:podIPs":{".":{},"k:{\"ip\":\"10.42.1.37\"}":{".":{},"f:ip":{}}},` +
+		`"f:startTime":{}}}`)
+	return []metav1.ManagedFieldsEntry{
+		{
+			Manager:    "kube-controller-manager",
+			Operation:  metav1.ManagedFieldsOperationUpdate,
+			APIVersion: "v1",
+			Time:       ptrTime(time.Unix(1700000000, 0)),
+			FieldsType: "FieldsV1",
+			FieldsV1:   &metav1.FieldsV1{Raw: spec},
+		},
+		{
+			Manager:     "kubelet",
+			Operation:   metav1.ManagedFieldsOperationUpdate,
+			APIVersion:  "v1",
+			Time:        ptrTime(time.Unix(1700000100, 0)),
+			FieldsType:  "FieldsV1",
+			FieldsV1:    &metav1.FieldsV1{Raw: status},
+			Subresource: "status",
+		},
+	}
+}
+
+func ptrTime(t time.Time) *metav1.Time {
+	mt := metav1.NewTime(t)
+	return &mt
+}

--- a/internal/executor/cluster.go
+++ b/internal/executor/cluster.go
@@ -30,6 +30,14 @@ type Cluster interface {
 	// drain must leave the node usable, since evicted pods cannot be un-evicted.
 	Uncordon(ctx context.Context, node string) error
 
+	// PodPresent reports whether one pod still exists and is not terminating.
+	//
+	// Narrow on purpose. The drain loop asks this every couple of seconds per
+	// evicted pod, and answering it from a full cluster snapshot meant listing
+	// every pod in the cluster to learn about one — which on a large cluster
+	// cost more than the drain itself.
+	PodPresent(ctx context.Context, namespace, name string) (bool, error)
+
 	// Evict requests voluntary eviction through the policy/v1 eviction API,
 	// which is what makes the API server enforce PodDisruptionBudgets. A plain
 	// pod delete would bypass them entirely — the single most important

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -330,14 +330,18 @@ func (e *Executor) drain(ctx context.Context, run store.Run, step model.PlanStep
 }
 
 // waitGone blocks until the pod has left the API server's view.
+//
+// Asks about the one pod rather than reading the cluster. This used to take a
+// full snapshot on every tick — every pod in the cluster, every two seconds,
+// to answer a question about a single object.
 func (e *Executor) waitGone(ctx context.Context, pod model.Pod) error {
 	deadline := time.Now().Add(e.opts.SettleTimeout)
 	for {
-		live, err := e.cluster.Snapshot(ctx)
+		present, err := e.cluster.PodPresent(ctx, pod.Namespace, pod.Name)
 		if err != nil {
-			return fmt.Errorf("read cluster state: %w", err)
+			return fmt.Errorf("check %s: %w", pod.Key(), err)
 		}
-		if p, ok := findPod(live, pod.Namespace, pod.Name); !ok || p.Terminating {
+		if !present {
 			return nil
 		}
 		if time.Now().After(deadline) {

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -117,6 +117,17 @@ func (f *fakeCluster) Evict(_ context.Context, namespace, name string) error {
 	return nil
 }
 
+func (f *fakeCluster) PodPresent(_ context.Context, namespace, name string) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, p := range f.snap.Pods {
+		if p.Namespace == namespace && p.Name == name {
+			return !p.Terminating, nil
+		}
+	}
+	return false, nil
+}
+
 func (f *fakeCluster) someOtherSchedulableNode(exclude string) string {
 	for _, n := range f.snap.Nodes {
 		if n.Name != exclude && !n.Unschedulable && n.Ready {

--- a/internal/executor/k8s.go
+++ b/internal/executor/k8s.go
@@ -32,6 +32,11 @@ func (k *K8sCluster) Snapshot(ctx context.Context) (*model.ClusterSnapshot, erro
 	return k.reader.Snapshot(ctx)
 }
 
+// PodPresent reports whether one pod still exists and is not terminating.
+func (k *K8sCluster) PodPresent(ctx context.Context, namespace, name string) (bool, error) {
+	return k.reader.PodPresent(ctx, namespace, name)
+}
+
 // Cordon marks a node unschedulable.
 func (k *K8sCluster) Cordon(ctx context.Context, node string) error {
 	return k.setUnschedulable(ctx, node, true)

--- a/internal/planner/scale_bench_test.go
+++ b/internal/planner/scale_bench_test.go
@@ -167,7 +167,6 @@ func BenchmarkScaleStoreSave(b *testing.B) {
 			}
 
 			b.ReportAllocs()
-			b.ReportMetric(float64(len(snapJSON)+len(analysisJSON))/1024/1024, "MB/row")
 
 			n := 0
 			for b.Loop() {
@@ -182,6 +181,21 @@ func BenchmarkScaleStoreSave(b *testing.B) {
 					b.Fatal(err)
 				}
 			}
+
+			// Report what is actually on disk, not the JSON that went in. Since
+			// M17 the blobs are gzipped, and a metric that kept reporting the
+			// uncompressed size would overstate retention by an order of
+			// magnitude — the exact thing this benchmark exists to track.
+			var stored int64
+			row := db.QueryRowForTest(context.Background(),
+				`SELECT length(snapshot) + length(analysis) FROM plans WHERE id = ?`,
+				fmt.Sprintf("plan-%d", n))
+			if err := row.Scan(&stored); err != nil {
+				b.Fatal(err)
+			}
+			raw := len(snapJSON) + len(analysisJSON)
+			b.ReportMetric(float64(stored)/1024/1024, "MB/row")
+			b.ReportMetric(float64(raw)/float64(stored), "compression")
 		})
 	}
 }

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -11,6 +11,8 @@
 package sqlite
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"database/sql"
 	"encoding/json"
@@ -206,11 +208,11 @@ func (s *Store) Save(ctx context.Context, rec store.Record) (bool, error) {
 		return false, nil
 	}
 
-	snapshotJSON, err := json.Marshal(rec.Snapshot)
+	snapshotJSON, err := encodeBlob(rec.Snapshot)
 	if err != nil {
 		return false, fmt.Errorf("encode snapshot: %w", err)
 	}
-	analysisJSON, err := json.Marshal(rec.Analysis)
+	analysisJSON, err := encodeBlob(rec.Analysis)
 	if err != nil {
 		return false, fmt.Errorf("encode analysis: %w", err)
 	}
@@ -325,10 +327,10 @@ func (s *Store) ByID(ctx context.Context, id string) (store.Record, error) {
 	}
 	rec.StoredAt = parseTime(storedAt)
 
-	if err := json.Unmarshal(snapshotJSON, &rec.Snapshot); err != nil {
+	if err := decodeBlob(snapshotJSON, &rec.Snapshot); err != nil {
 		return store.Record{}, fmt.Errorf("decode snapshot: %w", err)
 	}
-	if err := json.Unmarshal(analysisJSON, &rec.Analysis); err != nil {
+	if err := decodeBlob(analysisJSON, &rec.Analysis); err != nil {
 		return store.Record{}, fmt.Errorf("decode analysis: %w", err)
 	}
 
@@ -471,3 +473,61 @@ func boolToInt(b bool) int {
 
 // compile-time check
 var _ store.Store = (*Store)(nil)
+
+// Snapshot and analysis blobs are gzipped.
+//
+// They are the bulk of a plan row — a 5,000-pod snapshot is 1.6 MB of JSON,
+// written on every plan change and retained. Pod specs compress about 13x
+// because the field names repeat on every object, so this is close to free
+// space back for a little CPU on a path that runs at most once per resync.
+//
+// BestSpeed rather than BestCompression: the difference in ratio is small and
+// the planner should not spend its cycle here.
+func encodeBlob(v any) ([]byte, error) {
+	raw, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	zw, err := gzip.NewWriterLevel(&buf, gzip.BestSpeed)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := zw.Write(raw); err != nil {
+		return nil, err
+	}
+	if err := zw.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// decodeBlob reads a blob written by encodeBlob, or a plain JSON one.
+//
+// Rows written before compression are still readable: gzip has a two-byte
+// magic number, so the format is self-describing and no migration is needed.
+// A schema bump would have meant rewriting every historical row, and plan
+// history is an audit trail worth not rewriting.
+func decodeBlob(data []byte, into any) error {
+	if len(data) >= 2 && data[0] == 0x1f && data[1] == 0x8b {
+		zr, err := gzip.NewReader(bytes.NewReader(data))
+		if err != nil {
+			return err
+		}
+		defer func() { _ = zr.Close() }()
+		return json.NewDecoder(zr).Decode(into)
+	}
+	return json.Unmarshal(data, into)
+}
+
+// ExecForTest runs a statement directly. Test-only: it exists so a test can
+// forge a pre-compression row and prove it is still readable.
+func (s *Store) ExecForTest(ctx context.Context, query string, args ...any) error {
+	_, err := s.db.ExecContext(ctx, query, args...)
+	return err
+}
+
+// QueryRowForTest reads one row directly. Test-only.
+func (s *Store) QueryRowForTest(ctx context.Context, query string, args ...any) *sql.Row {
+	return s.db.QueryRowContext(ctx, query, args...)
+}

--- a/internal/store/sqlite/sqlite_test.go
+++ b/internal/store/sqlite/sqlite_test.go
@@ -2,6 +2,7 @@ package sqlite_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"path/filepath"
@@ -341,5 +342,75 @@ func TestReconfirmingAPlanRefreshesStoredAt(t *testing.T) {
 	}
 	if age := time.Since(got.StoredAt); age > time.Minute {
 		t.Errorf("storedAt is %s old after re-confirmation; it should be fresh", age.Round(time.Second))
+	}
+}
+
+// Rows written before compression must still be readable.
+//
+// gzip has a two-byte magic number, so the blob format is self-describing and
+// no migration is needed. That matters more here than usual: plan history is
+// an audit trail, and a schema bump would have meant rewriting every
+// historical row to read it back.
+func TestUncompressedRowsAreStillReadable(t *testing.T) {
+	db := openTemp(t)
+	ctx := context.Background()
+
+	rec := record("legacy-plan", step(1, "a", model.ImpactGreen))
+	if _, err := db.Save(ctx, rec); err != nil {
+		t.Fatal(err)
+	}
+
+	// Rewrite the blobs as plain JSON, exactly as a pre-compression build did.
+	snapJSON, err := json.Marshal(rec.Snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	analysisJSON, err := json.Marshal(rec.Analysis)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.ExecForTest(ctx,
+		`UPDATE plans SET snapshot = ?, analysis = ? WHERE id = ?`,
+		snapJSON, analysisJSON, "legacy-plan"); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := db.ByID(ctx, "legacy-plan")
+	if err != nil {
+		t.Fatalf("a plain-JSON row became unreadable: %v", err)
+	}
+	if got.Snapshot == nil || len(got.Snapshot.Nodes) != len(rec.Snapshot.Nodes) {
+		t.Errorf("snapshot did not survive: %+v", got.Snapshot)
+	}
+}
+
+// Compression must not change what a caller sees.
+func TestCompressionRoundTripsExactly(t *testing.T) {
+	db := openTemp(t)
+	ctx := context.Background()
+
+	rec := record("plan-rt", step(1, "a", model.ImpactGreen))
+	if _, err := db.Save(ctx, rec); err != nil {
+		t.Fatal(err)
+	}
+	got, err := db.ByID(ctx, "plan-rt")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want, _ := json.Marshal(rec.Snapshot)
+	back, _ := json.Marshal(got.Snapshot)
+	if string(want) != string(back) {
+		t.Errorf("snapshot changed through storage:\n want %s\n got  %s", want, back)
+	}
+
+	// And the stored bytes really are compressed.
+	var size int
+	if err := db.QueryRowForTest(ctx,
+		`SELECT length(snapshot) FROM plans WHERE id = ?`, "plan-rt").Scan(&size); err != nil {
+		t.Fatal(err)
+	}
+	if size >= len(want) {
+		t.Errorf("stored blob is %d bytes against %d of JSON; it is not compressed", size, len(want))
 	}
 }


### PR DESCRIPTION
Phase 4, M17 — data volume. M18 made the planner fast enough; this is what it costs to *hold* that cluster in memory and *keep* its plans on disk.

## Stored plans are gzipped

| Pods | JSON in | On disk | Ratio | `Save` time |
|---|---|---|---|---|
| 119 | 0.10 MB | 5.3 KB | 19.1× | 1.5 ms |
| 916 | 1.00 MB | 54 KB | 19.2× | 4.7 ms |
| 2,526 | 4.44 MB | 197 KB | 23.1× | 18 ms |
| 5,026 | 14.1 MB | **609 KB** | **23.8×** | 54 ms |

Self-describing via the gzip magic bytes, so no migration was needed and rows written by earlier builds still read back — there's a test that forges a plain-JSON row to prove it.

Compressing costs nothing at the sizes that matter: `Save` is slower at 119 pods (0.74 → 1.5 ms) and *faster* from 2,526 up (29 → 18 ms), because writing 20× fewer bytes to SQLite more than pays for the gzip.

`BenchmarkScaleStoreSave` now reports bytes actually on disk rather than marshalled JSON length — which after this change would have overstated retention by ~20×, the exact quantity it exists to track.

## The informer cache is transformed on the way in

Managed fields, pod annotations and container statuses are discarded before anything is cached.

| | Heap per pod | 50,000 pods |
|---|---|---|
| Untransformed | 9,183 B | 459 MB |
| Transformed | 6,423 B | **321 MB** |

**The number had to be calibrated, not assumed.** A first pass measured 2 B of managed fields per pod and made the transform look worthless — `kubectl` hides the section unless you pass `--show-managed-fields`. With it, kubelet-run pods on the dev cluster carry a mean 3,505 B, about 40% of the serialised object.

### How it's guarded

The risk in a transform is stripping something the converter reads. Rather than maintain a list of fields, `transform_test.go` asserts the property: convert an object, transform it, convert it again, require the two domain objects to be identical. A field added to `convert.go` that the transform strips fails on the next run without anyone remembering to update anything.

Three mutations were run against it — stripping node annotations, pod conditions, pod labels — and each fails the test. Node annotations are deliberately kept: `convertNode` reads them, and the KWOK fabric marks fake nodes with one.

### Verified end to end, not by argument

Against the live 31-node fabric the planner emits byte-identical `snapshot`, `constraints` and `plan` lines before and after — including plan id `283ba43a9d15`, which is a content hash and could not match if the transform had changed what the planner sees.

## Reads are paginated

Every List pages at 500. The drain loop's "has this pod gone yet" poll — which listed every pod in the cluster every two seconds to ask about one — is now a single Get.

## Also

Adds the **M18** row the README never got, and splits Phase 4 out of the Phase 3 table where M15 and M16 had been sitting.

## Verification

`go test ./...` green · `make lint` all chart contract checks pass · `make bench` numbers in [docs/benchmarks.md](docs/benchmarks.md) · deployed to the live fabric and diffed against the pre-change planner output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)