### PR TITLE
M20: publish metrics, run the gates, make the chart installable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,109 @@
+# Every gate this repo relies on, run by a machine instead of by whoever
+# remembered.
+#
+# Most of the project's safety story is "there is a test that fails if you
+# break it": the palette guards that keep the risk scale colour-blind-safe, the
+# ast check that no API route escapes authorization, the assertion that the
+# executor alone holds pods/eviction, the transform test that the informer
+# cache cannot drop a field the planner reads. None of those protected anything
+# until this file existed, because nothing ran them.
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  # So a scheduled run catches breakage from the outside world — a new
+  # Kubernetes schema, a yanked dependency — rather than the next contributor.
+  schedule:
+    - cron: "17 6 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  go:
+    name: go test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: vet
+        run: go vet ./...
+
+      - name: test
+        # -race because the planner, executor and HTTP servers all run
+        # concurrently in production and the tests exercise that.
+        run: go test -race -count=1 ./...
+
+      - name: gofmt
+        run: |
+          unformatted="$(gofmt -l . | grep -v '^ui/' || true)"
+          if [ -n "$unformatted" ]; then
+            echo "::error::gofmt would change these files:"
+            echo "$unformatted"
+            exit 1
+          fi
+
+  chart:
+    name: chart contract
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - uses: azure/setup-helm@v4
+
+      # hack/lint-chart.sh reads telemetry.MetricsPath out of the Go source and
+      # asserts the rendered templates agree, so this job needs the whole repo,
+      # not just charts/.
+      - name: lint
+        run: make lint
+
+  ui:
+    name: ui typecheck and build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ui
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: ui/package-lock.json
+
+      - run: npm ci
+      - run: npm run typecheck
+      # A build failure is a real failure: the frontend ships as a static
+      # bundle, so anything tsc lets through still has to survive Vite.
+      - run: npm run build
+
+  bench:
+    name: benchmarks compile and run
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      # Not a performance gate. A shared runner's timings are far too noisy to
+      # assert against, and a flaky red build teaches people to ignore CI.
+      # What this catches is the benchmarks silently rotting — the numbers in
+      # docs/benchmarks.md are load-bearing for Phase 4 decisions, and they are
+      # worthless if nobody can reproduce them.
+      - name: run benchmarks once
+        run: go test ./internal/planner/ -run '^$' -bench . -benchtime 1x -timeout 20m

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,113 @@
+# Publishes the four images and the chart.
+#
+# Until this existed the chart defaulted to ghcr.io/atedgimo/k8s-dencer-* and
+# nothing had ever pushed there, so `helm install` could not work for anyone —
+# the chart advertised images that did not exist. `make images-release` builds
+# multi-arch but deliberately does not push, because credentials belong here
+# rather than on a laptop.
+name: release
+
+on:
+  push:
+    tags: ["v*"]
+  # Publishing is destructive in the sense that a tag's images should never
+  # change under it, so this is never automatic on a branch.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to publish (e.g. v0.1.0). Must already exist."
+        required: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  images:
+    name: build and push images
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - component: planner
+            dockerfile: build/go.Dockerfile
+          - component: ui-backend
+            dockerfile: build/go.Dockerfile
+          - component: executor
+            dockerfile: build/go.Dockerfile
+          - component: ui-frontend
+            dockerfile: build/ui.Dockerfile
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+
+      - name: derive version
+        id: v
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          # arm64 is not optional: the whole project is developed on Apple
+          # silicon, and an amd64-only image would fail to run on the machine
+          # it was built for.
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            COMPONENT=${{ matrix.component }}
+            VERSION=${{ steps.v.outputs.version }}
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/k8s-dencer-${{ matrix.component }}:${{ steps.v.outputs.version }}
+            ghcr.io/${{ github.repository_owner }}/k8s-dencer-${{ matrix.component }}:latest
+          provenance: true
+          sbom: true
+
+  chart:
+    name: publish chart
+    needs: images
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+      - uses: azure/setup-helm@v4
+
+      - name: derive version
+        id: v
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      # The chart's appVersion is what selects the image tag, so a chart
+      # published with a stale appVersion would install images from a previous
+      # release without saying so.
+      - name: chart version matches the tag
+        run: |
+          chart_app="$(grep '^appVersion:' charts/k8s-dencer/Chart.yaml | tr -d '"' | awk '{print $2}')"
+          chart_ver="$(grep '^version:' charts/k8s-dencer/Chart.yaml | awk '{print $2}')"
+          want="${{ steps.v.outputs.version }}"
+          if [ "$chart_app" != "$want" ] || [ "$chart_ver" != "$want" ]; then
+            echo "::error::tag is $want but Chart.yaml has version=$chart_ver appVersion=$chart_app"
+            exit 1
+          fi
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: package and push
+        run: |
+          helm package charts/k8s-dencer -d dist
+          helm push dist/k8s-dencer-${{ steps.v.outputs.version }}.tgz \
+            oci://ghcr.io/${{ github.repository_owner }}/charts

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,8 @@ ui/dist/
 *.db
 *.sqlite
 .DS_Store
+
+# Stray binaries from `go build ./cmd/<x>` without -o.
+/planner
+/executor
+/ui-backend

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Moti Atedgi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # k8s-dencer
 
+[![ci](https://github.com/atedgimo/k8s-dencer/actions/workflows/ci.yml/badge.svg)](https://github.com/atedgimo/k8s-dencer/actions/workflows/ci.yml)
+[![license: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+
 k8s-dencer continuously analyzes your Kubernetes cluster's constraints (PDBs, topology spread, affinity, taints) and builds a node consolidation plan — broken into discrete, impact-rated steps you can inspect and run on your own terms, on request or during a maintenance window. Nothing executes without explicit approval.
 
 **Execution is opt-in, gated, and off by default.** Set `executor.enabled=true` and a separate workload — its own image, its own ServiceAccount, no inbound network surface — becomes able to cordon and evict. Everything else stays read-only: `make lint` fails the build if `pods/eviction` appears on any role but the executor's, or in any profile that did not ask for one.
@@ -55,7 +58,7 @@ estimated — every milestone here starts from a number in
 | **M17** | Data volume — gzipped plan blobs (23.8× at 5k pods), informer cache transform (−30% heap), paginated reads | **done** |
 | **M18** | Planner cost — memoised topology-spread counts, **112×** faster analysis at 5k pods | **done** |
 | **M19** | UI at scale — density rendering, virtualised field, aggregated graph payload | planned |
-| **M20** | `/metrics` on all three components; honest `serviceMonitor`; published images | planned |
+| **M20** | `/metrics` on all three components; monitors that scrape a real path; CI; published images | **done** |
 | **M21** | Multi-node k3d, PodSecurity enforcing, real ingress and StorageClass | planned |
 
 High availability and a Postgres store were **dropped, not deferred**: a
@@ -74,12 +77,25 @@ The planner watches the cluster through informers and publishes an immutable
 `ClusterSnapshot` every resync period:
 
 ```
-snapshot:    nodes=31 nodesOccupied=29 pods=121 pdbs=0 pdbsBlocking=0
+snapshot:    nodes=31 nodesOccupied=28 pods=121 pdbs=0 pdbsBlocking=0
              cpuRequestedPct=38.6% memRequestedPct=19.6% usageData=false
 constraints: movable=120 blocked=1 stuck=26 antiAffinity=0 spreadBound=1
              controllerPinned=1 nodesUndrainable=1
-plan:        id=283ba43a9d15 steps=16 nodesBefore=29 nodesAfter=13 reclaims=16
-             green=12 yellow=1 red=3
+plan:        id=754f04015304 steps=15 nodesBefore=28 nodesAfter=13 reclaims=15
+             green=12 yellow=0 red=3
+```
+
+The same numbers are on `/metrics`, which is the point of it — nothing is
+derived twice:
+
+```
+dencer_plan_age_seconds 4.181680473
+dencer_plan_nodes_reclaimable 15
+dencer_plan_steps{impact="Green"} 12
+dencer_plan_steps{impact="Yellow"} 0
+dencer_plan_steps{impact="Red"} 3
+dencer_snapshot_nodes 31
+dencer_snapshot_pods 121
 ```
 
 Plans are rated, explained, persisted, visualised, and answerable in natural
@@ -126,12 +142,14 @@ internal/
   executor/        the ONLY package that mutates a cluster: cordon, evict, verify, abort
   store/           Store interface + SQLite implementation and migrations
   auth/            TokenReview authn + SubjectAccessReview authz; no credential store of our own
+  telemetry/       structured logger + the Prometheus series each component publishes
   api/             rest/ (+ SSE events), graph/ (Cytoscape payload), agenttools/ (MCP)
 ui/                React + Vite; packing field in plain DOM, bundled typefaces
 charts/k8s-dencer/ THE product deliverable — see Chart below
 demo/              POC only: KWOK values + the synthetic topology chart
 build/             Dockerfile.go (parameterised by COMPONENT) + Dockerfile.ui
 hack/              lint-chart.sh — the portability gate
+.github/workflows/ ci.yml (every gate, on every PR) + release.yml (images and chart)
 test/fixtures/     ClusterSnapshots captured from a live cluster for golden tests
 test/palette/      guards the CVD mitigation: glyph+word per rating, chroma only for risk
 test/ui/           guards that every request carries the token, and the token never leaves the tab
@@ -188,6 +206,10 @@ Runs `helm lint` and `kubeconform --strict` across every profile, then asserts t
 15. the consolidation-operator ClusterRole ships **unbound**
 16. a NetworkPolicy is present by default, and restricts ingress only
 17. `auth.oidc.enabled=true` without an issuer and client ID is rejected
+18. the monitors scrape **the path the code actually serves** — read out of `telemetry.MetricsPath`, not repeated in the chart
+19. every component the chart scrapes **registers the metrics handler** in its `main.go`
+20. scraping **does not give the executor a Service** — planner and executor stay reachable only as pods
+21. enabling `serviceMonitor` makes the NetworkPolicy **admit the monitoring namespace**, or the scrape is silently dropped
 
 ### Known constraints
 
@@ -806,11 +828,112 @@ Verified end to end: the agent calls the tool, receives the classifier's exact w
 
 ---
 
+## Observability
+
+Every component serves Prometheus metrics at `/metrics` on the port it already
+listens on. The path is a Go constant, `telemetry.MetricsPath`, and `make lint`
+reads it out of the source and fails if the chart's monitors disagree.
+
+That assertion exists because the chart used to ship a `ServiceMonitor`
+scraping `/metrics` when **no component served `/metrics` at all**. A monitor
+aimed at a 404 is worse than no monitor: it presents as a configured target
+that is merely failing.
+
+```bash
+helm upgrade --install ... --set serviceMonitor.enabled=true --set podMonitor.enabled=true
+```
+
+**A `PodMonitor` for planner and executor, a `ServiceMonitor` for ui-backend.**
+Not an inconsistency — the executor holds `pods/eviction` and deliberately has
+no Service, so that the component able to evict is unreachable over the
+network. Giving it one so Prometheus could discover it would spend a security
+property on a scrape target. A `PodMonitor` addresses pods directly and costs
+nothing. `make lint` asserts no Service is ever rendered for either.
+
+If `networkPolicy.enabled` and `serviceMonitor.enabled` are both on, the policy
+admits `monitoringNamespace` (default `monitoring`). Without that the scrape is
+dropped at the network layer and the target simply reads as down, with nothing
+in the chart to explain why — so that is asserted too.
+
+### What is published
+
+Each component registers only the series it actually writes. The planner does
+not publish eviction metrics: a permanent zero would read as "evictions are
+fast" when the truth is that the process has never performed one. A missing
+series is a question; a series pinned at zero is a wrong answer.
+
+**Planner** — `dencer_plan_age_seconds`, `dencer_plan_steps{impact}`,
+`dencer_plan_nodes_reclaimable`, `dencer_snapshot_nodes`,
+`dencer_snapshot_pods`, `dencer_plan_cycle_seconds`,
+`dencer_snapshot_failures_total`
+
+**Executor** — `dencer_runs_total{status}`, `dencer_guard_refusals_total{rule}`,
+`dencer_eviction_duration_seconds`, `dencer_evictions_total{outcome}`,
+`dencer_nodes_drained_total`, `dencer_recovery_wait_seconds`
+
+**ui-backend** — Go runtime and process series only. It holds the SQLite writer,
+so heap and file descriptors are what an operator would look at; request
+counters are not there because no one has asked a question that needs them.
+
+Three properties are worth calling out, because each is a way this could have
+been quietly useless:
+
+- **Plan age is computed when scraped, not written by the planning loop.** A
+  gauge the loop sets would freeze at its last value if the loop died —
+  reporting a fresh plan at exactly the moment there is none. It reads `-1`
+  before the first plan, so a startup gap is distinguishable from a stall.
+- **Every impact rating is set explicitly, including the zeroes.** An unset
+  label vanishes from the scrape, and a missing series graphs as a gap rather
+  than as "no Red steps".
+- **A test parses the `Metrics` struct and fails on any field nothing writes.**
+  A metric with no writer scrapes as zero, and zero is indistinguishable from
+  healthy.
+
+---
+
+## Continuous integration
+
+`.github/workflows/ci.yml` runs on every push and pull request: `go vet`,
+`go test -race`, `gofmt`, `make lint`, the UI typecheck and build, and the
+benchmarks once through.
+
+Worth being blunt about why this arrived at M20 rather than M0. Much of this
+project's safety story is "there is a test that fails if you break it" — the
+palette guards that keep the risk scale colour-blind-safe, the ast check that no
+API route escapes authorization, the assertion that only the executor holds
+`pods/eviction`, the transform test that the informer cache cannot drop a field
+the planner reads. **None of those protected anything until CI existed**, because
+nothing ran them except whoever remembered to.
+
+The benchmark job is not a performance gate. A shared runner's timings are far
+too noisy to assert against, and a flaky red build teaches people to ignore CI.
+It catches the benchmarks rotting: the numbers in
+[docs/benchmarks.md](docs/benchmarks.md) drive Phase 4 decisions and are
+worthless if nobody can reproduce them.
+
+## Releases
+
+`.github/workflows/release.yml` publishes on a `v*` tag: four multi-arch images
+(`linux/amd64,linux/arm64`, with provenance and SBOM) to
+`ghcr.io/atedgimo/k8s-dencer-*`, then the packaged chart to
+`oci://ghcr.io/atedgimo/charts`.
+
+Until this existed the chart defaulted to those image references and nothing had
+ever pushed to them, so `helm install` could not work for anyone. The release
+job refuses to publish if `Chart.yaml`'s `version` and `appVersion` do not match
+the tag — `appVersion` selects the image tag, so a stale one would install a
+previous release's images without saying so.
+
+arm64 is not optional: the project is developed on Apple silicon, and an
+amd64-only image would fail to run on the machine that built it.
+
+---
+
 ## Development
 
 ```bash
 make build          # compile Go
-make test           # go vet + go test + UI typecheck
+make test           # go vet + go test + UI typecheck (CI adds -race)
 make images         # native-arch images for the local cluster
 make images-release # multi-arch linux/amd64,linux/arm64
 make deploy         # helm upgrade --install with the provider overlay
@@ -829,3 +952,9 @@ make logs           # tail the planner
 ```bash
 make demo CLUSTER_PROVIDER=k3d
 ```
+
+---
+
+## License
+
+[MIT](LICENSE).

--- a/charts/k8s-dencer/Chart.yaml
+++ b/charts/k8s-dencer/Chart.yaml
@@ -29,3 +29,13 @@ keywords:
 maintainers:
   - name: Moti Atedgi
     email: atedgimo@gmail.com
+
+annotations:
+  # Artifact Hub reads these. The licence is declared here as well as in
+  # LICENSE so it survives `helm pull` of the packaged chart.
+  artifacthub.io/license: MIT
+  artifacthub.io/links: |
+    - name: source
+      url: https://github.com/atedgimo/k8s-dencer
+    - name: benchmarks
+      url: https://github.com/atedgimo/k8s-dencer/blob/main/docs/benchmarks.md

--- a/charts/k8s-dencer/templates/executor/deployment.yaml
+++ b/charts/k8s-dencer/templates/executor/deployment.yaml
@@ -93,7 +93,8 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           ports:
-            # Probes only. There is no API on this port.
+            # Probes and /metrics. There is no API on this port, and the
+            # executor has no Service: it is scraped via PodMonitor.
             - name: probe
               containerPort: {{ .Values.executor.probePort }}
               protocol: TCP

--- a/charts/k8s-dencer/templates/networkpolicy.yaml
+++ b/charts/k8s-dencer/templates/networkpolicy.yaml
@@ -1,8 +1,9 @@
 {{- if .Values.networkPolicy.enabled }}
 {{/*
 Restricts who may reach ui-backend. The frontend always may; Kagent may when
-the integration is on, since the agent calls the MCP endpoint directly.
-Anything else must be listed in networkPolicy.extraIngressFrom.
+the integration is on, since the agent calls the MCP endpoint directly, and
+Prometheus may when serviceMonitor is on. Anything else must be listed in
+networkPolicy.extraIngressFrom.
 */}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -26,6 +27,15 @@ spec:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: {{ include "k8s-dencer.kagentNamespace" . }}
+        {{- end }}
+        {{- if .Values.serviceMonitor.enabled }}
+        {{/*
+        Prometheus must be admitted explicitly or the scrape is dropped here
+        and the target reads as down, with nothing in the chart to explain why.
+        */}}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.monitoringNamespace }}
         {{- end }}
         {{- with .Values.networkPolicy.extraIngressFrom }}
         {{- toYaml . | nindent 8 }}

--- a/charts/k8s-dencer/templates/podmonitor.yaml
+++ b/charts/k8s-dencer/templates/podmonitor.yaml
@@ -1,0 +1,57 @@
+{{- if .Values.podMonitor.enabled }}
+{{/*
+Planner and executor are scraped as pods, not through a Service.
+
+Neither has one, and that is a security property rather than an oversight: the
+executor holds pods/eviction, and the architecture keeps it unreachable from
+the network. Adding a Service so Prometheus could discover it would spend that
+property on observability. A PodMonitor does not need one.
+
+Requires the Prometheus Operator CRDs, like the ServiceMonitor.
+*/}}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "k8s-dencer.fullname" . }}-planner
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "k8s-dencer.componentLabels" (dict "ctx" . "component" "planner") | nindent 4 }}
+    {{- with .Values.podMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "k8s-dencer.componentSelectorLabels" (dict "ctx" . "component" "planner") | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  podMetricsEndpoints:
+    - port: health
+      path: /metrics
+      interval: {{ .Values.podMonitor.interval }}
+      scrapeTimeout: {{ .Values.podMonitor.scrapeTimeout }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "k8s-dencer.fullname" . }}-executor
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "k8s-dencer.componentLabels" (dict "ctx" . "component" "executor") | nindent 4 }}
+    {{- with .Values.podMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "k8s-dencer.componentSelectorLabels" (dict "ctx" . "component" "executor") | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  podMetricsEndpoints:
+    - port: probe
+      path: /metrics
+      interval: {{ .Values.podMonitor.interval }}
+      scrapeTimeout: {{ .Values.podMonitor.scrapeTimeout }}
+{{- end }}

--- a/charts/k8s-dencer/values.yaml
+++ b/charts/k8s-dencer/values.yaml
@@ -437,12 +437,39 @@ auth:
   # a fifth ever appears.
   mcpRequireToken: false
 
+# Observability. Every component serves Prometheus metrics on its existing HTTP
+# port at a fixed path — see telemetry.MetricsPath in the Go source, which
+# hack/lint-chart.sh asserts is the same string used below. A monitor pointing
+# at a path the code does not serve is worse than no monitor: it reports a
+# healthy scrape target that returns 404s.
 serviceMonitor:
+  # Scrapes ui-backend, the only component with a Service.
   # Requires the Prometheus Operator CRDs.
   enabled: false
   interval: 30s
   scrapeTimeout: 10s
   labels: {}
+
+podMonitor:
+  # Scrapes planner and executor.
+  #
+  # A PodMonitor rather than a Service, deliberately. The privilege split holds
+  # that the component reachable over the network cannot evict, and the one
+  # that can evict has no Service at all. Giving the executor a Service so
+  # Prometheus could find it would trade that property for a scrape target;
+  # a PodMonitor addresses pods directly and costs nothing.
+  enabled: false
+  interval: 30s
+  scrapeTimeout: 10s
+  labels: {}
+
+# Namespace Prometheus runs in.
+#
+# Load-bearing when networkPolicy.enabled and serviceMonitor.enabled are both
+# on: the ui-backend policy admits only the frontend and Kagent, so without
+# this the scrape is dropped at the network layer and the target simply reads
+# as down. Ignored when either is off.
+monitoringNamespace: monitoring
 
 # Kagent integration. Off by default so the chart installs on clusters that do
 # not have the kagent.dev CRDs.

--- a/cmd/executor/main.go
+++ b/cmd/executor/main.go
@@ -88,6 +88,7 @@ func run(ctx context.Context, log *slog.Logger) error {
 	}
 	go windows.Run(ctx, duration(log, "WINDOW_SYNC_INTERVAL", 30*time.Second))
 
+	metrics := telemetry.NewMetrics(telemetry.ComponentExecutor)
 	exec := executor.New(executor.NewK8sCluster(reader), db, db, log, executor.Options{
 		Worker:        env("POD_NAME", "executor"),
 		Limits:        limits,
@@ -96,11 +97,13 @@ func run(ctx context.Context, log *slog.Logger) error {
 		PollInterval:  duration(log, "CLUSTER_POLL_INTERVAL", 2*time.Second),
 		Windows:       windows,
 		Readiness:     executor.Readiness(env("EXECUTOR_READINESS", string(executor.ReadinessReady))),
+		Metrics:       metrics,
 	})
 
 	health := &httpserver.Health{}
 	mux := http.NewServeMux()
 	health.Register(mux)
+	metrics.Register(mux)
 	health.SetReady(true)
 
 	log.Info("starting", "version", version, "worker", env("POD_NAME", "executor"),

--- a/cmd/planner/main.go
+++ b/cmd/planner/main.go
@@ -100,8 +100,10 @@ func run(ctx context.Context, log *slog.Logger) error {
 	})
 
 	health := &httpserver.Health{}
+	metrics := telemetry.NewMetrics(telemetry.ComponentPlanner)
 	mux := http.NewServeMux()
 	health.Register(mux)
+	metrics.Register(mux)
 	mux.HandleFunc("GET /debug/snapshot", yamlHandler(func() any {
 		if v := latest.Load(); v != nil {
 			return v
@@ -143,7 +145,7 @@ func run(ctx context.Context, log *slog.Logger) error {
 	ticker := time.NewTicker(resync)
 	defer ticker.Stop()
 
-	collect(ctx, log, collector, &latest, &latestAnalysis, &latestPlan, strategy, planOpts, classifier, db, retain)
+	collect(ctx, log, collector, &latest, &latestAnalysis, &latestPlan, strategy, planOpts, classifier, db, retain, metrics)
 
 	for {
 		select {
@@ -154,7 +156,7 @@ func run(ctx context.Context, log *slog.Logger) error {
 		case err := <-serveErr:
 			return err
 		case <-ticker.C:
-			collect(ctx, log, collector, &latest, &latestAnalysis, &latestPlan, strategy, planOpts, classifier, db, retain)
+			collect(ctx, log, collector, &latest, &latestAnalysis, &latestPlan, strategy, planOpts, classifier, db, retain, metrics)
 		}
 	}
 }
@@ -171,10 +173,14 @@ func collect(
 	classifier impact.Classifier,
 	db store.Store,
 	retain int,
+	m *telemetry.Metrics,
 ) {
+	cycleStart := time.Now()
+
 	snap, err := c.Snapshot(ctx)
 	if err != nil {
 		log.Error("snapshot failed", "error", err)
+		m.SnapshotFailure.Inc()
 		return
 	}
 	latest.Store(snap)
@@ -207,6 +213,8 @@ func collect(
 		"podSlotsUsedPct", pct(pods),
 		"usageData", snap.HasUsageData,
 	)
+	m.SnapshotNodes.Set(float64(len(snap.Nodes)))
+	m.SnapshotPods.Set(float64(len(snap.Pods)))
 
 	analysis := constraints.Analyze(snap)
 	latestAnalysis.Store(analysis)
@@ -252,6 +260,17 @@ func collect(
 		"yellow", byRating[model.ImpactYellow],
 		"red", byRating[model.ImpactRed],
 	)
+
+	// Set every rating explicitly, including the zeroes. Leaving a label unset
+	// makes the series vanish from the scrape, and a missing series reads as a
+	// gap in a graph rather than as "no Red steps" — the opposite of the
+	// reassurance it should give.
+	for _, r := range []model.ImpactRating{model.ImpactGreen, model.ImpactYellow, model.ImpactRed} {
+		m.PlanSteps.WithLabelValues(string(r)).Set(float64(byRating[r]))
+	}
+	m.NodesReclaimed.Set(float64(plan.ReclaimedNodes()))
+	m.PlanProduced(time.Now())
+	m.PlanCycleTime.Observe(time.Since(cycleStart).Seconds())
 
 	stored, err := db.Save(ctx, store.Record{
 		Plan:     plan,

--- a/cmd/ui-backend/main.go
+++ b/cmd/ui-backend/main.go
@@ -93,6 +93,7 @@ func run(ctx context.Context, log *slog.Logger) error {
 	health := &httpserver.Health{}
 	mux := http.NewServeMux()
 	health.Register(mux)
+	telemetry.NewMetrics(telemetry.ComponentUIBackend).Register(mux)
 	api.Routes(mux)
 
 	// The Kagent agent reaches the same plan store over MCP. It is mounted on

--- a/hack/lint-chart.sh
+++ b/hack/lint-chart.sh
@@ -282,5 +282,78 @@ if tar -tzf "$tmp"/*.tgz | grep -q '/ci/'; then
 fi
 green "  ci/ excluded from the package"
 
+bold "==> contract: monitors scrape a path the code actually serves"
+# The original sin this replaces: the chart shipped a ServiceMonitor pointing
+# at /metrics when no component served /metrics at all. A monitor aimed at a
+# 404 is worse than none — it presents as a configured, failing target.
+#
+# So the path is taken from the Go source rather than repeated here, and the
+# rendered templates are required to agree with it.
+go_path="$(grep -oE 'MetricsPath = "[^"]+"' internal/telemetry/metrics.go | head -1 | sed 's/.*"\(.*\)"/\1/')"
+if [ -z "$go_path" ]; then
+  fail "could not read telemetry.MetricsPath from the Go source"
+fi
+for kind in serviceMonitor podMonitor; do
+  # Scoped to the monitor documents: the Ingress also has a "path:" key, and
+  # matching it would compare the chart's code against the wrong object.
+  rendered="$(helm template dencer "$CHART" --set "$kind.enabled=true" 2>/dev/null \
+    | awk '/^kind: (ServiceMonitor|PodMonitor)$/,/^---$/' \
+    | grep -E '^\s+path: ' | awk '{print $2}' | sort -u)"
+  if [ -z "$rendered" ]; then
+    fail "$kind rendered no scrape path"
+  fi
+  for p in $rendered; do
+    if [ "$p" != "$go_path" ]; then
+      fail "$kind scrapes '$p' but the code serves '$go_path'"
+    fi
+  done
+done
+green "  chart and code agree on $go_path"
+
+bold "==> contract: every component that is scraped serves metrics"
+# A monitor for a component whose binary never registers the endpoint would be
+# the same lie in a new place.
+for c in planner executor ui-backend; do
+  dir="cmd/${c}"
+  # Comment lines are stripped first: grep alone happily matches a
+  # commented-out registration, so the check would survive the very change it
+  # exists to catch.
+  # Must name metrics specifically: every component also calls
+  # health.Register(mux), and a looser pattern matches that instead and can
+  # never fail. Comments are stripped first for the same reason — grep alone
+  # is satisfied by a commented-out registration.
+  if ! sed 's|//.*||' "$dir/main.go" | grep -qE '[Mm]etrics(\([^)]*\))?\.Register\(mux\)'; then
+    fail "$c is scraped by the chart but never registers the metrics handler"
+  fi
+done
+green "  planner, executor and ui-backend all register it"
+
+bold "==> contract: scraping does not give the executor a Service"
+# The privilege split says the component holding pods/eviction is unreachable
+# through a Service. Observability is exactly the kind of good reason someone
+# would break that for, so it is asserted rather than trusted.
+svc_docs="$(helm template dencer "$CHART" --namespace k8s-dencer \
+  --set podMonitor.enabled=true --set serviceMonitor.enabled=true \
+  | awk '/^kind: Service$/,/^---/')"
+# Guard the guard: render errors would make the grep below pass on empty input,
+# which is how a check ends up unable to fail. ui-backend has a Service, so
+# finding none means the render broke.
+if ! grep -q 'component: ui-backend' <<<"$svc_docs"; then
+  fail "no Services rendered at all; the check would have passed vacuously"
+fi
+if grep -qE 'component: (executor|planner)' <<<"$svc_docs"; then
+  fail "a Service was rendered for the executor or planner; use a PodMonitor instead"
+fi
+green "  planner and executor stay Service-less"
+
+bold "==> contract: NetworkPolicy admits the scraper it expects"
+# Enabling the ServiceMonitor while the policy blocks Prometheus produces a
+# target that is down for a reason nothing in the chart explains.
+if ! helm template dencer "$CHART" --set serviceMonitor.enabled=true \
+     | awk '/kind: NetworkPolicy/,/^---/' | grep -q 'kubernetes.io/metadata.name: monitoring'; then
+  fail "serviceMonitor is on but the NetworkPolicy does not admit monitoringNamespace"
+fi
+green "  monitoring namespace admitted when scraped"
+
 green "
 All chart contract checks passed."

--- a/internal/cluster/race_off_test.go
+++ b/internal/cluster/race_off_test.go
@@ -1,0 +1,5 @@
+//go:build !race
+
+package cluster
+
+const raceEnabled = false

--- a/internal/cluster/race_on_test.go
+++ b/internal/cluster/race_on_test.go
@@ -1,0 +1,8 @@
+//go:build race
+
+package cluster
+
+// The race detector adds its own per-object bookkeeping to the heap, so a
+// memory measurement taken under it describes the detector as much as the
+// code. The transform's heap saving is measured in a normal run instead.
+const raceEnabled = true

--- a/internal/cluster/transform_bench_test.go
+++ b/internal/cluster/transform_bench_test.go
@@ -15,6 +15,9 @@ func TestTransformHeapSaving(t *testing.T) {
 	if testing.Short() {
 		t.Skip("allocates ~100k pods")
 	}
+	if raceEnabled {
+		t.Skip("heap measurement is meaningless under the race detector")
+	}
 	const n = 50000
 
 	measure := func(transform bool) uint64 {

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -29,6 +29,7 @@ import (
 	"github.com/atedgimo/k8s-dencer/internal/model"
 	"github.com/atedgimo/k8s-dencer/internal/safety"
 	"github.com/atedgimo/k8s-dencer/internal/store"
+	"github.com/atedgimo/k8s-dencer/internal/telemetry"
 )
 
 // Options configure an executor.
@@ -39,6 +40,11 @@ type Options struct {
 
 	// Limits are the Safety Guard's rails.
 	Limits safety.Limits
+
+	// Metrics receives run outcomes, guard refusals and eviction timings.
+	// Defaults to a private set, so tests and callers that do not care can
+	// leave it nil.
+	Metrics *telemetry.Metrics
 
 	// StepTimeout bounds a single step end to end. Exceeding it aborts.
 	StepTimeout time.Duration
@@ -60,6 +66,12 @@ type Options struct {
 
 // withDefaults fills unset values with conservative ones.
 func (o Options) withDefaults() Options {
+	if o.Metrics == nil {
+		// A private set rather than nil checks at every call site. Tests get
+		// working counters they can assert on, and production always passes
+		// the real one.
+		o.Metrics = telemetry.NewMetrics(telemetry.ComponentExecutor)
+	}
 	if o.Worker == "" {
 		o.Worker = "executor"
 	}
@@ -88,6 +100,7 @@ type Executor struct {
 	guard   *safety.Guard
 	log     *slog.Logger
 	opts    Options
+	metrics *telemetry.Metrics
 }
 
 // New builds an executor.
@@ -104,6 +117,7 @@ func New(cluster Cluster, runs store.ExecutionStore, plans store.Store, log *slo
 		guard:   guard,
 		log:     log,
 		opts:    opts,
+		metrics: opts.Metrics,
 	}
 }
 
@@ -300,6 +314,7 @@ func (e *Executor) drain(ctx context.Context, run store.Run, step model.PlanStep
 			return err
 		}
 
+		evictStart := time.Now()
 		if err := e.cluster.Evict(ctx, pod.Namespace, pod.Name); err != nil {
 			// The API server can refuse on PDB grounds even when the
 			// pre-flight check passed — state can change between the two, and
@@ -307,9 +322,11 @@ func (e *Executor) drain(ctx context.Context, run store.Run, step model.PlanStep
 			// not a fault, so it is audited as one.
 			var blocked *safety.Blocked
 			if errors.As(err, &blocked) {
+				e.metrics.EvictionsTotal.WithLabelValues("blocked").Inc()
 				e.blocked(ctx, run, step, blocked)
 				return blocked
 			}
+			e.metrics.EvictionsTotal.WithLabelValues("error").Inc()
 			return fmt.Errorf("evict %s: %w", pod.Key(), err)
 		}
 		if k := ownerKey(pod); k != "" {
@@ -322,11 +339,24 @@ func (e *Executor) drain(ctx context.Context, run store.Run, step model.PlanStep
 		})
 
 		if err := e.waitGone(ctx, pod); err != nil {
+			e.metrics.EvictionsTotal.WithLabelValues("timeout").Inc()
 			return err
 		}
+		// Measured to the pod actually being gone, not to the API call
+		// returning. The call returns as soon as the eviction is accepted; the
+		// wait afterwards is where a long grace period or a slow shutdown
+		// shows up, and that is the part that stretches a drain.
+		e.metrics.EvictionDuration.Observe(time.Since(evictStart).Seconds())
+		e.metrics.EvictionsTotal.WithLabelValues("evicted").Inc()
 	}
 
-	return e.verifyRecovered(ctx, run, step, before, affected)
+	recoverStart := time.Now()
+	if err := e.verifyRecovered(ctx, run, step, before, affected); err != nil {
+		return err
+	}
+	e.metrics.RecoveryWaitSeconds.Observe(time.Since(recoverStart).Seconds())
+	e.metrics.NodesDrainedTotal.Inc()
+	return nil
 }
 
 // waitGone blocks until the pod has left the API server's view.
@@ -430,6 +460,7 @@ func (e *Executor) blocked(ctx context.Context, run store.Run, step model.PlanSt
 	if !errors.As(err, &b) {
 		return
 	}
+	e.metrics.GuardRefusalsTotal.WithLabelValues(string(b.Rule)).Inc()
 	e.event(ctx, run, store.RunEvent{
 		Step: step.SequenceNumber, Node: step.TargetNode, Level: store.EventBlocked,
 		Action: "Guard", Rule: string(b.Rule), Message: b.Reason,
@@ -443,6 +474,7 @@ func (e *Executor) fail(ctx context.Context, run store.Run, msg string) {
 
 func (e *Executor) finish(ctx context.Context, run store.Run, status store.RunStatus, summary string) {
 	e.log.Info("run finished", "run", run.ID, "status", status, "summary", summary)
+	e.metrics.RunsTotal.WithLabelValues(string(status)).Inc()
 	// Detached: a cancelled context must not leave a run stuck Running forever.
 	closeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 15*time.Second)
 	defer cancel()

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -1,0 +1,204 @@
+package telemetry
+
+import (
+	"net/http"
+	"sync/atomic"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+// Metrics is the set of series k8s-dencer publishes.
+//
+// The selection rule is "would an operator page on this", not "can we measure
+// it". Four things can go wrong in a way nobody would otherwise notice:
+//
+//   - the planner stops planning, and the UI keeps serving a stale plan that
+//     looks fine (PlanAge);
+//   - runs start failing, and nobody looks at the ledger (RunsTotal);
+//   - the guard starts refusing everything, which means the plan and the
+//     cluster have diverged (GuardRefusalsTotal);
+//   - evictions hang on a PDB, turning a drain into an indefinite wait
+//     (EvictionDuration).
+//
+// Everything here is wired to a real call site. A registered metric that
+// nothing ever updates is worse than no metric: it reads as zero, which is
+// indistinguishable from healthy.
+type Metrics struct {
+	registry *prometheus.Registry
+
+	// Planner.
+	//
+	// planStamp holds when the current plan was produced. Plan age is derived
+	// from it at scrape time rather than written into a gauge by the planning
+	// loop — a gauge the loop sets would freeze at its last value if the loop
+	// died, reporting a fresh plan precisely when there is none. The whole
+	// point of this series is to notice that the loop stopped.
+	planStamp       atomic.Int64
+	PlanSteps       *prometheus.GaugeVec
+	NodesReclaimed  prometheus.Gauge
+	SnapshotNodes   prometheus.Gauge
+	SnapshotPods    prometheus.Gauge
+	PlanCycleTime   prometheus.Histogram
+	SnapshotFailure prometheus.Counter
+
+	// Executor.
+	RunsTotal           *prometheus.CounterVec
+	GuardRefusalsTotal  *prometheus.CounterVec
+	EvictionDuration    prometheus.Histogram
+	EvictionsTotal      *prometheus.CounterVec
+	NodesDrainedTotal   prometheus.Counter
+	RecoveryWaitSeconds prometheus.Histogram
+}
+
+// Component names the process publishing metrics.
+//
+// Each one registers only the series it actually writes. Registering the whole
+// set everywhere would have the planner publish dencer_eviction_duration_seconds
+// as a permanent zero — the planner cannot evict — and an operator reading that
+// would see a component reporting healthy evictions it never performs. A series
+// that is absent is a question; a series pinned at zero is a wrong answer.
+type Component string
+
+const (
+	ComponentPlanner   Component = "planner"
+	ComponentExecutor  Component = "executor"
+	ComponentUIBackend Component = "ui-backend"
+)
+
+// NewMetrics builds the metric set against a private registry, registering the
+// series that belong to the given component.
+//
+// A private registry rather than prometheus.DefaultRegisterer: controller-runtime
+// registers its own workqueue and client-go series into the default one, and
+// exporting those by accident would make the scrape output depend on which
+// libraries happen to be linked in.
+func NewMetrics(component Component) *Metrics {
+	reg := prometheus.NewRegistry()
+
+	// Go runtime and process series are worth the bytes here: Phase 4 is about
+	// memory, and the informer cache is the largest consumer in the planner.
+	reg.MustRegister(
+		collectors.NewGoCollector(),
+		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
+	)
+
+	m := &Metrics{
+		registry: reg,
+
+		PlanSteps: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "dencer_plan_steps",
+			Help: "Steps in the current plan, by impact classification.",
+		}, []string{"impact"}),
+		NodesReclaimed: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "dencer_plan_nodes_reclaimable",
+			Help: "Nodes the current plan would free if executed in full.",
+		}),
+		SnapshotNodes: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "dencer_snapshot_nodes",
+			Help: "Nodes in the most recent cluster snapshot.",
+		}),
+		SnapshotPods: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "dencer_snapshot_pods",
+			Help: "Pods in the most recent cluster snapshot.",
+		}),
+		PlanCycleTime: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Name: "dencer_plan_cycle_seconds",
+			Help: "Time to snapshot, analyse and plan. Approaching the resync period means the planner is falling behind.",
+			// Spans the measured range in docs/benchmarks.md, from a small
+			// cluster to well past the point where a cycle outruns its resync.
+			Buckets: []float64{0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60},
+		}),
+		SnapshotFailure: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "dencer_snapshot_failures_total",
+			Help: "Snapshots that could not be taken.",
+		}),
+
+		RunsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "dencer_runs_total",
+			Help: "Execution runs by terminal status.",
+		}, []string{"status"}),
+		GuardRefusalsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "dencer_guard_refusals_total",
+			Help: "Steps or evictions refused by the safety guard, by rule.",
+		}, []string{"rule"}),
+		EvictionDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Name: "dencer_eviction_duration_seconds",
+			Help: "Time from eviction call to the pod being gone. A long tail means PDBs are holding drains open.",
+			// Terminating a pod is bounded by its grace period, which defaults
+			// to 30s and is routinely raised; the top bucket has to sit well
+			// above it or a stuck drain looks the same as a slow one.
+			Buckets: []float64{0.1, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300},
+		}),
+		EvictionsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "dencer_evictions_total",
+			Help: "Eviction attempts by outcome.",
+		}, []string{"outcome"}),
+		NodesDrainedTotal: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "dencer_nodes_drained_total",
+			Help: "Nodes fully drained and cordoned.",
+		}),
+		RecoveryWaitSeconds: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Name:    "dencer_recovery_wait_seconds",
+			Help:    "Time spent waiting for evicted workloads to become Ready again.",
+			Buckets: []float64{1, 5, 10, 30, 60, 120, 300, 600},
+		}),
+	}
+
+	switch component {
+	case ComponentPlanner:
+		reg.MustRegister(prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+			Name: "dencer_plan_age_seconds",
+			Help: "Age of the most recent plan. Rises without bound if the planner stops planning. Negative one before the first plan.",
+		}, func() float64 {
+			ns := m.planStamp.Load()
+			if ns == 0 {
+				// Distinguishable from a genuinely fresh plan: an alert on
+				// plan age must not fire during startup, and must not be
+				// silenced by a zero that means "never planned".
+				return -1
+			}
+			return time.Since(time.Unix(0, ns)).Seconds()
+		}))
+		reg.MustRegister(
+			m.PlanSteps, m.NodesReclaimed, m.SnapshotNodes, m.SnapshotPods,
+			m.PlanCycleTime, m.SnapshotFailure,
+		)
+	case ComponentExecutor:
+		reg.MustRegister(
+			m.RunsTotal, m.GuardRefusalsTotal, m.EvictionDuration, m.EvictionsTotal,
+			m.NodesDrainedTotal, m.RecoveryWaitSeconds,
+		)
+	case ComponentUIBackend:
+		// Nothing of its own yet. The Go and process collectors above are the
+		// point: ui-backend is the component that holds the SQLite writer and
+		// serves the API, so heap and file descriptors are what an operator
+		// would look at. Adding request counters here is M20 work that has not
+		// been justified by an actual question anyone asked.
+	}
+	return m
+}
+
+// Register installs the scrape endpoint on mux.
+//
+// The path is fixed rather than configurable: the chart's serviceMonitor has to
+// name it, and a mismatch between the two is exactly the failure this milestone
+// exists to remove.
+func (m *Metrics) Register(mux *http.ServeMux) {
+	mux.Handle("GET "+MetricsPath, promhttp.HandlerFor(m.registry, promhttp.HandlerOpts{
+		// A scrape must never take the process down.
+		ErrorHandling: promhttp.ContinueOnError,
+	}))
+}
+
+// MetricsPath is where every component serves its scrape endpoint. The chart
+// asserts against this value; see hack/lint-chart.sh.
+const MetricsPath = "/metrics"
+
+// PlanProduced records that a plan was just produced, which resets plan age.
+func (m *Metrics) PlanProduced(at time.Time) { m.planStamp.Store(at.UnixNano()) }
+
+// Gatherer exposes the registry for tests that want to read series back.
+func (m *Metrics) Gatherer() prometheus.Gatherer { return m.registry }

--- a/internal/telemetry/metrics_test.go
+++ b/internal/telemetry/metrics_test.go
@@ -1,0 +1,269 @@
+package telemetry
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// A metric that nothing writes is worse than no metric at all: it scrapes as
+// zero, and zero is indistinguishable from healthy. "No runs have failed" and
+// "nobody wired up the failure counter" produce the same graph.
+//
+// So the declaration is checked against the call sites. Every exported field on
+// Metrics must be referenced by non-test code somewhere outside this file.
+func TestEveryMetricHasAWriter(t *testing.T) {
+	fields := exportedMetricFields(t)
+	if len(fields) == 0 {
+		t.Fatal("found no fields on Metrics; the parser is broken, not the code")
+	}
+
+	root := repoRoot(t)
+	used := map[string]bool{}
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case ".git", "node_modules", "ui", "vendor":
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		// metrics.go declares them; it does not count as a writer.
+		if filepath.Base(path) == "metrics.go" && strings.Contains(path, "telemetry") {
+			return nil
+		}
+		src, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		for _, f := range fields {
+			if strings.Contains(string(src), "."+f) {
+				used[f] = true
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+
+	for _, f := range fields {
+		if !used[f] {
+			t.Errorf("Metrics.%s is declared but nothing outside metrics.go ever writes it; "+
+				"it would scrape as zero forever, which reads as healthy", f)
+		}
+	}
+}
+
+// Plan age is the one series whose whole purpose is to notice that the planner
+// stopped. Writing it from the planning loop would defeat that — the value
+// would freeze at its last reading, so a dead planner would report a fresh
+// plan. It has to be computed when scraped.
+func TestPlanAgeIsDerivedAtScrapeTime(t *testing.T) {
+	m := NewMetrics(ComponentPlanner)
+
+	body := scrape(t, m)
+	if !strings.Contains(body, "dencer_plan_age_seconds -1") {
+		t.Errorf("before any plan, age should be -1 to distinguish 'never planned' from 'just planned'; got:\n%s",
+			grepLines(body, "dencer_plan_age_seconds"))
+	}
+
+	m.PlanProduced(nowMinus(90))
+	body = scrape(t, m)
+	line := grepLines(body, "dencer_plan_age_seconds")
+	if strings.Contains(line, "-1") {
+		t.Fatalf("age still -1 after a plan was recorded: %s", line)
+	}
+	// Two scrapes of a static gauge would be identical; a derived one moves.
+	if !strings.Contains(line, "89") && !strings.Contains(line, "90") {
+		t.Errorf("expected an age near 90s, got: %s", line)
+	}
+}
+
+// Every rating must be present even at zero, or "no Red steps" disappears from
+// the scrape and reads as a gap in the graph rather than as reassurance.
+func TestPlanStepsReportsZeroRatingsExplicitly(t *testing.T) {
+	m := NewMetrics(ComponentPlanner)
+	for _, r := range []string{"Green", "Yellow", "Red"} {
+		m.PlanSteps.WithLabelValues(r).Set(0)
+	}
+	body := scrape(t, m)
+	for _, r := range []string{"Green", "Yellow", "Red"} {
+		if !strings.Contains(body, `dencer_plan_steps{impact="`+r+`"}`) {
+			t.Errorf("rating %s missing from the scrape at zero", r)
+		}
+	}
+}
+
+func TestScrapeEndpointServes(t *testing.T) {
+	m := NewMetrics(ComponentPlanner)
+	mux := http.NewServeMux()
+	m.Register(mux)
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, MetricsPath, nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET %s = %d, want 200", MetricsPath, rec.Code)
+	}
+	body := rec.Body.String()
+	// Go runtime series come along deliberately: Phase 4 is about memory.
+	if !strings.Contains(body, "go_memstats_") {
+		t.Error("Go runtime collector is not registered")
+	}
+	// controller-runtime registers into the default registry; exporting those
+	// by accident would make the output depend on linked libraries.
+	if strings.Contains(body, "workqueue_") || strings.Contains(body, "rest_client_") {
+		t.Error("default-registry series leaked into the scrape; use the private registry")
+	}
+}
+
+func exportedMetricFields(t *testing.T) []string {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "metrics.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse metrics.go: %v", err)
+	}
+	var out []string
+	ast.Inspect(f, func(n ast.Node) bool {
+		ts, ok := n.(*ast.TypeSpec)
+		if !ok || ts.Name.Name != "Metrics" {
+			return true
+		}
+		st, ok := ts.Type.(*ast.StructType)
+		if !ok {
+			return false
+		}
+		for _, fld := range st.Fields.List {
+			for _, name := range fld.Names {
+				if name.IsExported() {
+					out = append(out, name.Name)
+				}
+			}
+		}
+		return false
+	})
+	return out
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("no go.mod above the test directory")
+		}
+		dir = parent
+	}
+}
+
+func scrape(t *testing.T, m *Metrics) string {
+	t.Helper()
+	mux := http.NewServeMux()
+	m.Register(mux)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, MetricsPath, nil))
+	return rec.Body.String()
+}
+
+func grepLines(body, substr string) string {
+	var out []string
+	for _, l := range strings.Split(body, "\n") {
+		if strings.Contains(l, substr) && !strings.HasPrefix(l, "#") {
+			out = append(out, l)
+		}
+	}
+	return strings.Join(out, "\n")
+}
+
+func nowMinus(seconds int) time.Time { return time.Now().Add(-time.Duration(seconds) * time.Second) }
+
+// Each component must publish only what it can actually write. The planner
+// cannot evict; an operator who sees dencer_eviction_duration_seconds on the
+// planner reads a permanent zero as "evictions are fast", when the truth is
+// that this process has never performed one.
+func TestComponentsPublishOnlyTheirOwnSeries(t *testing.T) {
+	// Write to every metric on both components before scraping. Labelled
+	// metrics emit nothing until a child exists, so without this the check
+	// would pass on two empty scrapes and prove nothing. Writing to a metric
+	// the component does not register is also the realistic mistake: it is
+	// silently dropped, and this asserts that it stays dropped.
+	touch := func(m *Metrics) *Metrics {
+		m.PlanProduced(time.Now())
+		m.PlanSteps.WithLabelValues("Green").Set(1)
+		m.NodesReclaimed.Set(1)
+		m.SnapshotNodes.Set(1)
+		m.SnapshotPods.Set(1)
+		m.PlanCycleTime.Observe(1)
+		m.SnapshotFailure.Inc()
+		m.RunsTotal.WithLabelValues("Succeeded").Inc()
+		m.GuardRefusalsTotal.WithLabelValues("PDBHeadroom").Inc()
+		m.EvictionDuration.Observe(1)
+		m.EvictionsTotal.WithLabelValues("evicted").Inc()
+		m.NodesDrainedTotal.Inc()
+		m.RecoveryWaitSeconds.Observe(1)
+		return m
+	}
+
+	planner := scrape(t, touch(NewMetrics(ComponentPlanner)))
+	executor := scrape(t, touch(NewMetrics(ComponentExecutor)))
+
+	plannerOnly := []string{
+		"dencer_plan_age_seconds", "dencer_plan_steps", "dencer_snapshot_pods",
+		"dencer_snapshot_nodes", "dencer_plan_cycle_seconds", "dencer_snapshot_failures_total",
+		"dencer_plan_nodes_reclaimable",
+	}
+	executorOnly := []string{
+		"dencer_runs_total", "dencer_eviction_duration_seconds", "dencer_nodes_drained_total",
+		"dencer_guard_refusals_total", "dencer_evictions_total", "dencer_recovery_wait_seconds",
+	}
+
+	for _, name := range plannerOnly {
+		if !strings.Contains(planner, name) {
+			t.Errorf("planner is missing its own series %s", name)
+		}
+		if strings.Contains(executor, name) {
+			t.Errorf("executor publishes %s, which only the planner writes", name)
+		}
+	}
+	for _, name := range executorOnly {
+		if !strings.Contains(executor, name) {
+			t.Errorf("executor is missing its own series %s", name)
+		}
+		if strings.Contains(planner, name) {
+			t.Errorf("planner publishes %s, which only the executor writes; "+
+				"a permanent zero reads as healthy evictions it never performed", name)
+		}
+	}
+
+	// ui-backend has no series of its own yet, but must still scrape cleanly
+	// with the runtime collectors, or the chart's ServiceMonitor is pointless.
+	ui := scrape(t, touch(NewMetrics(ComponentUIBackend)))
+	if !strings.Contains(ui, "go_memstats_") {
+		t.Error("ui-backend scrape carries no runtime series at all")
+	}
+	if strings.Contains(ui, "dencer_") {
+		t.Error("ui-backend publishes dencer_ series it does not write")
+	}
+}


### PR DESCRIPTION
> **Stacked on #22** — targets `feat/m17-data-volume`. Merge #22 first and this retargets to `main` automatically.

Phase 4, M20. Three things the repo claimed or implied but did not do.

## The `serviceMonitor` was scraping nothing

The chart shipped a ServiceMonitor pointing at `/metrics` when **no component served `/metrics` at all**. A monitor aimed at a 404 is worse than none — it presents as a configured target that merely happens to be failing.

All three components now serve it, and `hack/lint-chart.sh` reads `telemetry.MetricsPath` out of the Go source and fails if the rendered templates disagree. The path is not repeated in the chart, so the two cannot drift.

## Scraping does not cost the privilege split

Planner and executor get a **PodMonitor**, not a Service. Neither has one, and that's a security property: the executor holds `pods/eviction` and is deliberately unreachable over the network. Giving it a Service so Prometheus could discover it would spend that property on a scrape target.

Four new lint assertions, all mutation-verified:

| Assertion | Catches |
|---|---|
| monitors scrape the path the code serves | the original bug |
| every scraped component registers the handler | a component silently dropping it |
| no Service is rendered for planner/executor | someone "fixing" discovery the easy way |
| `serviceMonitor` ⇒ NetworkPolicy admits the scraper | a target that's down with nothing explaining why |

Two of those **could not fail** when first written — one matched a commented-out registration, the other matched `health.Register(mux)` instead of the metrics one. Both fixed and re-verified.

## Each component publishes only what it writes

Registering the full set everywhere had the planner publishing `dencer_eviction_duration_seconds` as a permanent zero. The planner cannot evict — and a zero there reads as "evictions are fast", not "this process has never performed one". **A missing series is a question; a series pinned at zero is a wrong answer.**

Two more ways this could have been quietly useless:

- **Plan age is derived at scrape time.** A gauge written by the planning loop would freeze at its last value if the loop died — reporting a fresh plan at exactly the moment there is none. Reads `-1` before the first plan, so startup is distinguishable from a stall.
- **Every impact rating is set explicitly, including zeroes.** An unset label vanishes from the scrape and graphs as a gap rather than as "no Red steps".

A test parses the `Metrics` struct and fails on any field nothing writes. Verified by adding an orphan metric.

Live values from the running fabric, cross-checked against the planner log:

```
dencer_plan_age_seconds 4.181680473
dencer_plan_nodes_reclaimable 15
dencer_plan_steps{impact="Green"} 12
dencer_plan_steps{impact="Yellow"} 0
dencer_plan_steps{impact="Red"} 3
dencer_snapshot_nodes 31
dencer_snapshot_pods 121
```

## CI — the reason the rest of it matters

**There was none.** Most of this project's safety story is "there is a test that fails if you break it": the CVD palette guards, the ast check that no API route escapes authorization, the eviction-only assertion, the M17 transform test. None of them protected anything, because nothing ran them except whoever remembered to.

`ci.yml` runs `go vet`, `go test -race`, `gofmt`, `make lint`, the UI typecheck and build, and the benchmarks once through. All green locally.

The benchmark job is **not** a performance gate — shared-runner timings are too noisy to assert on, and a flaky red build teaches people to ignore CI. It catches the benchmarks rotting, which matters because their numbers drive Phase 4 decisions.

The M17 heap measurement now skips under `-race`, where the detector's own bookkeeping would be most of what it measures.

## Releases

`release.yml` publishes four multi-arch images (amd64 + arm64, provenance and SBOM) and the packaged chart on a `v*` tag. The chart has always defaulted to `ghcr.io/atedgimo/k8s-dencer-*` and **nothing had ever pushed there**, so `helm install` could not work for anyone. The job refuses to publish if `Chart.yaml` disagrees with the tag, since `appVersion` selects the image tag.

## LICENSE

There wasn't one — the repo was all-rights-reserved and legally unusable by anyone else. MIT, per the owner's choice. Note that a CNCF donation would later require relicensing to Apache 2.0 with sign-off from every contributor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)