### PR TITLE
Derive the release version from the tag, not the branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,12 @@ jobs:
 
       - name: derive version
         id: v
-        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+        # On a tag push GITHUB_REF_NAME is the tag; on workflow_dispatch it is
+        # the branch the workflow was launched from, which would publish the
+        # wrong version under a correct-looking tag. The input wins when given.
+        run: |
+          ref="${{ inputs.tag || github.ref_name }}"
+          echo "version=${ref#v}" >> "$GITHUB_OUTPUT"
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
@@ -85,7 +90,12 @@ jobs:
 
       - name: derive version
         id: v
-        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+        # On a tag push GITHUB_REF_NAME is the tag; on workflow_dispatch it is
+        # the branch the workflow was launched from, which would publish the
+        # wrong version under a correct-looking tag. The input wins when given.
+        run: |
+          ref="${{ inputs.tag || github.ref_name }}"
+          echo "version=${ref#v}" >> "$GITHUB_OUTPUT"
 
       # The chart's appVersion is what selects the image tag, so a chart
       # published with a stale appVersion would install images from a previous


### PR DESCRIPTION
Found while reviewing `release.yml` before cutting `v0.1.0`.

`GITHUB_REF_NAME` is the tag on a tag push — correct for the path that matters. But on `workflow_dispatch` it's the *branch* the run was launched from. Re-publishing a release by hand would have built images tagged `main` while the job reported success, and the chart job's tag-matching guard would then have failed pointing at `Chart.yaml` rather than at the real cause.

Now uses `inputs.tag` when provided, falling back to `github.ref_name`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)