### PR TITLE
M19: make the UI survive a cluster it cannot draw

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,9 @@ jobs:
 
       - run: npm ci
       - run: npm run typecheck
+      # Density mode reads optional fields; a field that stops arriving renders
+      # as zero rather than failing, so the arithmetic is asserted directly.
+      - run: npm run test:density
       # A build failure is a real failure: the frontend ships as a static
       # bundle, so anything tsc lets through still has to survive Vite.
       - run: npm run build

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ build: ## Compile the Go binaries locally
 test: ## Run Go and UI tests
 	go vet ./...
 	go test ./...
-	cd ui && npm run typecheck
+	cd ui && npm run typecheck && npm run test:density
 
 .PHONY: images
 images: ## Build native-arch images for the local cluster

--- a/README.md
+++ b/README.md
@@ -172,14 +172,16 @@ cluster rather than taking this page's word for it, in
 
 Measured, not estimated — on synthesised clusters, with no cluster running:
 
-| Pods | Constraint analysis | Planning | Stored per plan |
-|---|---|---|---|
-| 916 | 16 ms | 17 ms | 54 KB |
-| 2,526 | 90 ms | 110 ms | 197 KB |
-| 5,026 | 298 ms | 466 ms | 609 KB |
+| Pods | Constraint analysis | Planning | Stored per plan | UI payload |
+|---|---|---|---|---|
+| 916 | 16 ms | 17 ms | 54 KB | 0.24 MB |
+| 2,526 | 90 ms | 110 ms | 197 KB | 0.03 MB |
+| 5,026 | 298 ms | 466 ms | 609 KB | 0.05 MB |
 
-Comfortably past 5,000 pods against a 30-second resync. Method, growth curves and
-the known ceiling in **[docs/benchmarks.md](docs/benchmarks.md)**.
+The UI payload falls rather than rises past 2,526 pods because that is where it
+stops sending an element per pod and starts sending occupancy per node — an
+individual 6px block conveys nothing at that density anyway. Method, growth
+curves and the known ceiling in **[docs/benchmarks.md](docs/benchmarks.md)**.
 
 ## Documentation
 

--- a/cmd/ui-backend/main.go
+++ b/cmd/ui-backend/main.go
@@ -9,6 +9,7 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
@@ -94,6 +95,12 @@ func run(ctx context.Context, log *slog.Logger) error {
 	mux := http.NewServeMux()
 	health.Register(mux)
 	telemetry.NewMetrics(telemetry.ComponentUIBackend).Register(mux)
+	// A machine that struggles at 4,000 pod elements should be able to say so
+	// without redeploying a different build.
+	if lim := intEnv("GRAPH_POD_DETAIL_LIMIT", 0); lim != 0 {
+		api = api.WithGraphPodDetailLimit(lim)
+		log.Info("graph detail limit overridden", "podDetailLimit", lim)
+	}
 	api.Routes(mux)
 
 	// The Kagent agent reaches the same plan store over MCP. It is mounted on
@@ -212,6 +219,21 @@ func env(key, fallback string) string {
 // boolEnv reads a boolean setting. An unparseable value takes the fallback,
 // which for security settings is the safe end: a typo in AUTH_ENABLED leaves
 // authentication on rather than silently opening the API.
+// intEnv reads an integer setting. A malformed value is refused rather than
+// silently defaulted: a typo'd limit that quietly reverts is worse than one
+// that fails loudly at startup.
+func intEnv(key string, fallback int) int {
+	raw := os.Getenv(key)
+	if raw == "" {
+		return fallback
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil {
+		panic(fmt.Sprintf("%s must be an integer, got %q", key, raw))
+	}
+	return n
+}
+
 func boolEnv(key string, fallback bool) bool {
 	raw, ok := os.LookupEnv(key)
 	if !ok || raw == "" {

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -9,6 +9,50 @@ measured at thousands of pods without standing anything up.
 Apple M-series laptop, Go 1.26, `-benchtime 1x`. Absolute numbers will differ on
 other hardware; **the growth curves are the point.**
 
+## After M19 — what reaches the browser
+
+The graph endpoint is the last thing between a 50,000-pod cluster and an
+unusable UI. Two changes, in that order, because the first made the second
+smaller.
+
+**Stop sending what nothing reads.** The payload carried an edge per proposed
+move, per anti-affinity relation and per PDB membership — **45% of all elements
+at 2,526 pods** — and nothing had read an edge since M11 replaced the node-link
+graph with the packing field. It also carried `utilization`, `drained`,
+`targetNode` and `moveStep`, which no code ever read. Building the PDB edges
+walked every pod for every PDB, so removing them also removed a quadratic term.
+
+**Summarise pods above a threshold.** Past `PodDetailLimit` (default 4,000) the
+payload sends occupancy per node instead of an element per pod. At that density
+an individual 6px block conveys nothing, so this is less a degraded view than
+the right zoom level.
+
+| Pods | Before M19 | After the cut | Aggregated | vs. before |
+|---|---|---|---|---|
+| 916 | 0.46 MB | 0.24 MB | — | 1.9× |
+| 2,526 | 1.22 MB | 0.65 MB | **0.027 MB** | **44×** |
+| 5,026 | 2.41 MB | 1.29 MB | **0.054 MB** | **44×** |
+
+Per pod: 480 B → 256 B → **11 B**. Extrapolated to the 50,000-pod target, the
+payload goes from ~24 MB to well under 1 MB, and DOM elements from ~95,000 to
+roughly one per node.
+
+Two supporting changes were needed to make the aggregated view honest rather
+than merely small:
+
+- `model.Move` now carries the pod's CPU and memory. Without it the density
+  view could show a drained node emptying but not the receiving nodes filling,
+  understating exactly the number an operator judges a plan on. Verified: the
+  golden planner tests still produce byte-identical step lists.
+- The node element always carries `podCount`, in both modes. Counting pod
+  elements locally would give a second answer to "how full is this node", and
+  two answers is worse than either.
+
+The field also virtualises above 150 node boxes, mounting only the visible band
+plus three rows of overscan. Which boxes are on screen is arithmetic over the
+computed grid rather than measurement, so there is no observer per element and
+no layout thrash.
+
 ## After M17 — memory and stored bytes
 
 M18 made the planner fast enough; M17 addresses what it costs to *hold* and

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -47,7 +47,7 @@ estimated — every milestone here starts from a number in
 | **M16** | Measured ceiling — synthesised clusters, `make bench` | **done** |
 | **M17** | Data volume — gzipped plan blobs (23.8× at 5k pods), informer cache transform (−30% heap), paginated reads | **done** |
 | **M18** | Planner cost — memoised topology-spread counts, **112×** faster analysis at 5k pods | **done** |
-| **M19** | UI at scale — density rendering, virtualised field, aggregated graph payload | planned |
+| **M19** | UI at scale — aggregated payload (**44×** smaller at 5k pods), density rendering, virtualised field | **done** |
 | **M20** | `/metrics` on all three components; monitors that scrape a real path; CI; published images | **done** |
 | **M21** | Multi-node k3d, PodSecurity enforcing, real ingress and StorageClass | planned |
 

--- a/internal/api/graph/graph.go
+++ b/internal/api/graph/graph.go
@@ -1,18 +1,20 @@
-// Package graph renders a plan and its cluster snapshot as a Cytoscape.js
-// element list.
+// Package graph renders a plan and its cluster snapshot for the UI.
 //
-// Shaped for Cytoscape's compound-node model: a cluster node is a parent and
-// its pods are children. That maps directly onto "this node contains these
-// pods" without any layout trickery, which is why Cytoscape was chosen over a
-// force-directed library.
+// The shape is a flat element list where a pod names its node as Parent. That
+// began as Cytoscape's compound-node model; M11 replaced the node-link graph
+// with the packing field, and the shape survived because "this node contains
+// these pods" is exactly what the packing field needs too.
 //
-// Each pod carries both where it is now and where the plan would put it, so
-// the frontend can render the before/after view and animate the step scrubber
-// from one payload rather than diffing two.
+// What did not survive is everything Cytoscape needed and the packing field
+// does not. The payload used to carry an edge per proposed move, per
+// anti-affinity relation and per PDB membership — 45% of all elements at 2,500
+// pods — and no code has read an edge since M11. Building the PDB edges also
+// walked every pod for every PDB. They are gone, along with the per-element
+// fields nothing read. Emitting data no consumer reads is not free: it is
+// serialised, transferred, parsed and held in memory by a browser.
 package graph
 
 import (
-	"fmt"
 	"sort"
 
 	"github.com/atedgimo/k8s-dencer/internal/constraints"
@@ -24,36 +26,69 @@ type Payload struct {
 	PlanID   string    `json:"planId"`
 	Elements []Element `json:"elements"`
 	Stats    Stats     `json:"stats"`
+
+	// Aggregated reports that pods were summarised onto their nodes rather
+	// than sent individually. The UI switches to density rendering when it is
+	// set — it cannot infer this from an empty pod list, which is also what a
+	// genuinely empty cluster looks like.
+	Aggregated bool `json:"aggregated"`
 }
 
-// Element is one Cytoscape element.
+// Options controls how much detail the payload carries.
+type Options struct {
+	// PodDetailLimit is the largest pod count for which the payload carries an
+	// element per pod. Above it, pods are summarised onto their node.
+	//
+	// The limit exists because the cost is per pod on both sides: ~256 bytes
+	// serialised, and one absolutely-positioned DOM element in the packing
+	// field. 50,000 pods is 12.8 MB and 50,000 elements, which no browser
+	// renders usefully — and at that density an individual 6px block conveys
+	// nothing anyway. Aggregating is not a degraded view so much as the right
+	// zoom level.
+	PodDetailLimit int
+}
+
+// DefaultOptions keeps per-pod detail through the range where it is still
+// legible and the DOM is still manageable, which measurement puts at a few
+// thousand: 2,526 pods is 2,626 elements and 0.65 MB, and renders fine.
+func DefaultOptions() Options { return Options{PodDetailLimit: 4000} }
+
+// Element is one element of the payload.
 type Element struct {
-	Group string `json:"group"` // "nodes" or "edges"
-	Data  Data   `json:"data"`
+	Data Data `json:"data"`
 }
 
-// Data carries the element's fields. Cytoscape requires id; parent creates the
-// compound nesting; source/target define edges.
+// Data carries the element's fields.
+//
+// Every field here is read by the frontend. graph_contract_test.go asserts
+// that, by parsing this struct and searching the UI sources for each json tag,
+// so a field cannot be added speculatively or outlive its last reader. Where a
+// pod moves and which step moves it are deliberately absent: the UI derives
+// both from the plan's steps, which it already has.
 type Data struct {
 	ID     string `json:"id"`
 	Parent string `json:"parent,omitempty"`
-	Source string `json:"source,omitempty"`
-	Target string `json:"target,omitempty"`
 
-	Kind  string `json:"kind"` // node | pod | edge
+	Kind  string `json:"kind"` // node | pod
 	Label string `json:"label"`
 
 	// Node fields.
-	Zone           string  `json:"zone,omitempty"`
-	Ready          bool    `json:"ready,omitempty"`
-	Cordoned       bool    `json:"cordoned,omitempty"`
-	CPUAllocatable int64   `json:"cpuAllocatable,omitempty"`
-	CPURequested   int64   `json:"cpuRequested,omitempty"`
-	MemAllocatable int64   `json:"memAllocatable,omitempty"`
-	MemRequested   int64   `json:"memRequested,omitempty"`
-	Utilization    float64 `json:"utilization,omitempty"`
-	Drained        bool    `json:"drained,omitempty"`
-	DrainStep      int     `json:"drainStep,omitempty"`
+	Zone           string `json:"zone,omitempty"`
+	Ready          bool   `json:"ready,omitempty"`
+	Cordoned       bool   `json:"cordoned,omitempty"`
+	CPUAllocatable int64  `json:"cpuAllocatable,omitempty"`
+	CPURequested   int64  `json:"cpuRequested,omitempty"`
+	MemAllocatable int64  `json:"memAllocatable,omitempty"`
+	MemRequested   int64  `json:"memRequested,omitempty"`
+	DrainStep      int    `json:"drainStep,omitempty"`
+
+	// Occupancy, always sent. In detail mode the UI could count the pod
+	// elements itself; in aggregated mode there are none to count, and having
+	// one source for the number in both modes means the density view and the
+	// detail view cannot disagree about how full a node is.
+	PodCount     int `json:"podCount,omitempty"`
+	BlockedCount int `json:"blockedCount,omitempty"`
+	PinnedCount  int `json:"pinnedCount,omitempty"`
 
 	// Pod fields.
 	Namespace  string `json:"namespace,omitempty"`
@@ -62,14 +97,7 @@ type Data struct {
 	OwnerKind  string `json:"ownerKind,omitempty"`
 	OwnerName  string `json:"ownerName,omitempty"`
 	Movable    bool   `json:"movable"`
-	// TargetNode is where the plan relocates this pod, empty if it stays.
-	TargetNode string `json:"targetNode,omitempty"`
-	MoveStep   int    `json:"moveStep,omitempty"`
 	Blocked    bool   `json:"blocked,omitempty"`
-
-	// Edge fields. Relation is "anti-affinity", "pdb" or "move".
-	Relation string `json:"relation,omitempty"`
-	Impact   string `json:"impact,omitempty"`
 }
 
 // Stats are the headline figures for the UI's tile row.
@@ -84,25 +112,54 @@ type Stats struct {
 	MemoryReclaimed int64          `json:"memoryReclaimedBytes"`
 }
 
-// Build renders the payload.
+// Build renders the payload at default detail.
 func Build(plan *model.Plan, snap *model.ClusterSnapshot, analysis *constraints.Analysis) Payload {
+	return BuildWith(plan, snap, analysis, DefaultOptions())
+}
+
+// BuildWith renders the payload, summarising pods when there are too many to
+// send individually.
+func BuildWith(plan *model.Plan, snap *model.ClusterSnapshot, analysis *constraints.Analysis, opts Options) Payload {
 	p := Payload{PlanID: plan.ID}
+	p.Aggregated = opts.PodDetailLimit > 0 && len(snap.Pods) > opts.PodDetailLimit
 
 	// Where the plan sends each pod, and which step does it.
+	// targets is still needed for the PodsMoved stat; drainStep tells a node
+	// element which step empties it, which is what the field animates against.
 	targets := make(map[string]model.Move, 64)
-	moveStep := make(map[string]int, 64)
 	drainStep := make(map[string]int, len(plan.Steps))
-	stepImpact := make(map[string]string, len(plan.Steps))
 
 	for _, step := range plan.Steps {
 		if step.TargetNode != "" {
 			drainStep[step.TargetNode] = step.SequenceNumber
-			stepImpact[step.TargetNode] = string(step.Impact)
 		}
 		for _, m := range step.Moves {
-			key := m.Namespace + "/" + m.Pod
-			targets[key] = m
-			moveStep[key] = step.SequenceNumber
+			targets[m.Namespace+"/"+m.Pod] = m
+		}
+	}
+
+	// One pass for occupancy, so the node loop below does not walk every pod
+	// per node — that shape is how the PDB edges came to be quadratic.
+	type tally struct{ pods, blocked, pinned int }
+	occupancy := make(map[string]*tally, len(snap.Nodes))
+	for i := range snap.Pods {
+		pod := &snap.Pods[i]
+		if pod.NodeName == "" {
+			continue
+		}
+		t := occupancy[pod.NodeName]
+		if t == nil {
+			t = &tally{}
+			occupancy[pod.NodeName] = t
+		}
+		t.pods++
+		if !pod.IsMovable() {
+			t.pinned++
+		}
+		if analysis != nil {
+			if pc, ok := analysis.ForPod(pod.Key()); ok && !pc.Movable {
+				t.blocked++
+			}
 		}
 	}
 
@@ -116,7 +173,6 @@ func Build(plan *model.Plan, snap *model.ClusterSnapshot, analysis *constraints.
 			reclaimedMem += n.Allocatable.MemoryBytes
 		}
 		p.Elements = append(p.Elements, Element{
-			Group: "nodes",
 			Data: Data{
 				ID:             nodeID(n.Name),
 				Kind:           "node",
@@ -128,18 +184,25 @@ func Build(plan *model.Plan, snap *model.ClusterSnapshot, analysis *constraints.
 				CPURequested:   requested.MilliCPU,
 				MemAllocatable: n.Allocatable.MemoryBytes,
 				MemRequested:   requested.MemoryBytes,
-				Utilization:    requested.DominantRatio(n.Allocatable),
-				Drained:        isDrained,
 				DrainStep:      drainStep[n.Name],
-				Impact:         stepImpact[n.Name],
+				PodCount:       occ(occupancy, n.Name).pods,
+				BlockedCount:   occ(occupancy, n.Name).blocked,
+				PinnedCount:    occ(occupancy, n.Name).pinned,
 			},
 		})
 	}
 
+	if p.Aggregated {
+		// The node elements above already carry everything the density view
+		// draws. Skipping the pod loop is the entire saving.
+		p.Stats = buildStats(plan, targets, reclaimedCPU, reclaimedMem)
+		return p
+	}
+
 	for _, pod := range snap.Pods {
 		if pod.NodeName == "" {
-			// Unscheduled pods have no parent to nest under; Cytoscape would
-			// render them as orphans floating outside the graph.
+			// Unscheduled pods have no node to sit inside, and the packing
+			// field has nowhere to draw them.
 			continue
 		}
 		key := pod.Key()
@@ -157,25 +220,21 @@ func Build(plan *model.Plan, snap *model.ClusterSnapshot, analysis *constraints.
 			data.OwnerKind = pod.Owner.Kind
 			data.OwnerName = pod.Owner.Name
 		}
-		if m, moved := targets[key]; moved {
-			data.TargetNode = m.ToNode
-			data.MoveStep = moveStep[key]
-		}
 		if analysis != nil {
 			if pc, ok := analysis.ForPod(key); ok {
 				data.Blocked = !pc.Movable
 			}
 		}
-		p.Elements = append(p.Elements, Element{Group: "nodes", Data: data})
+		p.Elements = append(p.Elements, Element{Data: data})
 	}
 
-	p.Elements = append(p.Elements, moveEdges(targets, moveStep, stepImpact)...)
-	if analysis != nil {
-		p.Elements = append(p.Elements, constraintEdges(snap, analysis)...)
-	}
+	p.Stats = buildStats(plan, targets, reclaimedCPU, reclaimedMem)
+	return p
+}
 
+func buildStats(plan *model.Plan, targets map[string]model.Move, reclaimedCPU, reclaimedMem int64) Stats {
 	ratings := plan.CountByRating()
-	p.Stats = Stats{
+	return Stats{
 		NodesBefore: plan.NodesBefore,
 		NodesAfter:  plan.NodesAfter,
 		Reclaimed:   plan.ReclaimedNodes(),
@@ -189,84 +248,15 @@ func Build(plan *model.Plan, snap *model.ClusterSnapshot, analysis *constraints.
 		CPUReclaimed:    reclaimedCPU,
 		MemoryReclaimed: reclaimedMem,
 	}
-	return p
 }
 
-// moveEdges draw each proposed relocation, so the frontend can animate a pod
-// travelling to its destination when the scrubber reaches that step.
-func moveEdges(targets map[string]model.Move, moveStep map[string]int, stepImpact map[string]string) []Element {
-	out := make([]Element, 0, len(targets))
-	for key, m := range targets {
-		out = append(out, Element{
-			Group: "edges",
-			Data: Data{
-				ID:       fmt.Sprintf("move:%s", key),
-				Source:   podID(key),
-				Target:   nodeID(m.ToNode),
-				Kind:     "edge",
-				Relation: "move",
-				MoveStep: moveStep[key],
-				Impact:   stepImpact[m.FromNode],
-				Label:    fmt.Sprintf("step %d", moveStep[key]),
-			},
-		})
+// occ returns a node's tally, or an empty one for a node holding no pods.
+func occ[T any](m map[string]*T, name string) *T {
+	if t := m[name]; t != nil {
+		return t
 	}
-	sortElements(out)
-	return out
-}
-
-// constraintEdges expose the relationships that shape the plan. Anti-affinity
-// as a visible repulsion between pods is the clearest way to show why a node
-// cannot be emptied; a PDB grouping shows which pods share a disruption
-// budget.
-func constraintEdges(snap *model.ClusterSnapshot, analysis *constraints.Analysis) []Element {
-	var out []Element
-
-	for _, pdb := range snap.PDBs {
-		if pdb.Selector.IsEmpty() {
-			continue
-		}
-		var members []string
-		for _, pod := range snap.Pods {
-			if pod.Namespace == pdb.Namespace && pod.NodeName != "" && pdb.Selector.Matches(pod.Labels) {
-				members = append(members, pod.Key())
-			}
-		}
-		// A chain rather than a clique: n-1 edges instead of n²/2, which keeps
-		// a 90-pod deployment from swamping the canvas.
-		for i := 1; i < len(members); i++ {
-			out = append(out, Element{
-				Group: "edges",
-				Data: Data{
-					ID:       fmt.Sprintf("pdb:%s:%d", pdb.Key(), i),
-					Source:   podID(members[i-1]),
-					Target:   podID(members[i]),
-					Kind:     "edge",
-					Relation: "pdb",
-					Label:    pdb.Name,
-					Blocked:  pdb.Blocks(),
-				},
-			})
-		}
-	}
-
-	for _, pc := range analysis.Pods {
-		for _, c := range pc.Of(constraints.KindPodAntiAffinity) {
-			out = append(out, Element{
-				Group: "edges",
-				Data: Data{
-					ID:       fmt.Sprintf("anti:%s:%s", pc.Key(), c.Subject),
-					Source:   podID(pc.Key()),
-					Target:   nodeID(pc.NodeName),
-					Kind:     "edge",
-					Relation: "anti-affinity",
-					Label:    c.Subject,
-				},
-			})
-		}
-	}
-	sortElements(out)
-	return out
+	var zero T
+	return &zero
 }
 
 func nodeID(name string) string { return "node:" + name }

--- a/internal/api/graph/graph_contract_test.go
+++ b/internal/api/graph/graph_contract_test.go
@@ -1,0 +1,165 @@
+package graph
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// The payload exists to be read by one consumer, and its cost is paid four
+// times over: serialised here, transferred, parsed by the browser, then held in
+// memory. A field no one reads costs all four and buys nothing.
+//
+// That is not hypothetical. This payload carried an edge per proposed move, per
+// anti-affinity relation and per PDB membership — 45% of all elements at 2,500
+// pods — for the whole time between M11 replacing the node-link graph and M19
+// noticing. It also carried utilization, drained, targetNode and moveStep,
+// which nothing ever read.
+//
+// So the struct is checked against the frontend. Every json tag on Data must
+// appear in the UI sources.
+func TestEveryPayloadFieldIsReadByTheUI(t *testing.T) {
+	fields := jsonTags(t)
+	if len(fields) == 0 {
+		t.Fatal("parsed no json tags off Data; the parser is broken, not the payload")
+	}
+
+	ui := uiSources(t)
+
+	for _, f := range fields {
+		// Property access (d.zone) or index (d["zone"]). A bare occurrence
+		// would match the api.ts type declaration and pass for a field that is
+		// declared but never used, which is the exact failure being guarded.
+		pat := regexp.MustCompile(`[.\[]\s*["']?` + regexp.QuoteMeta(f) + `\b`)
+		if !pat.MatchString(ui) {
+			t.Errorf("Data.%s is emitted to every client but the UI never reads it; "+
+				"remove it, or wire it up", f)
+		}
+	}
+}
+
+// The counterpart: a field the UI reads but the payload stopped sending shows
+// up as undefined at runtime rather than as a compile error, because it is
+// optional in the TypeScript type. This catches the api.ts type drifting ahead
+// of the Go struct.
+func TestUITypeDoesNotDeclareFieldsThePayloadNoLongerSends(t *testing.T) {
+	sent := map[string]bool{}
+	for _, f := range jsonTags(t) {
+		sent[f] = true
+	}
+	// Fields the UI type carries for its own reasons, not from this payload.
+	allowed := map[string]bool{"kind": true, "id": true}
+
+	path := filepath.Join(repoRoot(t), "ui/src/api.ts")
+	src, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read api.ts: %v", err)
+	}
+
+	// The GraphData interface, whatever it is called, is the one declaring
+	// "parent" — the field unique to this payload.
+	block := interfaceContaining(string(src), "parent")
+	if block == "" {
+		t.Fatal("could not locate the graph element interface in api.ts")
+	}
+
+	for _, m := range regexp.MustCompile(`(?m)^\s*([a-zA-Z]+)\??:`).FindAllStringSubmatch(block, -1) {
+		f := m[1]
+		if !sent[f] && !allowed[f] {
+			t.Errorf("api.ts declares %q on the graph element, but the payload no longer sends it; "+
+				"it will read as undefined at runtime", f)
+		}
+	}
+}
+
+func jsonTags(t *testing.T) []string {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "graph.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse graph.go: %v", err)
+	}
+	var out []string
+	ast.Inspect(f, func(n ast.Node) bool {
+		ts, ok := n.(*ast.TypeSpec)
+		if !ok || ts.Name.Name != "Data" {
+			return true
+		}
+		st, ok := ts.Type.(*ast.StructType)
+		if !ok {
+			return false
+		}
+		for _, fld := range st.Fields.List {
+			if fld.Tag == nil {
+				continue
+			}
+			tag := reflect.StructTag(strings.Trim(fld.Tag.Value, "`")).Get("json")
+			name, _, _ := strings.Cut(tag, ",")
+			if name != "" && name != "-" {
+				out = append(out, name)
+			}
+		}
+		return false
+	})
+	return out
+}
+
+func uiSources(t *testing.T) string {
+	t.Helper()
+	root := filepath.Join(repoRoot(t), "ui/src")
+	var b strings.Builder
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return err
+		}
+		if !strings.HasSuffix(path, ".ts") && !strings.HasSuffix(path, ".tsx") {
+			return nil
+		}
+		src, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		b.Write(src)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk ui/src: %v", err)
+	}
+	if b.Len() == 0 {
+		t.Fatal("read no UI sources; the check would pass vacuously")
+	}
+	return b.String()
+}
+
+func interfaceContaining(src, marker string) string {
+	for _, block := range regexp.MustCompile(`(?s)interface\s+\w+\s*\{.*?\n\}`).FindAllString(src, -1) {
+		if regexp.MustCompile(`(?m)^\s*` + marker + `\??:`).MatchString(block) {
+			return block
+		}
+	}
+	return ""
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("no go.mod above the test directory")
+		}
+		dir = parent
+	}
+}

--- a/internal/api/rest/rest.go
+++ b/internal/api/rest/rest.go
@@ -44,18 +44,33 @@ type Server struct {
 	events   *Broker
 	guard    Guard
 	authInfo auth.Info
+
+	// graphOpts caps how much per-pod detail the graph endpoint sends. Exposed
+	// as a knob because the right threshold depends on the operator's machine
+	// as much as on the cluster.
+	graphOpts graph.Options
+}
+
+// WithGraphPodDetailLimit overrides the pod count above which the graph
+// endpoint summarises pods onto their nodes. Zero or negative disables
+// aggregation entirely, which is a reasonable choice on a small cluster and a
+// poor one on a large.
+func (s *Server) WithGraphPodDetailLimit(limit int) *Server {
+	s.graphOpts.PodDetailLimit = limit
+	return s
 }
 
 // New builds a server. guard authorizes every route; authInfo is published
 // unauthenticated so a client knows how to sign in.
 func New(s store.Store, log *slog.Logger, version string, guard Guard, authInfo auth.Info) *Server {
 	return &Server{
-		store:    s,
-		log:      log,
-		version:  version,
-		events:   NewBroker(log),
-		guard:    guard,
-		authInfo: authInfo,
+		store:     s,
+		log:       log,
+		version:   version,
+		events:    NewBroker(log),
+		guard:     guard,
+		authInfo:  authInfo,
+		graphOpts: graph.DefaultOptions(),
 	}
 }
 
@@ -219,7 +234,7 @@ func (s *Server) handleGraph(w http.ResponseWriter, r *http.Request) {
 		s.fail(w, err)
 		return
 	}
-	writeJSON(w, http.StatusOK, graph.Build(rec.Plan, rec.Snapshot, rec.Analysis))
+	writeJSON(w, http.StatusOK, graph.BuildWith(rec.Plan, rec.Snapshot, rec.Analysis, s.graphOpts))
 }
 
 func (s *Server) handleSnapshot(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/rest/rest_test.go
+++ b/internal/api/rest/rest_test.go
@@ -186,7 +186,7 @@ func TestGraphPayloadShape(t *testing.T) {
 		t.Fatal("graph has no elements")
 	}
 
-	var nodes, pods, moveEdges int
+	var nodes, pods, other int
 	for _, raw := range elements {
 		el := raw.(map[string]any)
 		data := el["data"].(map[string]any)
@@ -195,15 +195,14 @@ func TestGraphPayloadShape(t *testing.T) {
 			nodes++
 		case "pod":
 			pods++
-			// Compound nesting is how Cytoscape draws "this node holds these
-			// pods" — without a parent the pod floats free.
+			// A pod names the node it sits inside. Without a parent the
+			// packing field has nowhere to draw it.
 			if data["parent"] == nil || data["parent"] == "" {
 				t.Errorf("pod %v has no parent node", data["id"])
 			}
-		case "edge":
-			if data["relation"] == "move" {
-				moveEdges++
-			}
+		default:
+			other++
+			t.Errorf("unexpected element kind %v", data["kind"])
 		}
 	}
 	if nodes != 2 {
@@ -212,8 +211,10 @@ func TestGraphPayloadShape(t *testing.T) {
 	if pods != 1 {
 		t.Errorf("pod elements = %d, want 1", pods)
 	}
-	if moveEdges != 1 {
-		t.Errorf("move edges = %d, want 1", moveEdges)
+	// Edges were dropped in M19. Nothing has read one since the packing field
+	// replaced the node-link graph, and they were 45% of the payload.
+	if other != 0 {
+		t.Errorf("payload carries %d elements that are neither node nor pod", other)
 	}
 
 	stats, _ := body["stats"].(map[string]any)

--- a/internal/model/plan.go
+++ b/internal/model/plan.go
@@ -116,4 +116,14 @@ type Move struct {
 	Pod       string `json:"pod"`
 	FromNode  string `json:"fromNode"`
 	ToNode    string `json:"toNode"`
+
+	// What the pod takes with it.
+	//
+	// Carried on the move rather than looked up, because above the graph
+	// endpoint's detail limit the UI has no per-pod data to look it up in.
+	// Without these the density view could empty a drained node but not show
+	// the receiving nodes filling — understating exactly the number an
+	// operator is judging the plan on.
+	CPUMilli    int64 `json:"cpuMilli,omitempty"`
+	MemoryBytes int64 `json:"memoryBytes,omitempty"`
 }

--- a/internal/planner/greedy.go
+++ b/internal/planner/greedy.go
@@ -137,10 +137,12 @@ func tryDrain(
 		trial.Remove(p)
 		trial.Place(p, target)
 		moves = append(moves, model.Move{
-			Namespace: p.Namespace,
-			Pod:       p.Name,
-			FromNode:  node.Name,
-			ToNode:    target,
+			Namespace:   p.Namespace,
+			Pod:         p.Name,
+			FromNode:    node.Name,
+			ToNode:      target,
+			CPUMilli:    p.Requests.MilliCPU,
+			MemoryBytes: p.Requests.MemoryBytes,
 		})
 	}
 	return moves, true

--- a/ui/package.json
+++ b/ui/package.json
@@ -8,7 +8,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "typecheck": "tsc -b --noEmit"
+    "typecheck": "tsc -b --noEmit",
+    "test:density": "esbuild test/density.ts --bundle --platform=node --format=cjs --outfile=node_modules/.cache/density.cjs --log-level=error && node node_modules/.cache/density.cjs"
   },
   "dependencies": {
     "@fontsource-variable/archivo": "^5.3.0",

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -8,6 +8,13 @@ export interface Move {
   pod: string;
   fromNode: string;
   toNode: string;
+  /**
+   * What the pod takes with it. Present so the density view can show receiving
+   * nodes filling as the scrubber advances — above the graph endpoint's detail
+   * limit there is no per-pod data to look this up in.
+   */
+  cpuMilli?: number;
+  memoryBytes?: number;
 }
 
 export interface ImpactReason {
@@ -44,12 +51,18 @@ export interface PlanResponse {
   readOnly: boolean;
 }
 
+// Mirrors graph.Data in internal/api/graph. Kept exactly in step with it by
+// graph_contract_test.go, which fails both ways: on a Go field the UI never
+// reads, and on a field declared here that the payload no longer sends. The
+// second half matters because every field is optional, so a stale declaration
+// reads as undefined at runtime rather than failing to compile.
+//
+// Where a pod moves and which step moves it are deliberately not here. Both
+// come from the plan's steps, which the UI already holds.
 export interface GraphData {
   id: string;
   parent?: string;
-  source?: string;
-  target?: string;
-  kind: "node" | "pod" | "edge";
+  kind: "node" | "pod";
   label: string;
 
   zone?: string;
@@ -59,9 +72,10 @@ export interface GraphData {
   cpuRequested?: number;
   memAllocatable?: number;
   memRequested?: number;
-  utilization?: number;
-  drained?: boolean;
   drainStep?: number;
+  podCount?: number;
+  blockedCount?: number;
+  pinnedCount?: number;
 
   namespace?: string;
   cpuRequest?: number;
@@ -69,16 +83,10 @@ export interface GraphData {
   ownerKind?: string;
   ownerName?: string;
   movable?: boolean;
-  targetNode?: string;
-  moveStep?: number;
   blocked?: boolean;
-
-  relation?: "move" | "pdb" | "anti-affinity";
-  impact?: string;
 }
 
 export interface GraphElement {
-  group: "nodes" | "edges";
   data: GraphData;
 }
 
@@ -97,6 +105,11 @@ export interface GraphPayload {
   planId: string;
   elements: GraphElement[];
   stats: GraphStats;
+  /**
+   * The server summarised pods onto their nodes rather than sending one
+   * element each, because there were more than it will draw individually.
+   */
+  aggregated?: boolean;
 }
 
 export interface PodConstraint {

--- a/ui/src/components/PackingField.tsx
+++ b/ui/src/components/PackingField.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { GraphPayload, PlanStep } from "../api";
 import {
   NODE_GAP_X,
@@ -6,6 +6,7 @@ import {
   POD_SIZE,
   Model,
   computeLayout,
+  densityCounts,
   gridColumns,
   peakOccupancy,
   placementAtStep,
@@ -30,6 +31,17 @@ import {
  * property, because ~300 blocks reflowing at once would drop frames on a
  * laptop, which is exactly the machine this runs on.
  */
+
+/**
+ * Above this many node boxes, only the visible band is mounted. Below it the
+ * whole field stays in the DOM: virtualising a few dozen boxes costs more in
+ * scroll bookkeeping than it saves, and the reveal and drain animations both
+ * read better when nothing is being added and removed underneath them.
+ */
+const VIRTUALISE_ABOVE = 150;
+
+/** Rows kept mounted beyond the viewport, so a fast scroll shows boxes, not gaps. */
+const OVERSCAN_ROWS = 3;
 
 interface Props {
   graph: GraphPayload;
@@ -65,9 +77,47 @@ export default function PackingField({
     [model, steps, step],
   );
   const layout = useMemo(
-    () => computeLayout(model, placement, peak, columns),
-    [model, placement, peak, columns],
+    () => computeLayout(model, placement, peak, columns, steps, step),
+    [model, placement, peak, columns, steps, step],
   );
+
+  // Virtualisation.
+  //
+  // The field is absolutely positioned on a computed grid, so which boxes are
+  // on screen is arithmetic rather than measurement: no observer per element,
+  // no layout thrash. Only the visible band is mounted, plus a margin so a
+  // scroll does not expose blank space before React catches up.
+  //
+  // Below the threshold everything mounts. Virtualising 30 boxes costs more in
+  // scroll handlers than it saves, and the drain animation reads better when
+  // every box is present.
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [viewport, setViewport] = useState({ top: 0, height: 0 });
+  const virtualise = model.nodes.length > VIRTUALISE_ABOVE;
+
+  useEffect(() => {
+    if (!virtualise) return;
+    const el = scrollRef.current;
+    if (!el) return;
+    let frame = 0;
+    const measure = () => {
+      frame = 0;
+      setViewport({ top: el.scrollTop, height: el.clientHeight });
+    };
+    const onScroll = () => {
+      // Coalesce to one update per frame; a scroll fires far faster than a
+      // render can usefully follow.
+      if (!frame) frame = requestAnimationFrame(measure);
+    };
+    measure();
+    el.addEventListener("scroll", onScroll, { passive: true });
+    window.addEventListener("resize", onScroll);
+    return () => {
+      if (frame) cancelAnimationFrame(frame);
+      el.removeEventListener("scroll", onScroll);
+      window.removeEventListener("resize", onScroll);
+    };
+  }, [virtualise, model.nodes.length]);
 
   // Nodes this plan drains at or before the current step. They stay on the
   // field rather than vanishing: an operator wants to see what was reclaimed,
@@ -108,6 +158,18 @@ export default function PackingField({
   const rows = Math.ceil(model.nodes.length / columns);
   const height = rows * (layout.nodeHeight + NODE_GAP_Y);
 
+  const rowHeight = layout.nodeHeight + NODE_GAP_Y;
+  const visible = useMemo(() => {
+    if (!virtualise || viewport.height === 0) return null;
+    const first = Math.max(0, Math.floor(viewport.top / rowHeight) - OVERSCAN_ROWS);
+    const last =
+      Math.ceil((viewport.top + viewport.height) / rowHeight) + OVERSCAN_ROWS;
+    return { from: first * columns, to: last * columns };
+  }, [virtualise, viewport, rowHeight, columns]);
+
+  const inView = (index: number) =>
+    !visible || (index >= visible.from && index < visible.to);
+
   // How many nodes the plan drains in total. The tray counts progress against
   // the plan, not against the cluster: showing "of 31" beside a header reading
   // "Reclaim 1 of 14" put two different denominators on one screen.
@@ -117,17 +179,21 @@ export default function PackingField({
   );
 
   const podsByNode = useMemo(() => {
+    // In density mode there are no pod elements to count, so occupancy comes
+    // from the server's tally with the plan's moves applied. Counting the
+    // empty pod list here would report every node as holding nothing.
+    if (model.aggregated) return densityCounts(model, steps, step);
     const out = new Map<string, number>();
     for (const pod of model.pods) {
       const host = placement.get(pod.key) ?? pod.homeNode;
       out.set(host, (out.get(host) ?? 0) + 1);
     }
     return out;
-  }, [model, placement]);
+  }, [model, placement, steps, step]);
 
   return (
     <div className="field-wrap">
-      <div className="field-scroll">
+      <div className="field-scroll" ref={scrollRef}>
         <div
           className="field"
           style={{ width, height }}
@@ -136,9 +202,10 @@ export default function PackingField({
             onSelectPod(null);
           }}
         >
-          {model.nodes.map((node) => {
+          {model.nodes.map((node, index) => {
             const pos = layout.nodes.get(node.id);
             if (!pos) return null;
+            if (!inView(index)) return null;
             const fill = layout.nodeFill.get(node.name) ?? 0;
             const gone = reclaimed.has(node.name);
             const count = podsByNode.get(node.name) ?? 0;
@@ -195,11 +262,31 @@ export default function PackingField({
                     }}
                   />
                 </div>
+                {/* Density mode: the pod count *is* the content. At this size
+                  an individual block conveys nothing, so the box states its
+                  occupancy and the story becomes nodes emptying rather than
+                  pods flying — the same story at the right zoom. */}
+                {model.aggregated && (
+                  <div className="box-density">
+                    <span className="box-density-count num">
+                      {gone ? 0 : count}
+                    </span>
+                    <span className="box-density-unit mono">pods</span>
+                    {!gone && node.blockedCount > 0 && (
+                      <span
+                        className="box-density-blocked mono"
+                        title={`${node.blockedCount} pods cannot move`}
+                      >
+                        ● {node.blockedCount}
+                      </span>
+                    )}
+                  </div>
+                )}
               </div>
             );
           })}
 
-          {model.pods.map((pod) => {
+          {!model.aggregated && model.pods.map((pod) => {
             const pos = layout.pods.get(pod.id);
             if (!pos) return null;
             const host = placement.get(pod.key) ?? pod.homeNode;

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1434,3 +1434,46 @@
 .ledger-more-hint {
   color: var(--graphite-dim);
 }
+
+/* Density mode.
+   Above the graph endpoint's detail limit the server sends occupancy instead
+   of pods, so a box has no blocks inside it. The count becomes the content:
+   large enough to read at a glance across a field of hundreds, with the fill
+   bar still carrying utilisation. Colour stays out of it — the risk scale owns
+   colour, and a node's fullness is not a risk rating. */
+.box-density {
+  display: flex;
+  align-items: baseline;
+  gap: 0.28rem;
+  padding: 0.35rem 0.5rem 0;
+  flex-wrap: wrap;
+}
+
+.box-density-count {
+  font-size: 1.35rem;
+  line-height: 1;
+  color: var(--chalk);
+  font-variant-numeric: tabular-nums;
+}
+
+.box-density-unit {
+  font-size: 0.62rem;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+}
+
+/* Blocked pods get the same filled-circle glyph the risk scale uses, so the
+   mark means the same thing here as everywhere else. Never colour alone. */
+.box-density-blocked {
+  margin-left: auto;
+  font-size: 0.62rem;
+  color: var(--risk-yellow);
+  white-space: nowrap;
+}
+
+/* A drained node keeps its place in the grid rather than vanishing, so the
+   operator can see what was reclaimed; the count going to zero is the whole
+   animation in this mode. */
+.box-reclaimed .box-density-count {
+  color: var(--muted);
+}

--- a/ui/src/layout.ts
+++ b/ui/src/layout.ts
@@ -31,6 +31,13 @@ export const POD_COLS = 4;
  */
 const MAX_POD_COLS = 10;
 
+/**
+ * Side of a node box in density mode, where nothing is drawn inside it but a
+ * count and a fill bar. Small enough that a thousand nodes fit a scroll or two,
+ * large enough for the count to stay readable.
+ */
+const DENSITY_BOX = 92;
+
 /** Columns for a box that must hold `peak` pods without becoming a tower. */
 export function podColumns(peak: number): number {
   if (peak <= POD_COLS * 2) return POD_COLS;
@@ -60,10 +67,23 @@ export interface NodeInfo {
   name: string;
   zone?: string;
   cpuAllocatable: number;
+  cpuRequestedMilli: number;
   memAllocatable: number;
   cordoned: boolean;
   ready: boolean;
   drainStep: number;
+
+  /**
+   * Occupancy as the server counted it.
+   *
+   * The single source in both modes. In density mode there are no pod elements
+   * to count; in detail mode counting them locally would give a second answer
+   * that could disagree with this one, and two numbers for "how full is this
+   * node" is worse than either.
+   */
+  podCount: number;
+  blockedCount: number;
+  pinnedCount: number;
 }
 
 export interface Positioned {
@@ -88,6 +108,15 @@ export interface Positioned {
 export interface Model {
   nodes: NodeInfo[];
   pods: PodInfo[];
+  /**
+   * True when the server summarised pods onto their nodes instead of sending
+   * them, because there were too many to draw individually.
+   *
+   * Read from the payload rather than inferred from an empty pod list: a
+   * fully-drained cluster has no pods either, and rendering that as "too big
+   * to show" would be a lie in the one case an operator most wants confirmed.
+   */
+  aggregated: boolean;
 }
 
 /** Extracts the domain model from the graph payload. */
@@ -103,10 +132,14 @@ export function toModel(graph: GraphPayload): Model {
         name: d.label,
         zone: d.zone,
         cpuAllocatable: d.cpuAllocatable ?? 0,
+        cpuRequestedMilli: d.cpuRequested ?? 0,
         memAllocatable: d.memAllocatable ?? 0,
         cordoned: d.cordoned ?? false,
         ready: d.ready ?? false,
         drainStep: d.drainStep ?? 0,
+        podCount: d.podCount ?? 0,
+        blockedCount: d.blockedCount ?? 0,
+        pinnedCount: d.pinnedCount ?? 0,
       });
     } else if (d.kind === "pod" && d.parent) {
       pods.push({
@@ -127,7 +160,7 @@ export function toModel(graph: GraphPayload): Model {
 
   nodes.sort((a, b) => collate(a.name, b.name));
   pods.sort((a, b) => collate(a.key, b.key));
-  return { nodes, pods };
+  return { nodes, pods, aggregated: graph.aggregated ?? false };
 }
 
 /**
@@ -162,7 +195,12 @@ export function computeLayout(
   placement: Map<string, string>,
   maxPodsPerNode: number,
   columns: number,
+  steps: PlanStep[] = [],
+  step = 0,
 ): Positioned {
+  if (model.aggregated) {
+    return densityLayout(model, columns, steps, step);
+  }
   const cols = podColumns(maxPodsPerNode);
   const rows = Math.max(2, Math.ceil(maxPodsPerNode / cols));
   const innerWidth = cols * POD_SIZE + (cols - 1) * POD_GAP;
@@ -238,4 +276,84 @@ export function gridColumns(nodeCount: number): number {
 /** Sorts names so node-2 comes before node-10. */
 function collate(a: string, b: string): number {
   return a.localeCompare(b, undefined, { numeric: true, sensitivity: "base" });
+}
+
+
+/**
+ * Layout when the server summarised pods onto their nodes.
+ *
+ * There are no pod elements to place, so the box is compact and its fill comes
+ * from the counts and requests the server sent. The scrubber still works: the
+ * plan's moves carry what each pod takes with it, so applying steps 1..n gives
+ * the exact occupancy and load at that step, not an estimate.
+ */
+function densityLayout(
+  model: Model,
+  columns: number,
+  steps: PlanStep[],
+  step: number,
+): Positioned {
+  const nodeWidth = DENSITY_BOX;
+  const nodeHeight = DENSITY_BOX;
+
+  const nodes = new Map<string, { x: number; y: number }>();
+  const nodeLoad = new Map<string, number>();
+  const nodeFill = new Map<string, number>();
+  const emptied = new Set<string>();
+
+  // Start from what the server counted, then apply the moves up to this step.
+  const count = new Map<string, number>();
+  const load = new Map<string, number>();
+  for (const n of model.nodes) {
+    count.set(n.name, n.podCount);
+    load.set(n.name, n.cpuRequestedMilli);
+  }
+  for (const s of steps) {
+    if (s.sequenceNumber > step) break;
+    for (const m of s.moves) {
+      count.set(m.fromNode, (count.get(m.fromNode) ?? 0) - 1);
+      count.set(m.toNode, (count.get(m.toNode) ?? 0) + 1);
+      load.set(m.fromNode, (load.get(m.fromNode) ?? 0) - (m.cpuMilli ?? 0));
+      load.set(m.toNode, (load.get(m.toNode) ?? 0) + (m.cpuMilli ?? 0));
+    }
+  }
+
+  model.nodes.forEach((node, i) => {
+    const col = i % columns;
+    const row = Math.floor(i / columns);
+    nodes.set(node.id, {
+      x: col * (nodeWidth + NODE_GAP_X),
+      y: row * (nodeHeight + NODE_GAP_Y),
+    });
+
+    const cpu = Math.max(0, load.get(node.name) ?? 0);
+    nodeLoad.set(node.name, cpu);
+    nodeFill.set(
+      node.name,
+      node.cpuAllocatable > 0 ? cpu / node.cpuAllocatable : 0,
+    );
+    // Pinned pods never move, so a node holding only pinned pods is never
+    // emptied however far the scrubber runs.
+    if ((count.get(node.name) ?? 0) <= node.pinnedCount) emptied.add(node.name);
+  });
+
+  return { nodes, pods: new Map(), nodeWidth, nodeHeight, nodeLoad, nodeFill, emptied };
+}
+
+/** Occupancy per node at a step, when pods were summarised rather than sent. */
+export function densityCounts(
+  model: Model,
+  steps: PlanStep[],
+  step: number,
+): Map<string, number> {
+  const count = new Map<string, number>();
+  for (const n of model.nodes) count.set(n.name, n.podCount);
+  for (const s of steps) {
+    if (s.sequenceNumber > step) break;
+    for (const m of s.moves) {
+      count.set(m.fromNode, (count.get(m.fromNode) ?? 0) - 1);
+      count.set(m.toNode, (count.get(m.toNode) ?? 0) + 1);
+    }
+  }
+  return count;
 }

--- a/ui/test/density.ts
+++ b/ui/test/density.ts
@@ -1,0 +1,75 @@
+/**
+ * Density-mode checks.
+ *
+ * There is no test runner in this project's UI, and adding one for a handful
+ * of pure functions was not worth the dependency. esbuild is already present
+ * for the build, so this bundles and runs under node: enough to hold the
+ * arithmetic that density mode depends on.
+ *
+ * It exists because density mode fails silently. Every value it reads is
+ * optional in the payload type, so a field that stops arriving reads as
+ * undefined and renders as zero — a node showing "0 pods" looks like a
+ * successful drain rather than a bug. This codebase has already shipped a
+ * blank page from exactly that shape of mistake.
+ *
+ *   npm run test:density
+ */
+import { toModel, computeLayout, densityCounts, gridColumns } from "../src/layout";
+import type { GraphPayload, PlanStep } from "../src/api";
+
+const node = (name: string, podCount: number, cpuReq: number, pinned = 0, blocked = 0) => ({
+  data: { id: `node:${name}`, kind: "node" as const, label: name,
+          cpuAllocatable: 8000, cpuRequested: cpuReq, memAllocatable: 1, memRequested: 1,
+          podCount, pinnedCount: pinned, blockedCount: blocked, drainStep: 0 },
+});
+
+const graph: GraphPayload = {
+  planId: "p", aggregated: true, stats: {} as never,
+  elements: [node("a", 4, 2000), node("b", 3, 1500), node("c", 0, 0)],
+};
+
+const steps: PlanStep[] = [{
+  id: "s1", sequenceNumber: 1, targetNode: "a", impact: "Green", rationale: "",
+  moves: [
+    { namespace: "d", pod: "p1", fromNode: "a", toNode: "b", cpuMilli: 500, memoryBytes: 1 },
+    { namespace: "d", pod: "p2", fromNode: "a", toNode: "b", cpuMilli: 500, memoryBytes: 1 },
+  ],
+}];
+
+let failures = 0;
+const check = (label: string, got: unknown, want: unknown) => {
+  const ok = JSON.stringify(got) === JSON.stringify(want);
+  if (!ok) { failures++; console.log(`  FAIL ${label}: got ${JSON.stringify(got)} want ${JSON.stringify(want)}`); }
+  else console.log(`  ok   ${label} = ${JSON.stringify(got)}`);
+};
+
+const model = toModel(graph);
+check("aggregated flag survives toModel", model.aggregated, true);
+check("no pod elements", model.pods.length, 0);
+check("podCount read from payload", model.nodes.map(n => n.podCount), [4, 3, 0]);
+
+// Step 0 — the cluster as it stands.
+const c0 = densityCounts(model, steps, 0);
+check("step 0 counts", [c0.get("a"), c0.get("b")], [4, 3]);
+
+// Step 1 — two pods move a -> b.
+const c1 = densityCounts(model, steps, 1);
+check("step 1 counts after 2 moves", [c1.get("a"), c1.get("b")], [2, 5]);
+
+const cols = gridColumns(model.nodes.length);
+const l0 = computeLayout(model, new Map(), 1, cols, steps, 0);
+const l1 = computeLayout(model, new Map(), 1, cols, steps, 1);
+
+check("fill at step 0 (a: 2000/8000)", l0.nodeFill.get("a"), 0.25);
+check("fill at step 0 (b: 1500/8000)", l0.nodeFill.get("b"), 0.1875);
+// The point of putting cpuMilli on Move: the receiving node must visibly fill.
+check("a drains by 1000 milli", l1.nodeLoad.get("a"), 1000);
+check("b GAINS 1000 milli", l1.nodeLoad.get("b"), 2500);
+check("b fill rises", l1.nodeFill.get("b")! > l0.nodeFill.get("b")!, true);
+check("boxes are positioned", l0.nodes.size, 3);
+check("density boxes are square-ish", l0.nodeWidth === l0.nodeHeight, true);
+check("empty node counts as emptied", l0.emptied.has("c"), true);
+check("occupied node not emptied at step 0", l0.emptied.has("a"), false);
+
+console.log(failures === 0 ? "\nALL DENSITY CHECKS PASSED" : `\n${failures} FAILURES`);
+process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
One DOM element per pod does not reach 50,000. Two changes, in this order, because the first made the second smaller.

## Stop sending what nothing reads

The graph payload carried an edge per proposed move, per anti-affinity relation and per PDB membership — **45% of all elements at 2,526 pods** — and nothing has read an edge since M11 replaced the node-link graph with the packing field. It also carried `utilization`, `drained`, `targetNode` and `moveStep`, which no code ever read. Building the PDB edges walked every pod for every PDB, so they were a quadratic term as well as dead weight.

**480 bytes per pod → 256.**

## Summarise pods above a threshold

Past `PodDetailLimit` (default 4,000, settable via `GRAPH_POD_DETAIL_LIMIT`) the payload sends occupancy per node instead of an element per pod.

| Pods | Before | After the cut | Aggregated | vs. before |
|---|---|---|---|---|
| 916 | 0.46 MB | 0.24 MB | — | 1.9× |
| 2,526 | 1.22 MB | 0.65 MB | **0.027 MB** | **44×** |
| 5,026 | 2.41 MB | 1.29 MB | **0.054 MB** | **44×** |

Per pod: 480 B → 256 B → **11 B**. At 50,000 pods that's ~24 MB → well under 1 MB, and ~95,000 DOM elements → roughly one per node.

At that density an individual 6px block conveys nothing, so this is less a degraded view than the right zoom level — the animation becomes nodes emptying rather than pods flying, which is the same story at the scale being asked about.

## Two supporting changes, to make it honest rather than merely small

- **`model.Move` now carries the pod's CPU and memory.** Without it the density view could empty a drained node but not show the *receiving* nodes filling — understating exactly the number an operator judges a plan on. Golden planner tests still produce byte-identical step lists.
- **The node element always carries `podCount`,** in both modes. Counting pod elements locally would give a second answer to "how full is this node", and two answers is worse than either.

## Virtualisation

Above 150 boxes only the visible band mounts, plus three rows of overscan. Which boxes are on screen is arithmetic over the computed grid rather than measurement — no observer per element, no layout thrash. Below the threshold everything mounts; virtualising a few dozen boxes costs more in scroll bookkeeping than it saves.

## Two guards, because both halves fail silently

- **`graph_contract_test.go`** parses the payload struct and fails on any field the UI never reads, so nothing outlives its last reader again. It fails the *other* way too — on an `api.ts` field the payload stopped sending — which matters because every field is optional, so a stale declaration reads as `undefined` at runtime rather than failing to compile. That half caught eight fields immediately.
- **`ui/test/density.ts`** asserts the density arithmetic under node via esbuild (no test-runner dependency added). A field that stops arriving renders a node as **"0 pods" — indistinguishable from a successful drain.** This codebase has already shipped a blank page from that shape of mistake. Wired into `make test` and CI.

## Verified live, both modes

Against the running 31-node / 121-pod fabric:

| | elements | bytes | aggregated |
|---|---|---|---|
| default limit (4000) | 152 (31 node + 121 pod) | 46 KB | false |
| limit forced to 50 | 31 (node only) | 8 KB | true |

`podCount` summed across nodes = **121**, exactly the pods present. No edges, no dead fields in either.

`go vet`, `go test -race`, `gofmt`, `make lint`, typecheck, density test and build all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)