### PR TITLE
M21: install it, drain a real node, prove the workload came back

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,10 +107,19 @@ jobs:
           go-version-file: go.mod
           cache: true
       - uses: azure/setup-helm@v4
-      - uses: AbsaOSS/k3d-action@v2
-        with:
-          cluster-name: noop
-          command: version
+
+      # Installed directly rather than through a marketplace action. The one
+      # tried first was pinned to a k3d release that no longer exists, and it
+      # created a cluster of its own that hack/e2e.sh does not want — the
+      # script builds and tears down its own. Pinned so a k3d release cannot
+      # change what this job tests without a commit.
+      - name: install k3d
+        env:
+          K3D_VERSION: v5.9.0
+        run: |
+          curl -sfL https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh \
+            | TAG="$K3D_VERSION" bash
+          k3d version
 
       - name: e2e
         run: ./hack/e2e.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,28 @@ jobs:
       # bundle, so anything tsc lets through still has to survive Vite.
       - run: npm run build
 
+  e2e:
+    name: e2e on a multi-node cluster
+    runs-on: ubuntu-latest
+    # The only job that installs anything. Everything else is unit tests,
+    # rendered templates, or benchmarks over synthesised fixtures — none of
+    # which evict a pod that is really running.
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - uses: azure/setup-helm@v4
+      - uses: AbsaOSS/k3d-action@v2
+        with:
+          cluster-name: noop
+          command: version
+
+      - name: e2e
+        run: ./hack/e2e.sh
+
   bench:
     name: benchmarks compile and run
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -168,6 +168,10 @@ endif
 # Lint
 # ---------------------------------------------------------------------------
 
+.PHONY: e2e
+e2e: ## Install on a throwaway multi-node k3d cluster and drain a real node
+	./hack/e2e.sh
+
 .PHONY: lint
 lint: $(KUBECONFORM) ## Chart portability gate: lint, render and assert the contract
 	@KUBECONFORM=$(KUBECONFORM) CHART=$(CHART) ./hack/lint-chart.sh

--- a/README.md
+++ b/README.md
@@ -128,11 +128,6 @@ helm install k8s-dencer oci://ghcr.io/atedgimo/charts/k8s-dencer \
   --set auth.enabled=true
 ```
 
-> **Not published yet.** The release pipeline is in place but no version has been
-> tagged, so the OCI chart and its images do not exist. Until then, install from
-> a checkout with `make deploy`. See
-> [docs/development.md](docs/development.md).
-
 Execution stays off unless you ask for it, and the chart refuses to enable it
 without authentication and persistence:
 
@@ -203,10 +198,18 @@ curves and the known ceiling in **[docs/benchmarks.md](docs/benchmarks.md)**.
 execution, and maintenance windows. Phase 4 — hardening toward 1000 nodes and
 50,000 pods — is in progress, with metrics, CI and the release pipeline landed.
 
-This is young software. It has been exercised end to end against a KWOK fabric
-and a real OIDC provider, and it has never run against a production cluster.
-Treat the read-only path as ready to try, and the executor as something to enable
-deliberately, on something you can afford to be wrong about.
+**v0.1.0 is published** — images and chart on `ghcr.io`, installable by the
+command above.
+
+Every release is verified end to end before it ships: CI stands up a five-node
+k3d cluster with PodSecurity enforcing `restricted`, installs the chart, plans
+against real workloads with real readiness probes, drains a node through the
+eviction API, and asserts the workload came back Ready. That is what
+[`make e2e`](hack/e2e.sh) does, and it runs on every pull request.
+
+It has still never run against a production cluster. Treat the read-only path
+as ready to try, and the executor as something to enable deliberately, on
+something you can afford to be wrong about.
 
 Full milestone history in [docs/roadmap.md](docs/roadmap.md).
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -30,6 +30,43 @@ make demo CLUSTER_PROVIDER=k3d
 
 ---
 
+## End-to-end
+
+```bash
+make e2e            # throwaway 5-node k3d cluster, installs, drains a real node
+KEEP=1 make e2e     # leave the cluster up afterwards
+./hack/e2e.sh clean # tear it down
+```
+
+The only gate that installs anything. Everything else in CI is unit tests,
+rendered templates, or benchmarks over synthesised fixtures — none of which
+evict a pod that is really running.
+
+It closes three gaps that nothing else could:
+
+- **`readiness: Ready` had never run anywhere.** The executor verifies recovery
+  on the PodReady condition, which is what stops it declaring a crash-looping
+  workload healthy and draining the next node. KWOK cannot exercise it — a fake
+  pod reaches Running and never becomes Ready, so the demo overlay sets
+  `readiness: Running`. Here the pods have containers and httpGet probes, and
+  the default is used.
+- **One node.** OrbStack is single-node, so co-scheduling and the ReadWriteOnce
+  claim's node affinity had never met a cluster that could get them wrong.
+- **PodSecurity was a grep.** The chart has claimed restricted-PSS compliance
+  since M0 on the strength of `helm template | grep`. Here the namespace
+  enforces it and the API server decides.
+
+Two things it needs that are worth knowing, because both look like bugs:
+
+- **Five nodes, not three.** The Safety Guard's `MinReadyNodes` floor defaults
+  to 3, so draining anything on a three-node cluster leaves two and the guard
+  refuses. Lowering the floor would test a configuration nobody runs.
+- **`minNodeAge=0s`.** The planner refuses to drain a node younger than ten
+  minutes — the rail that stops it reclaiming a node an autoscaler just added.
+  Sensible in production, fatal to a test that built its cluster seconds
+  earlier. On a genuinely fresh cluster, expect no plan for the first ten
+  minutes.
+
 ## Test fabric (KWOK)
 
 A node-consolidation planner cannot be tested on a single-node cluster. [KWOK](https://kwok.sigs.k8s.io/) provides fake nodes with no kubelet, so a laptop presents a 30-node topology while the **real** scheduler, PDB accounting and eviction API all apply.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -49,7 +49,8 @@ estimated — every milestone here starts from a number in
 | **M18** | Planner cost — memoised topology-spread counts, **112×** faster analysis at 5k pods | **done** |
 | **M19** | UI at scale — aggregated payload (**44×** smaller at 5k pods), density rendering, virtualised field | **done** |
 | **M20** | `/metrics` on all three components; monitors that scrape a real path; CI; published images | **done** |
-| **M21** | Multi-node k3d, PodSecurity enforcing, real ingress and StorageClass | planned |
+| **M21** | Multi-node k3d e2e in CI, PodSecurity **enforcing**, `readiness: Ready` on real pods | **done** |
+| **M21b** | Real ingress controller and StorageClass | planned |
 
 High availability and a Postgres store were **dropped, not deferred**: a
 consolidation planner is not a serving path. The run queue is already crash-safe

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -1,0 +1,309 @@
+#!/usr/bin/env bash
+#
+# End-to-end: install the chart on a multi-node cluster, plan against real
+# workloads, drain a node, and prove the workload came back.
+#
+# This exists because every other gate in this repository is a unit test, a
+# rendered template or a benchmark over synthesised fixtures. None of them
+# install anything, and none of them evict a pod that is really running.
+#
+# Three specific gaps it closes:
+#
+#   1. readiness: Ready had never run anywhere. The executor verifies recovery
+#      by waiting for the PodReady condition — the fix that stops it declaring
+#      a crash-looping workload healthy and draining the next node. The KWOK
+#      fabric cannot exercise it, because a fake pod reaches Running and never
+#      becomes Ready, so the demo overlay sets readiness: Running and the real
+#      path was covered only by a fake cluster in a Go test. Here the pods have
+#      containers and probes, and the default is used.
+#
+#   2. One node. OrbStack is a single node, so co-scheduling and the
+#      ReadWriteOnce claim's node affinity had never been exercised against a
+#      cluster that could get them wrong.
+#
+#   3. PodSecurity was a grep. The chart has claimed restricted-PSS compliance
+#      since M0 on the strength of `helm template | grep`. Here the namespace
+#      enforces it and the API server decides.
+#
+#   ./hack/e2e.sh            run it
+#   ./hack/e2e.sh clean      tear the cluster down
+#   KEEP=1 ./hack/e2e.sh     leave the cluster up afterwards for poking at
+#
+set -euo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CLUSTER="${CLUSTER:-dencer-e2e}"
+CTX="k3d-${CLUSTER}"
+NS="${NS:-k8s-dencer}"
+APP_NS="${APP_NS:-shop}"
+RELEASE="k8s-dencer"
+# Five nodes, not three. The Safety Guard's MinReadyNodes floor defaults to 3,
+# so on a three-node cluster draining anything would leave two and the guard
+# refuses — correctly. Lowering the floor to make the test pass would be
+# testing a configuration nobody runs; adding nodes tests the real one.
+AGENTS="${AGENTS:-4}"
+PF_PORT="${PF_PORT:-18099}"
+
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+bold()  { printf '\033[1m%s\033[0m\n' "$*"; }
+fail()  { red "FAIL: $*"; exit 1; }
+
+# k3d switches the current context on create. Anything else the operator has
+# open must not silently start pointing at a throwaway cluster — a lesson from
+# verify-sso.sh, which once left `make token` talking to the wrong API server.
+ORIGINAL_CTX="$(kubectl config current-context 2>/dev/null || true)"
+restore_context() {
+  if [[ -n "$ORIGINAL_CTX" ]] && kubectl config get-contexts -o name 2>/dev/null | grep -qx "$ORIGINAL_CTX"; then
+    kubectl config use-context "$ORIGINAL_CTX" >/dev/null 2>&1 || true
+  fi
+}
+
+PF=""
+cleanup() {
+  [[ -n "$PF" ]] && kill "$PF" 2>/dev/null || true
+  if [[ "${KEEP:-0}" != "1" ]]; then
+    k3d cluster delete "$CLUSTER" >/dev/null 2>&1 || true
+  fi
+  restore_context
+}
+trap cleanup EXIT
+
+if [[ "${1:-}" == "clean" ]]; then
+  k3d cluster delete "$CLUSTER" >/dev/null 2>&1 || true
+  restore_context
+  green "removed"
+  exit 0
+fi
+
+for bin in k3d kubectl helm docker; do
+  command -v "$bin" >/dev/null || fail "$bin is required"
+done
+
+# ---------------------------------------------------------------- cluster
+
+bold "==> multi-node cluster"
+k3d cluster delete "$CLUSTER" >/dev/null 2>&1 || true
+k3d cluster create "$CLUSTER" --servers 1 --agents "$AGENTS" --wait --timeout 300s >/dev/null
+nodes="$(kubectl --context "$CTX" get nodes --no-headers | wc -l | tr -d ' ')"
+[[ "$nodes" -ge 4 ]] || fail "expected at least 4 nodes for the guard's floor, got $nodes"
+green "  ${nodes} nodes"
+
+bold "==> namespace with PodSecurity enforcing"
+kubectl --context "$CTX" create namespace "$NS" >/dev/null
+# enforce, not warn. The chart has claimed restricted-PSS compliance since M0
+# on the strength of a grep; if any pod in the release violates it, admission
+# refuses and this script fails rather than a reviewer noticing later.
+kubectl --context "$CTX" label namespace "$NS" \
+  pod-security.kubernetes.io/enforce=restricted \
+  pod-security.kubernetes.io/enforce-version=latest >/dev/null
+kubectl --context "$CTX" create namespace "$APP_NS" >/dev/null
+kubectl --context "$CTX" label namespace "$APP_NS" \
+  pod-security.kubernetes.io/enforce=restricted \
+  pod-security.kubernetes.io/enforce-version=latest >/dev/null
+green "  restricted enforced on $NS and $APP_NS"
+
+# ---------------------------------------------------------------- images
+
+bold "==> images"
+TAG="$(make -s -C "$REPO" print-tag)"
+make -s -C "$REPO" images >/dev/null 2>&1 || fail "image build failed"
+k3d image import -c "$CLUSTER" \
+  "k8s-dencer-planner:${TAG}" "k8s-dencer-ui-backend:${TAG}" \
+  "k8s-dencer-executor:${TAG}" "k8s-dencer-ui-frontend:${TAG}" >/dev/null 2>&1 \
+  || fail "could not import images into the cluster"
+green "  built and imported ${TAG}"
+
+# ---------------------------------------------------------------- workload
+
+bold "==> real workloads"
+# Real containers with real readiness probes. This is the whole point: a KWOK
+# pod has no container to probe, so the Ready path could never be exercised.
+# nginx-unprivileged because it already runs rootless and read-only, which
+# restricted PSS requires and which the chart's own images satisfy.
+kubectl --context "$CTX" apply -f - >/dev/null <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+  namespace: ${APP_NS}
+spec:
+  replicas: 6
+  selector:
+    matchLabels: { app: web }
+  template:
+    metadata:
+      labels: { app: web }
+    spec:
+      terminationGracePeriodSeconds: 2
+      containers:
+        - name: web
+          image: nginxinc/nginx-unprivileged:1.27-alpine
+          ports: [{ containerPort: 8080 }]
+          # The probe is load-bearing for this test. The executor waits on the
+          # PodReady condition, so a pod that starts but never passes this
+          # would hold the drain open — which is exactly the behaviour being
+          # verified.
+          readinessProbe:
+            httpGet: { path: /, port: 8080 }
+            initialDelaySeconds: 1
+            periodSeconds: 2
+          resources:
+            requests: { cpu: 20m, memory: 24Mi }
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            capabilities: { drop: ["ALL"] }
+            seccompProfile: { type: RuntimeDefault }
+EOF
+kubectl --context "$CTX" -n "$APP_NS" rollout status deploy/web --timeout=180s >/dev/null \
+  || fail "test workload never became ready"
+ready="$(kubectl --context "$CTX" -n "$APP_NS" get deploy web -o jsonpath='{.status.readyReplicas}')"
+green "  ${ready} replicas Ready with httpGet probes"
+
+# ---------------------------------------------------------------- install
+
+# minNodeAge=0s: a fresh k3d cluster's nodes are seconds old, and the planner
+# correctly refuses to drain anything younger than minNodeAge — the rail that
+# stops it reclaiming a node an autoscaler added moments ago. Sensible in
+# production, fatal to a test that built its cluster ten seconds earlier.
+bold "==> install with execution on and readiness: Ready"
+helm --kube-context "$CTX" upgrade --install "$RELEASE" "$REPO/charts/k8s-dencer" \
+  --namespace "$NS" \
+  --set auth.enabled=true \
+  --set persistence.enabled=true \
+  --set executor.enabled=true \
+  --set planner.minNodeAge=0s \
+  --set-string planner.image.tag="$TAG" \
+  --set-string uiBackend.image.tag="$TAG" \
+  --set-string executor.image.tag="$TAG" \
+  --set-string uiFrontend.image.tag="$TAG" \
+  --set planner.image.pullPolicy=IfNotPresent \
+  --set uiBackend.image.pullPolicy=IfNotPresent \
+  --set executor.image.pullPolicy=IfNotPresent \
+  --set uiFrontend.image.pullPolicy=IfNotPresent \
+  --set-string planner.image.registry="" \
+  --set-string uiBackend.image.registry="" \
+  --set-string executor.image.registry="" \
+  --set-string uiFrontend.image.registry="" \
+  --set-string planner.image.repository=k8s-dencer-planner \
+  --set-string uiBackend.image.repository=k8s-dencer-ui-backend \
+  --set-string executor.image.repository=k8s-dencer-executor \
+  --set-string uiFrontend.image.repository=k8s-dencer-ui-frontend \
+  --wait --timeout 300s >/dev/null || {
+    kubectl --context "$CTX" -n "$NS" get pods
+    fail "chart did not install"
+  }
+
+# The default is Ready. Assert it rather than assume, because the whole value
+# of this run is that the Ready path executed.
+mode="$(kubectl --context "$CTX" -n "$NS" get deploy "${RELEASE}-executor" \
+  -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="EXECUTOR_READINESS")].value}')"
+[[ "${mode:-Ready}" == "Ready" ]] || fail "executor is on readiness=${mode}; this run would not exercise the Ready path"
+green "  installed, executor readiness=${mode:-Ready} (default)"
+
+# Admission had its say: every pod is running under enforced restricted PSS.
+green "  all pods admitted under enforced restricted PodSecurity"
+
+# ---------------------------------------------------------------- plan
+
+bold "==> a plan against real state"
+kubectl --context "$CTX" -n "$NS" port-forward "svc/${RELEASE}-ui-backend" "${PF_PORT}:8080" >/dev/null 2>&1 &
+PF=$!
+sleep 5
+
+kubectl --context "$CTX" get serviceaccount e2e-operator -n "$NS" >/dev/null 2>&1 \
+  || kubectl --context "$CTX" create serviceaccount e2e-operator -n "$NS" >/dev/null
+kubectl --context "$CTX" create rolebinding e2e-operator -n "$NS" \
+  --clusterrole="${RELEASE}-consolidation-operator" \
+  --serviceaccount="${NS}:e2e-operator" >/dev/null 2>&1 || true
+TOKEN="$(kubectl --context "$CTX" create token e2e-operator -n "$NS" --duration=30m)"
+
+api() { curl -sS -H "Authorization: Bearer ${TOKEN}" "http://localhost:${PF_PORT}$1" "${@:2}"; }
+
+plan=""
+for _ in $(seq 1 40); do
+  plan="$(api /api/v1/plans/latest 2>/dev/null || true)"
+  # The endpoint wraps the plan: {"plan": {...}, ...}. Reading "steps" off the
+  # top level silently yields zero, which looks exactly like "no plan yet".
+  steps="$(printf '%s' "$plan" | python3 -c 'import json,sys
+try:
+    d = json.load(sys.stdin)
+    print(len((d.get("plan") or d).get("steps") or []))
+except Exception:
+    print(0)' 2>/dev/null || echo 0)"
+  [[ "$steps" -gt 0 ]] && break
+  sleep 5
+done
+if [[ "${steps:-0}" -eq 0 ]]; then
+  # Say why, rather than leaving the next person to guess. The usual causes are
+  # a rail doing its job, not a broken planner.
+  red "planner produced no steps after 200s. Current state:"
+  kubectl --context "$CTX" -n "$NS" logs deploy/"${RELEASE}-planner" --tail=6 2>/dev/null | sed 's/^/    /'
+  echo "    node ages:"
+  kubectl --context "$CTX" get nodes -o custom-columns=NAME:.metadata.name,AGE:.metadata.creationTimestamp --no-headers | sed 's/^/      /'
+  fail "no plan"
+fi
+green "  plan with ${steps} steps"
+
+# Pick a step that does not need a maintenance window, and that actually moves
+# something — a step with no moves would drain an already-empty node and prove
+# nothing about recovery.
+read -r SEQ TARGET MOVES <<<"$(printf '%s' "$plan" | python3 -c '
+import json,sys
+d = json.load(sys.stdin)
+p = d.get("plan") or d
+for s in p.get("steps") or []:
+    if s.get("impact") != "Red" and s.get("moves"):
+        print(s["sequenceNumber"], s.get("targetNode",""), len(s["moves"])); break
+else:
+    print("", "", "")
+')"
+[[ -n "${SEQ:-}" ]] || fail "no non-Red step with moves; nothing to execute"
+green "  step ${SEQ} drains ${TARGET}, moving ${MOVES} pods"
+
+before_ready="$(kubectl --context "$CTX" -n "$APP_NS" get deploy web -o jsonpath='{.status.readyReplicas}')"
+
+# ---------------------------------------------------------------- execute
+
+bold "==> execute it"
+planid="$(printf '%s' "$plan" | python3 -c 'import json,sys; d=json.load(sys.stdin); print((d.get("plan") or d)["id"])')"
+run="$(api "/api/v1/plans/${planid}/execute" -X POST -H 'Content-Type: application/json' \
+  -d "{\"steps\":[${SEQ}]}")"
+# json.load consumes stdin, so read once and reuse it.
+runid="$(printf '%s' "$run" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("runId") or d.get("id",""))' 2>/dev/null || true)"
+[[ -n "$runid" ]] || fail "execute did not return a run id: $run"
+green "  run ${runid} queued"
+
+status=""
+for _ in $(seq 1 60); do
+  # Wrapped as {"run": {...}, "events": [...]}, like the plan endpoint.
+  status="$(api "/api/v1/runs/${runid}" | python3 -c 'import json,sys; d=json.load(sys.stdin); print((d.get("run") or d).get("status",""))' 2>/dev/null || true)"
+  case "$status" in Succeeded|Failed|Blocked) break;; esac
+  sleep 5
+done
+[[ "$status" == "Succeeded" ]] || {
+  api "/api/v1/runs/${runid}" | python3 -m json.tool | tail -40
+  fail "run ended ${status:-unknown}, want Succeeded"
+}
+green "  run Succeeded"
+
+# ---------------------------------------------------------------- verify
+
+bold "==> the cluster actually changed"
+sched="$(kubectl --context "$CTX" get node "$TARGET" -o jsonpath='{.spec.unschedulable}' 2>/dev/null || true)"
+[[ "$sched" == "true" ]] || fail "node ${TARGET} is not cordoned"
+green "  ${TARGET} cordoned"
+
+left="$(kubectl --context "$CTX" -n "$APP_NS" get pods --field-selector "spec.nodeName=${TARGET}" \
+  --no-headers 2>/dev/null | grep -vc Terminating || true)"
+[[ "${left:-0}" -eq 0 ]] || fail "${left} workload pods still on the drained node"
+green "  no workload pods left on it"
+
+after_ready="$(kubectl --context "$CTX" -n "$APP_NS" get deploy web -o jsonpath='{.status.readyReplicas}')"
+[[ "${after_ready:-0}" -eq "${before_ready}" ]] \
+  || fail "readyReplicas ${before_ready} -> ${after_ready}: the workload did not fully recover"
+green "  all ${after_ready} replicas Ready again — on the Ready path, with real probes"
+
+echo
+green "e2e passed: multi-node, PodSecurity enforced, real pods evicted and recovered."


### PR DESCRIPTION
Every gate in this repo was a unit test, a rendered template, or a benchmark over synthesised fixtures. **None installed anything, and none evicted a pod that was really running.** `hack/e2e.sh` does, on every PR.

```
==> multi-node cluster                5 nodes
==> namespace with PodSecurity        restricted enforced
==> real workloads                    6 replicas Ready with httpGet probes
==> install                           executor readiness=Ready (default)
                                      all pods admitted under enforced restricted PSS
==> a plan against real state         plan with 3 steps
                                      step 1 drains agent-0, moving 2 pods
==> execute it                        run Succeeded
==> the cluster actually changed      agent-0 cordoned
                                      no workload pods left on it
                                      all 6 replicas Ready again
```

## Three gaps nothing else could close

- **`readiness: Ready` had never run anywhere.** The executor verifies recovery on the PodReady condition — the fix that stops it calling a crash-looping workload healthy and draining the next node, and the one gap the Phase 4 plan called *outage-causing* rather than inconvenient. KWOK can't exercise it: a fake pod reaches Running and never becomes Ready, so the demo overlay sets `readiness: Running` and the real path lived only in a Go test against a fake cluster. Here the pods are nginx with httpGet probes and the default is used.
- **One node.** OrbStack is single-node, so co-scheduling and the RWO claim's node affinity had never met a cluster that could get them wrong.
- **PodSecurity was a grep.** The chart has claimed restricted-PSS compliance since M0 on the strength of `helm template | grep`. The namespace now *enforces* restricted and the API server decides. Every pod in the release is admitted under it.

## Two rails that looked like failures

Both worth knowing, both now documented:

- **`MinReadyNodes` refused to drain 1 of 3 nodes** — two is below the floor of three. So the cluster has **five** nodes rather than a lowered floor: a test that weakens a safety rail to pass is testing a configuration nobody runs.
- **No plan at all until `minNodeAge=0s`.** The planner won't touch a node younger than ten minutes — the rail against reclaiming a node an autoscaler just added. Correct, and it means **a genuinely fresh cluster shows no plan for ten minutes**, which will confuse a first-time user.

## Three bugs in the harness, all mine

- The plan and run endpoints wrap their payloads (`{"plan": {...}}`, `{"run": {...}}`). Reading `steps` and `status` off the top level silently returned `0` and `""` — indistinguishable from "no plan yet" and "still running".
- A comment placed inside a line-continuation swallowed the flag after it. `bash -n` accepts it; verified the hazard directly (`--second: command not found`).

## Also

**v0.1.0 is published.** All four images and the chart are public on `ghcr.io` and pull anonymously — verified with `docker manifest inspect` and `helm show chart`. The README's "not published yet" caveat is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)