### PR TITLE
CLI: dencer, for operators who don't want the UI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,50 @@ jobs:
           provenance: true
           sbom: true
 
+  cli:
+    name: build and attach CLI binaries
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: derive version
+        id: v
+        run: |
+          ref="${{ inputs.tag || github.ref_name }}"
+          echo "version=${ref#v}" >> "$GITHUB_OUTPUT"
+
+      # Static, cross-compiled, no cgo — the same properties the server images
+      # rely on, for the same reason: a CLI that can drain nodes should not
+      # depend on the libc of whatever machine it lands on.
+      - name: build
+        env:
+          VERSION: ${{ steps.v.outputs.version }}
+        run: |
+          mkdir -p dist
+          for target in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64; do
+            os="${target%/*}"; arch="${target#*/}"
+            CGO_ENABLED=0 GOOS="$os" GOARCH="$arch" go build \
+              -trimpath -ldflags="-s -w -X main.version=${VERSION}" \
+              -o "dist/dencer-${os}-${arch}" ./cmd/dencer
+          done
+          cd dist && sha256sum dencer-* > checksums.txt && cat checksums.txt
+
+      - name: attach to the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag || github.ref_name }}
+        run: |
+          gh release view "$TAG" >/dev/null 2>&1 || gh release create "$TAG" --generate-notes
+          gh release upload "$TAG" dist/dencer-* dist/checksums.txt --clobber
+
   chart:
     name: publish chart
     needs: images

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ ui/dist/
 /planner
 /executor
 /ui-backend
+bin/

--- a/Makefile
+++ b/Makefile
@@ -168,6 +168,19 @@ endif
 # Lint
 # ---------------------------------------------------------------------------
 
+.PHONY: cli
+cli: ## Build the dencer CLI into ./bin
+	@mkdir -p bin
+	go build -trimpath -ldflags="-s -w -X main.version=$(IMAGE_TAG)" -o bin/dencer ./cmd/dencer
+	@echo "built bin/dencer"
+
+.PHONY: cli-install
+cli-install: cli ## Install dencer and kubectl-dencer into $(GOBIN) or ~/go/bin
+	@dest="$${GOBIN:-$$HOME/go/bin}"; mkdir -p "$$dest"; \
+	install -m 0755 bin/dencer "$$dest/dencer"; \
+	ln -sf "$$dest/dencer" "$$dest/kubectl-dencer"; \
+	echo "installed $$dest/dencer and kubectl-dencer (so 'kubectl dencer plan' works)"
+
 .PHONY: e2e
 e2e: ## Install on a throwaway multi-node k3d cluster and drain a real node
 	./hack/e2e.sh

--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ happens to be able to execute, not an autoscaler with a UI.
   the rule that stopped it.
 - **Answers questions in natural language** through an optional Kagent agent
   that quotes the analyzer rather than re-deriving anything.
+- **Works without the UI.** `dencer` (also a `kubectl` plugin) does everything
+  the UI does from a terminal, with `-o json` for pipelines — see
+  [docs/cli.md](docs/cli.md).
 
 **Execution is off by default.** Until you set `executor.enabled=true`, no
 component in the release can cordon, evict, or write to a node — and `make lint`
@@ -183,6 +186,7 @@ curves and the known ceiling in **[docs/benchmarks.md](docs/benchmarks.md)**.
 | | |
 |---|---|
 | [Installation and configuration](docs/install.md) | Chart values, profiles, and the constraints each choice carries |
+| [CLI](docs/cli.md) | `dencer` and `kubectl dencer`, for operators who don't want the UI |
 | [Architecture](docs/architecture.md) | Components, analyzer, planner, impact ratings, API, UI |
 | [Authentication and authorization](docs/security.md) | Token delegation, OIDC/SSO, verifying the privilege split |
 | [Execution and safety](docs/execution.md) | Per-step behaviour, the guard's rails, maintenance windows, audit |

--- a/cmd/dencer/main.go
+++ b/cmd/dencer/main.go
@@ -1,0 +1,389 @@
+// Command dencer is the command-line client for k8s-dencer.
+//
+// Also installable as a kubectl plugin: name it kubectl-dencer on PATH and
+// `kubectl dencer plan` works, which is why every global flag mirrors
+// kubectl's spelling.
+//
+// No third-party CLI framework. The command set is small and flat, the flag
+// parsing is one stdlib FlagSet per subcommand, and the dependency tree of a
+// tool that can drain nodes is worth keeping short.
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/atedgimo/k8s-dencer/internal/cli"
+	"github.com/atedgimo/k8s-dencer/internal/store"
+)
+
+var version = "dev"
+
+const usage = `dencer — inspect and run Kubernetes node-consolidation plans.
+
+Usage:
+  dencer <command> [flags]
+
+Commands:
+  plan                  the current plan, one line per step
+  explain <step>        why a step is rated as it is, and what it moves
+  why <ns>/<pod>        why a pod can or cannot move
+  run --steps 1,3-5     execute selected steps and watch them
+  status                the run in flight, or the last one
+  version
+
+Global flags:
+  --server URL          backend base URL. Default: port-forward via kubeconfig
+  --token TOKEN         bearer token. Default: $DENCER_TOKEN, then kubeconfig
+  -n, --namespace NS    release namespace (default k8s-dencer)
+  --release NAME        Helm release name (default k8s-dencer)
+  --kubeconfig PATH     kubeconfig to use
+  --context NAME        kubeconfig context to use
+  -o, --output FORMAT   text (default), json or yaml
+  --timeout DURATION    per-request timeout (default 30s)
+
+Examples:
+  dencer plan
+  dencer explain 3
+  dencer why shop/web-7d9f-abcde
+  dencer run --steps 1,2 --dry-run
+  dencer plan -o json | jq '.plan.steps[] | select(.impact=="Red")'
+`
+
+type globals struct {
+	cfg    cli.Config
+	format cli.Format
+	// parsed validates flags that FlagSet cannot type-check for us. Called
+	// after Parse, before anything talks to the network.
+	parsed func() error
+}
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	if len(os.Args) < 2 {
+		fmt.Print(usage)
+		return nil
+	}
+	cmd := os.Args[1]
+	args := os.Args[2:]
+
+	switch cmd {
+	case "-h", "--help", "help":
+		fmt.Print(usage)
+		return nil
+	case "version":
+		fmt.Printf("dencer %s\n", version)
+		return nil
+	}
+
+	// Ctrl-C cancels the request, not the run. A drain in flight belongs to
+	// the executor and keeps going; the watcher says so on the way out.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	switch cmd {
+	case "plan":
+		return cmdPlan(ctx, args)
+	case "explain":
+		return cmdExplain(ctx, args)
+	case "why":
+		return cmdWhy(ctx, args)
+	case "run":
+		return cmdRun(ctx, args)
+	case "status":
+		return cmdStatus(ctx, args)
+	default:
+		return fmt.Errorf("unknown command %q\n\n%s", cmd, usage)
+	}
+}
+
+// bind registers the flags every subcommand accepts.
+func bind(fs *flag.FlagSet) *globals {
+	g := &globals{format: cli.FormatText}
+	var format string
+	fs.StringVar(&g.cfg.Server, "server", "", "backend base URL")
+	fs.StringVar(&g.cfg.Token, "token", "", "bearer token")
+	fs.StringVar(&g.cfg.Namespace, "namespace", "k8s-dencer", "release namespace")
+	fs.StringVar(&g.cfg.Namespace, "n", "k8s-dencer", "release namespace (shorthand)")
+	fs.StringVar(&g.cfg.Release, "release", "k8s-dencer", "Helm release name")
+	fs.StringVar(&g.cfg.Kubeconfig, "kubeconfig", "", "kubeconfig path")
+	fs.StringVar(&g.cfg.Context, "context", "", "kubeconfig context")
+	fs.StringVar(&format, "output", "text", "text, json or yaml")
+	fs.StringVar(&format, "o", "text", "output format (shorthand)")
+	fs.DurationVar(&g.cfg.Timeout, "timeout", 30*time.Second, "per-request timeout")
+	fs.BoolVar(&g.cfg.Insecure, "insecure-skip-tls-verify", false, "skip API server certificate verification")
+	fs.Usage = func() { fmt.Print(usage) }
+
+	g.parsed = func() error {
+		switch format {
+		case "text", "json", "yaml":
+			g.format = cli.Format(format)
+			return nil
+		}
+		return fmt.Errorf("unknown output format %q; want text, json or yaml", format)
+	}
+	return g
+}
+
+func connect(ctx context.Context, g *globals) (*cli.Client, error) {
+	if err := g.parsed(); err != nil {
+		return nil, err
+	}
+	return cli.Connect(ctx, g.cfg)
+}
+
+func cmdPlan(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("plan", flag.ExitOnError)
+	g := bind(fs)
+	id := fs.String("id", "latest", "plan id, or 'latest'")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	c, err := connect(ctx, g)
+	if err != nil {
+		return err
+	}
+	defer c.Close()
+
+	env, err := c.Plan(ctx, *id)
+	if err != nil {
+		return err
+	}
+	if g.format != cli.FormatText {
+		return cli.Encode(os.Stdout, g.format, env)
+	}
+	cli.PrintPlan(os.Stdout, env)
+	return nil
+}
+
+func cmdExplain(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("explain", flag.ExitOnError)
+	g := bind(fs)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() < 1 {
+		return errors.New("which step? e.g. dencer explain 3")
+	}
+	seq, err := cli.ParseSteps(fs.Arg(0))
+	if err != nil || len(seq) != 1 {
+		return fmt.Errorf("%q is not a single step number", fs.Arg(0))
+	}
+
+	c, err := connect(ctx, g)
+	if err != nil {
+		return err
+	}
+	defer c.Close()
+
+	plan, err := c.Plan(ctx, "latest")
+	if err != nil {
+		return err
+	}
+	env, err := c.Step(ctx, plan.Plan.ID, seq[0])
+	if err != nil {
+		return err
+	}
+	if g.format != cli.FormatText {
+		return cli.Encode(os.Stdout, g.format, env)
+	}
+	cli.PrintStep(os.Stdout, env)
+	return nil
+}
+
+func cmdWhy(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("why", flag.ExitOnError)
+	g := bind(fs)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() < 1 {
+		return errors.New("which pod? e.g. dencer why shop/web-7d9f-abcde")
+	}
+	ns, pod, ok := strings.Cut(fs.Arg(0), "/")
+	if !ok || ns == "" || pod == "" {
+		return fmt.Errorf("want namespace/pod, got %q", fs.Arg(0))
+	}
+
+	c, err := connect(ctx, g)
+	if err != nil {
+		return err
+	}
+	defer c.Close()
+
+	plan, err := c.Plan(ctx, "latest")
+	if err != nil {
+		return err
+	}
+	pc, err := c.PodConstraints(ctx, plan.Plan.ID, ns, pod)
+	if err != nil {
+		return err
+	}
+	if g.format != cli.FormatText {
+		return cli.Encode(os.Stdout, g.format, pc)
+	}
+	cli.PrintPodConstraints(os.Stdout, pc)
+	return nil
+}
+
+func cmdRun(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("run", flag.ExitOnError)
+	g := bind(fs)
+	steps := fs.String("steps", "", "steps to run, e.g. 1,3-5")
+	dryRun := fs.Bool("dry-run", false, "run every guard check and emit the same events without cordoning or evicting")
+	watch := fs.Bool("watch", true, "follow the run until it finishes")
+	yes := fs.Bool("yes", false, "skip the confirmation prompt")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *steps == "" {
+		return errors.New("which steps? e.g. dencer run --steps 1,3-5")
+	}
+	want, err := cli.ParseSteps(*steps)
+	if err != nil {
+		return err
+	}
+
+	c, err := connect(ctx, g)
+	if err != nil {
+		return err
+	}
+	defer c.Close()
+
+	plan, err := c.Plan(ctx, "latest")
+	if err != nil {
+		return err
+	}
+
+	// Show what is about to happen before doing it. This tool evicts pods, and
+	// "dencer run --steps 1-9" typed in the wrong terminal should not be a
+	// silent success.
+	if !*dryRun && !*yes {
+		confirmed, err := confirm(plan, want)
+		if err != nil {
+			return err
+		}
+		if !confirmed {
+			fmt.Println("Nothing was run.")
+			return nil
+		}
+	}
+
+	runID, err := c.Execute(ctx, plan.Plan.ID, want, *dryRun)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("run %s queued for steps %v", runID, want)
+	if *dryRun {
+		fmt.Print(" (dry run: nothing will be cordoned or evicted)")
+	}
+	fmt.Println()
+
+	if !*watch {
+		fmt.Printf("Follow it with: dencer status --run %s\n", runID)
+		return nil
+	}
+
+	final, err := c.Wait(ctx, runID, func(ev store.RunEvent) {
+		cli.PrintEvent(os.Stdout, ev)
+	})
+	if err != nil {
+		return err
+	}
+
+	fmt.Println()
+	switch final.Status {
+	case store.RunSucceeded:
+		fmt.Printf("Succeeded. %s\n", final.Summary)
+		return nil
+	case store.RunBlocked:
+		// A guard refusal is the product working, not an error in the usual
+		// sense — but it still must not exit 0, or a CI pipeline would treat a
+		// refused consolidation as a completed one.
+		return fmt.Errorf("blocked by the Safety Guard: %s", final.Summary)
+	default:
+		return fmt.Errorf("run %s: %s", final.Status, final.Summary)
+	}
+}
+
+func cmdStatus(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("status", flag.ExitOnError)
+	g := bind(fs)
+	runID := fs.String("run", "", "a specific run id")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	c, err := connect(ctx, g)
+	if err != nil {
+		return err
+	}
+	defer c.Close()
+
+	if *runID == "" {
+		active, err := c.ActiveRun(ctx)
+		if err != nil {
+			return err
+		}
+		if active == nil {
+			if g.format != cli.FormatText {
+				return cli.Encode(os.Stdout, g.format, map[string]any{"active": nil})
+			}
+			fmt.Println("No run in flight.")
+			return nil
+		}
+		*runID = active.ID
+	}
+
+	env, err := c.Run(ctx, *runID)
+	if err != nil {
+		return err
+	}
+	if g.format != cli.FormatText {
+		return cli.Encode(os.Stdout, g.format, env)
+	}
+	cli.PrintRun(os.Stdout, env)
+	return nil
+}
+
+// confirm shows what is about to be evicted and asks.
+func confirm(plan *cli.PlanEnvelope, want []int) (bool, error) {
+	fmt.Printf("About to run %d step(s) against plan %s:\n\n", len(want), plan.Plan.ID)
+	moves := 0
+	red := 0
+	for _, s := range plan.Plan.Steps {
+		for _, n := range want {
+			if s.SequenceNumber != n {
+				continue
+			}
+			fmt.Printf("  step %d  %-6s  drain %s (%d pods)\n",
+				s.SequenceNumber, s.Impact, s.TargetNode, len(s.Moves))
+			moves += len(s.Moves)
+			if s.Impact == "Red" {
+				red++
+			}
+		}
+	}
+	fmt.Printf("\n%d pod(s) will be evicted through the eviction API.\n", moves)
+	if red > 0 {
+		fmt.Printf("%d step(s) are Red and will be refused unless a MaintenanceWindow is open.\n", red)
+	}
+	fmt.Print("\nContinue? [y/N] ")
+
+	var answer string
+	_, _ = fmt.Scanln(&answer)
+	answer = strings.ToLower(strings.TrimSpace(answer))
+	return answer == "y" || answer == "yes", nil
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,6 +3,7 @@
 | | |
 |---|---|
 | **[Installation and configuration](install.md)** | Installing the chart, values profiles, and the constraints each choice carries |
+| **[CLI](cli.md)** | `dencer` and `kubectl dencer` — inspect and run plans without the UI |
 | **[Architecture](architecture.md)** | Components, the constraint analyzer, the planner, impact ratings, the API and the UI |
 | **[Authentication and authorization](security.md)** | TokenReview and SubjectAccessReview delegation, OIDC/SSO, and how to verify the privilege split yourself |
 | **[Execution and safety](execution.md)** | What the executor does per step, the Safety Guard's rails, maintenance windows, and the audit trail |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,127 @@
+# CLI
+
+`dencer` is a client of the REST API, not a second planner. Everything it
+shows was computed by the planner, and everything it asks for is authorised by
+the same SubjectAccessReview the UI goes through.
+
+That is the whole design decision. A CLI that talked to the cluster directly
+would need its own copy of the constraint analyzer and the Safety Guard, and
+the interesting failure would be the two copies disagreeing about whether a
+step is Red.
+
+## Install
+
+Download a binary from the [latest release](https://github.com/atedgimo/k8s-dencer/releases),
+or build from a checkout:
+
+```bash
+make cli-install    # installs dencer and kubectl-dencer into $GOBIN
+```
+
+The symlink is what makes `kubectl dencer plan` work — kubectl treats any
+`kubectl-*` binary on PATH as a plugin. Every global flag is spelled the way
+kubectl spells it, so muscle memory carries over.
+
+## Connecting
+
+With no flags, `dencer` finds the `ui-backend` Service through your kubeconfig
+and port-forwards to it, the same way `kubectl port-forward` would. Nothing to
+set up on a fresh install.
+
+```bash
+dencer plan                                   # port-forward via kubeconfig
+dencer plan --server https://dencer.example   # an Ingress, no port-forward
+dencer plan -n platform --release dencer      # a differently-named release
+```
+
+### Authentication
+
+The backend verifies identity with `TokenReview`, which only understands
+**bearer tokens**. If your kubeconfig authenticates with a client certificate —
+the default on k3d, kind and OrbStack — there is no token to send, and the CLI
+says so rather than letting the server answer "unauthenticated":
+
+```bash
+export DENCER_TOKEN="$(kubectl create token dencer-operator -n k8s-dencer)"
+dencer plan
+```
+
+With OIDC single sign-on the ID token in your kubeconfig is already a
+Kubernetes credential and is used directly.
+
+## Commands
+
+### `dencer plan`
+
+The current plan, one line per step, leading with the next action.
+
+```
+plan 754f04015304  4s old, greedy-first-fit-decreasing
+28 nodes now, 13 after, 15 reclaimable
+
+STEP  IMPACT    DRAINS        PODS  WHY
+1     ■ Red     kwok-node-12  3     Draining kwok-node-12 moves 3 pod(s). Rated Red…
+2     ● Green   kwok-node-16  3     Draining kwok-node-16 moves 3 pod(s). No disrup…
+
+Next: drain kwok-node-16 (● Green)
+  dencer run --steps 2
+
+■ 3 step(s) are Red and need an open MaintenanceWindow.
+```
+
+### `dencer explain <step>`
+
+Why a step is rated as it is, what it moves, and which pods on that node
+cannot.
+
+### `dencer why <namespace>/<pod>`
+
+Whether a pod can move and what is stopping it. Constraint explanations are
+printed **verbatim** — the analyzer's `Explanation` is the single canonical
+wording, and the UI and the Kagent agent quote the same string. If the CLI
+paraphrased, one constraint could be described three ways and an operator would
+have no way to tell which to believe.
+
+### `dencer run --steps 1,3-5`
+
+Executes the selected steps and follows them. Ranges and lists both work.
+
+Before evicting anything it shows what is about to happen and asks. `--yes`
+skips the prompt for scripts; `--dry-run` runs every guard check and emits the
+same events without cordoning or evicting.
+
+```
+run 9d251edd  Succeeded
+  ▲ 14:22:07 Guard    kwok-node-3   refused [PDBHeadroom]
+```
+
+**Exit codes carry the outcome.** A run refused by the Safety Guard exits
+non-zero, because a pipeline must not treat a refused consolidation as a
+completed one. Ctrl-C stops watching but does not stop the run — the executor
+owns it, and the CLI says so on the way out.
+
+### `dencer status`
+
+The run in flight, or a specific one with `--run <id>`, plus its audit trail.
+
+## Scripting
+
+Every command takes `-o json` or `-o yaml`, and colour turns itself off when
+output is not a terminal (`NO_COLOR` is honoured too).
+
+```bash
+# Fail a pipeline if the plan has grown a Red step
+dencer plan -o json | jq -e '[.plan.steps[] | select(.impact=="Red")] | length == 0'
+
+# Run every Green step, unattended
+dencer run --yes --steps "$(dencer plan -o json \
+  | jq -r '[.plan.steps[] | select(.impact=="Green") | .sequenceNumber] | join(",")')"
+```
+
+Risk is never carried by colour alone: each rating prints a glyph (`●` `▲` `■`)
+and its word, so the output survives a pipe, a CI log and a reader who cannot
+distinguish red from green.
+
+---
+
+[← Documentation index](README.md) · [Project README](../README.md)

--- a/go.mod
+++ b/go.mod
@@ -28,10 +28,12 @@ require (
 	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/moby/spdystream v0.5.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
@@ -65,6 +67,7 @@ require (
 	k8s.io/apiextensions-apiserver v0.36.0 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
+	k8s.io/streaming v0.36.3 // indirect
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect
 	modernc.org/libc v1.74.1 // indirect
 	modernc.org/mathutil v1.7.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,8 @@ github.com/google/pprof v0.0.0-20250403155104-27863c87afa6 h1:BHT72Gu3keYf3ZEu2J
 github.com/google/pprof v0.0.0-20250403155104-27863c87afa6/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5THxAzdVpqr6/geYxZytqFMBCOtn/ujyeo=
+github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674/go.mod h1:r4w70xmWCQKmi1ONH4KIaBptdivuRPyosB9RmPlGEwA=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
@@ -71,6 +73,8 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/moby/spdystream v0.5.1 h1:9sNYeYZUcci9R6/w7KDaFWEWeV4LStVG78Mpyq/Zm/Y=
+github.com/moby/spdystream v0.5.1/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
 github.com/modelcontextprotocol/go-sdk v1.6.1 h1:0zOSupjKUxPKSocPT1Wtago+mUHU2/uZ4xSOY0FGReU=
 github.com/modelcontextprotocol/go-sdk v1.6.1/go.mod h1:kzm3kzFL1/+AziGOE0nUs3gvPoNxMCvkxokMkuFapXQ=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -182,6 +186,8 @@ k8s.io/klog/v2 v2.140.0 h1:Tf+J3AH7xnUzZyVVXhTgGhEKnFqye14aadWv7bzXdzc=
 k8s.io/klog/v2 v2.140.0/go.mod h1:o+/RWfJ6PwpnFn7OyAG3QnO47BFsymfEfrz6XyYSSp0=
 k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a h1:xCeOEAOoGYl2jnJoHkC3hkbPJgdATINPMAxaynU2Ovg=
 k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a/go.mod h1:uGBT7iTA6c6MvqUvSXIaYZo9ukscABYi2btjhvgKGZ0=
+k8s.io/streaming v0.36.3 h1:9rAaqBk0C0Pc7+/fqGekj07NV+/Xrew58p647A0JT8w=
+k8s.io/streaming v0.36.3/go.mod h1:z6fV3D+NVkoeqRMtWwlUZK6U17SY/LqNzOxWL6GyR/s=
 k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 h1:AZYQSJemyQB5eRxqcPky+/7EdBj0xi3g0ZcxxJ7vbWU=
 k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2/go.mod h1:xDxuJ0whA3d0I4mf/C4ppKHxXynQ+fxnkmQH0vTHnuk=
 modernc.org/cc/v4 v4.29.0 h1:CXgwL8cvxmyzBQZzbSl/6xFtMCryb6u8IOqDci39cgc=

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -1,0 +1,341 @@
+// Package cli implements the dencer command-line client.
+//
+// It is a client of the REST API, not a second planner. Everything it shows
+// was computed by the planner and everything it asks for is authorised by the
+// same SubjectAccessReview the UI goes through. Re-deriving a plan locally
+// would put two implementations of the safety rails in the product, and the
+// interesting failure mode would be the two disagreeing about whether a step
+// is Red.
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
+)
+
+// Client talks to a k8s-dencer ui-backend.
+type Client struct {
+	base   string
+	token  string
+	http   *http.Client
+	closer func()
+}
+
+// Config selects how to reach the backend and how to authenticate.
+type Config struct {
+	// Server is an explicit base URL. When empty the client port-forwards to
+	// the Service through the kubeconfig, so the common case needs no setup.
+	Server string
+
+	// Token is a bearer token. When empty the client tries to find one in the
+	// kubeconfig.
+	Token string
+
+	Namespace  string
+	Release    string
+	Kubeconfig string
+	Context    string
+	Timeout    time.Duration
+	Insecure   bool
+}
+
+// Connect establishes a client.
+//
+// The default path deliberately does the awkward thing for the user: it finds
+// the Service and port-forwards to it, the same way `kubectl port-forward`
+// would, so `dencer plan` works on a fresh install with no flags. An operator
+// who has exposed the backend through an Ingress passes --server and none of
+// this runs.
+func Connect(ctx context.Context, cfg Config) (*Client, error) {
+	if cfg.Timeout == 0 {
+		cfg.Timeout = 30 * time.Second
+	}
+	c := &Client{
+		http:   &http.Client{Timeout: cfg.Timeout},
+		closer: func() {},
+	}
+
+	if cfg.Server != "" {
+		c.base = strings.TrimRight(cfg.Server, "/")
+		c.token = cfg.Token
+		if c.token == "" {
+			c.token = os.Getenv("DENCER_TOKEN")
+		}
+		return c, nil
+	}
+
+	restCfg, err := restConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	if cfg.Insecure {
+		restCfg.Insecure = true
+		restCfg.CAData = nil
+		restCfg.CAFile = ""
+	}
+
+	c.token = cfg.Token
+	if c.token == "" {
+		c.token = os.Getenv("DENCER_TOKEN")
+	}
+	if c.token == "" {
+		c.token, err = tokenFrom(restCfg)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	clientset, err := kubernetes.NewForConfig(restCfg)
+	if err != nil {
+		return nil, fmt.Errorf("kubernetes client: %w", err)
+	}
+
+	local, stop, err := forward(ctx, restCfg, clientset, cfg.Namespace, cfg.Release)
+	if err != nil {
+		return nil, err
+	}
+	c.base = fmt.Sprintf("http://localhost:%d", local)
+	c.closer = stop
+	return c, nil
+}
+
+// Close releases the port-forward, if one was opened.
+func (c *Client) Close() {
+	if c.closer != nil {
+		c.closer()
+	}
+}
+
+func restConfig(cfg Config) (*rest.Config, error) {
+	rules := clientcmd.NewDefaultClientConfigLoadingRules()
+	if cfg.Kubeconfig != "" {
+		rules.ExplicitPath = cfg.Kubeconfig
+	}
+	overrides := &clientcmd.ConfigOverrides{}
+	if cfg.Context != "" {
+		overrides.CurrentContext = cfg.Context
+	}
+	rc, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(rules, overrides).ClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("no usable kubeconfig: %w", err)
+	}
+	return rc, nil
+}
+
+// tokenFrom digs a bearer token out of the kubeconfig.
+//
+// This is where a client-certificate kubeconfig — the default on k3d, kind and
+// OrbStack — cannot help. The backend authenticates with TokenReview, which
+// only understands bearer tokens; a certificate authenticates to the API
+// server and means nothing to a TokenReview call. Rather than fail with
+// "unauthenticated" from the server and leave the user guessing, say so here
+// and name the fix.
+func tokenFrom(cfg *rest.Config) (string, error) {
+	if cfg.BearerToken != "" {
+		return cfg.BearerToken, nil
+	}
+	if cfg.BearerTokenFile != "" {
+		b, err := os.ReadFile(cfg.BearerTokenFile)
+		if err == nil && len(bytes.TrimSpace(b)) > 0 {
+			return string(bytes.TrimSpace(b)), nil
+		}
+	}
+	if cfg.ExecProvider != nil || cfg.AuthProvider != nil {
+		// An exec or OIDC provider produces a token, but only through the
+		// transport. Round-tripping it here would mean reimplementing
+		// client-go's credential plumbing.
+		return "", errors.New(
+			"your kubeconfig authenticates through a credential plugin, which this client cannot read directly.\n" +
+				"Pass a token explicitly:\n" +
+				"  dencer --token \"$(kubectl create token <serviceaccount> -n <namespace>)\" ...\n" +
+				"or set DENCER_TOKEN.")
+	}
+	return "", errors.New(
+		"your kubeconfig authenticates with a client certificate, and the backend verifies\n" +
+			"identity with TokenReview, which only accepts bearer tokens. A certificate proves who\n" +
+			"you are to the API server but cannot be reviewed as a token.\n\n" +
+			"Mint one:\n" +
+			"  dencer --token \"$(kubectl create token dencer-operator -n k8s-dencer)\" plan\n" +
+			"or set DENCER_TOKEN once for the session.")
+}
+
+// forward opens a port-forward to the ui-backend Service.
+func forward(ctx context.Context, cfg *rest.Config, cs kubernetes.Interface, ns, release string) (int, func(), error) {
+	svcName := release + "-ui-backend"
+	svc, err := cs.CoreV1().Services(ns).Get(ctx, svcName, metav1.GetOptions{})
+	if err != nil {
+		return 0, nil, fmt.Errorf(
+			"could not find Service %s/%s: %w\n"+
+				"Pass --namespace/--release if the release is named differently, or --server if the\n"+
+				"backend is reachable directly", ns, svcName, err)
+	}
+	port := int32(8080)
+	if len(svc.Spec.Ports) > 0 {
+		port = svc.Spec.Ports[0].Port
+	}
+
+	// Forwarding addresses a pod, not a Service. Picking the pod here rather
+	// than shelling out to kubectl keeps this a single static binary.
+	sel := labelSelector(svc.Spec.Selector)
+	pods, err := cs.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{LabelSelector: sel})
+	if err != nil {
+		return 0, nil, fmt.Errorf("list backend pods: %w", err)
+	}
+	var target *corev1.Pod
+	for i := range pods.Items {
+		if pods.Items[i].Status.Phase == corev1.PodRunning {
+			target = &pods.Items[i]
+			break
+		}
+	}
+	if target == nil {
+		return 0, nil, fmt.Errorf("no running %s pod in namespace %s", svcName, ns)
+	}
+
+	targetPort := port
+	if len(svc.Spec.Ports) > 0 && svc.Spec.Ports[0].TargetPort.IntValue() != 0 {
+		targetPort = int32(svc.Spec.Ports[0].TargetPort.IntValue())
+	}
+
+	roundTripper, upgrader, err := spdy.RoundTripperFor(cfg)
+	if err != nil {
+		return 0, nil, fmt.Errorf("spdy transport: %w", err)
+	}
+	host := strings.TrimLeft(cfg.Host, "htps:/")
+	serverURL := url.URL{
+		Scheme: "https",
+		Path:   fmt.Sprintf("/api/v1/namespaces/%s/pods/%s/portforward", ns, target.Name),
+		Host:   host,
+	}
+	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: roundTripper}, http.MethodPost, &serverURL)
+
+	// Port 0 lets the kernel choose, so two dencer invocations cannot collide
+	// and neither collides with a `make ui` the operator left running.
+	stopCh := make(chan struct{})
+	readyCh := make(chan struct{})
+	fw, err := portforward.New(dialer, []string{fmt.Sprintf("0:%d", targetPort)}, stopCh, readyCh, io.Discard, io.Discard)
+	if err != nil {
+		return 0, nil, fmt.Errorf("port-forward: %w", err)
+	}
+	errCh := make(chan error, 1)
+	go func() { errCh <- fw.ForwardPorts() }()
+
+	select {
+	case <-readyCh:
+	case err := <-errCh:
+		return 0, nil, fmt.Errorf("port-forward failed: %w", err)
+	case <-time.After(20 * time.Second):
+		close(stopCh)
+		return 0, nil, errors.New("timed out opening a port-forward to the backend")
+	}
+
+	ports, err := fw.GetPorts()
+	if err != nil || len(ports) == 0 {
+		close(stopCh)
+		return 0, nil, errors.New("port-forward opened but reported no local port")
+	}
+	return int(ports[0].Local), func() { close(stopCh) }, nil
+}
+
+func labelSelector(m map[string]string) string {
+	parts := make([]string, 0, len(m))
+	for k, v := range m {
+		parts = append(parts, k+"="+v)
+	}
+	return strings.Join(parts, ",")
+}
+
+// get fetches a JSON document into out.
+func (c *Client) get(ctx context.Context, path string, out any) error {
+	return c.do(ctx, http.MethodGet, path, nil, out)
+}
+
+func (c *Client) do(ctx context.Context, method, path string, body any, out any) error {
+	var rdr io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			return err
+		}
+		rdr = bytes.NewReader(b)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.base+path, rdr)
+	if err != nil {
+		return err
+	}
+	if c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		var netErr net.Error
+		if errors.As(err, &netErr) && netErr.Timeout() {
+			return fmt.Errorf("timed out talking to %s", c.base)
+		}
+		return fmt.Errorf("cannot reach %s: %w", c.base, err)
+	}
+	defer resp.Body.Close()
+
+	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 64<<20))
+	if resp.StatusCode >= 400 {
+		return apiError(resp.StatusCode, raw)
+	}
+	if out == nil {
+		return nil
+	}
+	if err := json.Unmarshal(raw, out); err != nil {
+		return fmt.Errorf("unexpected response from %s: %w", path, err)
+	}
+	return nil
+}
+
+// apiError turns the server's error envelope into something worth reading.
+func apiError(status int, raw []byte) error {
+	var e struct {
+		Error string `json:"error"`
+		Code  string `json:"code"`
+	}
+	_ = json.Unmarshal(raw, &e)
+	msg := e.Error
+	if msg == "" {
+		msg = strings.TrimSpace(string(raw))
+	}
+	switch status {
+	case http.StatusUnauthorized:
+		return fmt.Errorf("not authenticated: %s\nThe token was rejected. Mint a fresh one:\n"+
+			"  export DENCER_TOKEN=\"$(kubectl create token dencer-operator -n k8s-dencer)\"", msg)
+	case http.StatusForbidden:
+		// Naming the verb matters: the fix is a RoleBinding, and the user
+		// cannot guess which one from "forbidden".
+		return fmt.Errorf("not authorized: %s\nExecution needs 'create consolidations.dencer.io';\n"+
+			"reading needs 'get plans.dencer.io'. Both are checked against cluster RBAC", msg)
+	case http.StatusNotFound:
+		return fmt.Errorf("not found: %s", msg)
+	}
+	if msg == "" {
+		msg = http.StatusText(status)
+	}
+	return fmt.Errorf("%s (HTTP %d)", msg, status)
+}

--- a/internal/cli/client_test.go
+++ b/internal/cli/client_test.go
@@ -1,0 +1,186 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/atedgimo/k8s-dencer/internal/model"
+	"github.com/atedgimo/k8s-dencer/internal/store"
+)
+
+func TestParseSteps(t *testing.T) {
+	good := map[string][]int{
+		"1":       {1},
+		"1,3,5":   {1, 3, 5},
+		"1-4":     {1, 2, 3, 4},
+		"3,1-2,5": {1, 2, 3, 5},
+		"2,2,2":   {2},
+		" 1 , 3 ": {1, 3},
+		"5-5":     {5},
+	}
+	for in, want := range good {
+		got, err := ParseSteps(in)
+		if err != nil {
+			t.Errorf("%q: %v", in, err)
+			continue
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("%q = %v, want %v", in, got, want)
+		}
+	}
+
+	// A range that counts backwards is a typo, not an empty selection. Silently
+	// running nothing would look like success.
+	for _, bad := range []string{"", "x", "4-2", "1-", "-3", ",,", "1,x"} {
+		if got, err := ParseSteps(bad); err == nil {
+			t.Errorf("%q should be rejected, got %v", bad, got)
+		}
+	}
+}
+
+// The plan and run endpoints wrap their payloads. Reading "steps" or "status"
+// off the top level yields the zero value, which is indistinguishable from "no
+// plan yet" and "still running" — a mistake that cost a debugging session in
+// hack/e2e.sh before this client existed.
+func TestClientUnwrapsTheEnvelopes(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/plans/latest"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"plan": map[string]any{
+					"id":    "abc123",
+					"steps": []map[string]any{{"sequenceNumber": 1, "impact": "Green", "targetNode": "n1"}},
+				},
+				"strategy": "greedy",
+				"ratings":  map[string]int{"Green": 1},
+			})
+		case strings.Contains(r.URL.Path, "/runs/"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"run":    map[string]any{"id": "r1", "status": "Succeeded", "summary": "done"},
+				"events": []map[string]any{{"action": "Cordon", "message": "cordoned n1"}},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := &Client{base: srv.URL, http: srv.Client(), closer: func() {}}
+	ctx := context.Background()
+
+	plan, err := c.Plan(ctx, "latest")
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if plan.Plan.ID != "abc123" {
+		t.Errorf("plan id = %q, want abc123", plan.Plan.ID)
+	}
+	if len(plan.Plan.Steps) != 1 {
+		t.Errorf("steps = %d, want 1 — the envelope was not unwrapped", len(plan.Plan.Steps))
+	}
+
+	run, err := c.Run(ctx, "r1")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if run.Run.Status != store.RunSucceeded {
+		t.Errorf("status = %q, want Succeeded — the envelope was not unwrapped", run.Run.Status)
+	}
+	if len(run.Events) != 1 {
+		t.Errorf("events = %d, want 1", len(run.Events))
+	}
+}
+
+// An error the user cannot act on is barely better than a stack trace. Each of
+// these has a specific fix, and the message has to name it.
+func TestErrorsNameTheFix(t *testing.T) {
+	cases := []struct {
+		status int
+		body   string
+		want   []string
+	}{
+		{http.StatusUnauthorized, `{"error":"authentication required"}`,
+			[]string{"kubectl create token", "DENCER_TOKEN"}},
+		{http.StatusForbidden, `{"error":"forbidden"}`,
+			[]string{"create consolidations.dencer.io", "get plans.dencer.io"}},
+		{http.StatusNotFound, `{"error":"pod x/y is not in plan p"}`,
+			[]string{"pod x/y is not in plan p"}},
+	}
+	for _, tc := range cases {
+		err := apiError(tc.status, []byte(tc.body))
+		if err == nil {
+			t.Fatalf("status %d produced no error", tc.status)
+		}
+		for _, want := range tc.want {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("status %d message does not mention %q:\n%s", tc.status, want, err)
+			}
+		}
+	}
+}
+
+// Wait must not report a run finished while it is still going, and must not
+// spin forever on a terminal one.
+func TestWaitStopsOnTerminalStatusOnly(t *testing.T) {
+	polls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		polls++
+		status := "Running"
+		events := []map[string]any{{"action": "Cordon", "message": "cordoned"}}
+		if polls >= 2 {
+			status = "Blocked"
+			events = append(events, map[string]any{"action": "Guard", "rule": "PDBHeadroom", "message": "refused"})
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"run":    map[string]any{"id": "r1", "status": status},
+			"events": events,
+		})
+	}))
+	defer srv.Close()
+
+	c := &Client{base: srv.URL, http: srv.Client(), closer: func() {}}
+	var seen []string
+	final, err := c.Wait(context.Background(), "r1", func(ev store.RunEvent) {
+		seen = append(seen, ev.Action)
+	})
+	if err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	if final.Status != store.RunBlocked {
+		t.Errorf("final status = %q, want Blocked", final.Status)
+	}
+	// Each event exactly once, however many times it was polled.
+	if !reflect.DeepEqual(seen, []string{"Cordon", "Guard"}) {
+		t.Errorf("events delivered = %v, want [Cordon Guard] once each", seen)
+	}
+}
+
+// Colour is a presentation choice; the glyph and the word are the information.
+// Stripping colour must never remove either, or piping the output would drop
+// the risk rating entirely.
+func TestRatingSurvivesWithoutColour(t *testing.T) {
+	saved := colour
+	defer func() { colour = saved; resetPainters() }()
+
+	colour = false
+	resetPainters()
+	for _, want := range []string{"Green", "Yellow", "Red"} {
+		got := impactMark(ratingFor(want))
+		if !strings.Contains(got, want) {
+			t.Errorf("uncoloured mark %q does not contain the word %q", got, want)
+		}
+		if strings.Contains(got, "\033[") {
+			t.Errorf("uncoloured mark still carries escape codes: %q", got)
+		}
+		if !strings.ContainsAny(got, "●▲■") {
+			t.Errorf("uncoloured mark %q has no glyph; colour would be the only carrier", got)
+		}
+	}
+}
+
+func ratingFor(s string) model.ImpactRating { return model.ImpactRating(s) }

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -1,0 +1,179 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/atedgimo/k8s-dencer/internal/constraints"
+	"github.com/atedgimo/k8s-dencer/internal/model"
+	"github.com/atedgimo/k8s-dencer/internal/store"
+)
+
+// PlanEnvelope is what GET /api/v1/plans/{id} returns.
+type PlanEnvelope struct {
+	Plan     *model.Plan    `json:"plan"`
+	Strategy string         `json:"strategy"`
+	StoredAt time.Time      `json:"storedAt"`
+	Ratings  map[string]int `json:"ratings"`
+}
+
+type RunEnvelope struct {
+	Run    *store.Run       `json:"run"`
+	Events []store.RunEvent `json:"events"`
+}
+
+type StepEnvelope struct {
+	PlanID      string                       `json:"planId"`
+	Step        model.PlanStep               `json:"step"`
+	Constraints []constraints.PodConstraints `json:"constraints"`
+}
+
+// Plan fetches a plan. id may be "latest".
+func (c *Client) Plan(ctx context.Context, id string) (*PlanEnvelope, error) {
+	var out PlanEnvelope
+	if err := c.get(ctx, "/api/v1/plans/"+id, &out); err != nil {
+		return nil, err
+	}
+	if out.Plan == nil {
+		return nil, fmt.Errorf("no plan available yet")
+	}
+	return &out, nil
+}
+
+// Step fetches one step with the constraints of the pods it moves.
+func (c *Client) Step(ctx context.Context, planID string, seq int) (*StepEnvelope, error) {
+	var out StepEnvelope
+	err := c.get(ctx, fmt.Sprintf("/api/v1/plans/%s/steps/%d", planID, seq), &out)
+	return &out, err
+}
+
+// PodConstraints explains why one pod can or cannot move.
+func (c *Client) PodConstraints(ctx context.Context, planID, ns, pod string) (*constraints.PodConstraints, error) {
+	var out constraints.PodConstraints
+	err := c.get(ctx, fmt.Sprintf("/api/v1/plans/%s/constraints/%s/%s", planID, ns, pod), &out)
+	return &out, err
+}
+
+// Execute queues steps and returns the run id.
+func (c *Client) Execute(ctx context.Context, planID string, steps []int, dryRun bool) (string, error) {
+	var out struct {
+		RunID string `json:"runId"`
+	}
+	body := map[string]any{"steps": steps, "dryRun": dryRun}
+	if err := c.do(ctx, "POST", "/api/v1/plans/"+planID+"/execute", body, &out); err != nil {
+		return "", err
+	}
+	return out.RunID, nil
+}
+
+// Run fetches a run and its audit trail.
+func (c *Client) Run(ctx context.Context, id string) (*RunEnvelope, error) {
+	var out RunEnvelope
+	if err := c.get(ctx, "/api/v1/runs/"+id, &out); err != nil {
+		return nil, err
+	}
+	if out.Run == nil {
+		return nil, fmt.Errorf("run %s not found", id)
+	}
+	return &out, nil
+}
+
+// ActiveRun returns the run in flight, or nil.
+func (c *Client) ActiveRun(ctx context.Context) (*store.Run, error) {
+	var out struct {
+		Active *store.Run `json:"active"`
+	}
+	err := c.get(ctx, "/api/v1/runs", &out)
+	return out.Active, err
+}
+
+// Wait polls a run until it reaches a terminal state, reporting events as they
+// appear.
+//
+// Polling rather than the SSE stream: a run is minutes long and a poll is one
+// request every two seconds, whereas a streaming client has to handle
+// reconnection, and getting that subtly wrong in a tool people watch a drain
+// through is a poor trade for the latency it saves.
+func (c *Client) Wait(ctx context.Context, runID string, onEvent func(store.RunEvent)) (*store.Run, error) {
+	seen := 0
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		env, err := c.Run(ctx, runID)
+		if err != nil {
+			return nil, err
+		}
+		for _, ev := range env.Events[min(seen, len(env.Events)):] {
+			if onEvent != nil {
+				onEvent(ev)
+			}
+		}
+		seen = len(env.Events)
+
+		switch env.Run.Status {
+		case store.RunSucceeded, store.RunFailed, store.RunBlocked:
+			return env.Run, nil
+		}
+
+		select {
+		case <-ctx.Done():
+			// The run keeps going server-side; say so rather than implying
+			// Ctrl-C stopped a drain that is still evicting pods.
+			return nil, fmt.Errorf("stopped watching run %s; it is still running in the cluster", runID)
+		case <-ticker.C:
+		}
+	}
+}
+
+// ParseSteps accepts "1,3,5" and "1-4" and any mixture.
+func ParseSteps(spec string) ([]int, error) {
+	var out []int
+	seen := map[int]bool{}
+	for _, part := range strings.Split(spec, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		lo, hi, isRange := strings.Cut(part, "-")
+		if !isRange {
+			n, err := strconv.Atoi(lo)
+			if err != nil {
+				return nil, fmt.Errorf("%q is not a step number", part)
+			}
+			if !seen[n] {
+				seen[n], out = true, append(out, n)
+			}
+			continue
+		}
+		a, err1 := strconv.Atoi(strings.TrimSpace(lo))
+		b, err2 := strconv.Atoi(strings.TrimSpace(hi))
+		if err1 != nil || err2 != nil {
+			return nil, fmt.Errorf("%q is not a step range", part)
+		}
+		if a > b {
+			return nil, fmt.Errorf("range %q counts backwards", part)
+		}
+		for n := a; n <= b; n++ {
+			if !seen[n] {
+				seen[n], out = true, append(out, n)
+			}
+		}
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("no steps selected")
+	}
+	sort.Ints(out)
+	return out, nil
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -1,0 +1,339 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/atedgimo/k8s-dencer/internal/constraints"
+	"github.com/atedgimo/k8s-dencer/internal/model"
+	"github.com/atedgimo/k8s-dencer/internal/store"
+)
+
+// Colour is off unless the output is a terminal that wants it.
+//
+// The rule the UI established holds here too: colour means risk and nothing
+// else. It is also never the only carrier — every rating prints its glyph and
+// its word, so the output survives a pipe, a CI log, a monochrome terminal and
+// a reader who cannot distinguish red from green.
+var (
+	colour = wantsColour()
+	green  func(string) string
+	yellow func(string) string
+	red    func(string) string
+	dim    func(string) string
+	bold   func(string) string
+)
+
+func init() { resetPainters() }
+
+// resetPainters rebinds the colour helpers to the current value of colour.
+// Exists so a test can turn colour off and check that the glyph and the word
+// still carry the rating on their own.
+func resetPainters() {
+	green = paint("\033[32m")
+	yellow = paint("\033[33m")
+	red = paint("\033[31m")
+	dim = paint("\033[2m")
+	bold = paint("\033[1m")
+}
+
+func wantsColour() bool {
+	if os.Getenv("NO_COLOR") != "" || os.Getenv("TERM") == "dumb" {
+		return false
+	}
+	fi, err := os.Stdout.Stat()
+	return err == nil && fi.Mode()&os.ModeCharDevice != 0
+}
+
+func paint(code string) func(string) string {
+	return func(s string) string {
+		if !colour {
+			return s
+		}
+		return code + s + "\033[0m"
+	}
+}
+
+// glyph and word for an impact rating.
+//
+// ● ▲ ■ rather than three coloured dots: deuteranopia collapses the red/green
+// distinction, and the glyphs differ in shape as well as hue. The word is
+// always printed too.
+func impactMark(i model.ImpactRating) string {
+	switch i {
+	case model.ImpactGreen:
+		return green("● Green ")
+	case model.ImpactYellow:
+		return yellow("▲ Yellow")
+	case model.ImpactRed:
+		return red("■ Red   ")
+	default:
+		return string(i)
+	}
+}
+
+// Format selects the output encoding.
+type Format string
+
+const (
+	FormatText Format = "text"
+	FormatJSON Format = "json"
+	FormatYAML Format = "yaml"
+)
+
+// Encode writes v in the requested machine-readable format.
+func Encode(w io.Writer, f Format, v any) error {
+	switch f {
+	case FormatJSON:
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		return enc.Encode(v)
+	case FormatYAML:
+		b, err := yaml.Marshal(v)
+		if err != nil {
+			return err
+		}
+		_, err = w.Write(b)
+		return err
+	}
+	return fmt.Errorf("unknown format %q", f)
+}
+
+// PrintPlan renders a plan as a table.
+func PrintPlan(w io.Writer, env *PlanEnvelope) {
+	p := env.Plan
+	age := time.Since(p.GeneratedAt).Round(time.Second)
+
+	fmt.Fprintf(w, "%s  %s\n", bold("plan "+p.ID), dim(fmt.Sprintf("%s old, %s", age, env.Strategy)))
+	fmt.Fprintf(w, "%d nodes now, %d after, %s\n\n",
+		p.NodesBefore, p.NodesAfter, bold(fmt.Sprintf("%d reclaimable", p.ReclaimedNodes())))
+
+	if len(p.Steps) == 0 {
+		fmt.Fprintln(w, "No steps. Nothing to consolidate — every node is either needed or undrainable.")
+		return
+	}
+
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "STEP\tIMPACT\tDRAINS\tPODS\tWHY")
+	for _, s := range p.Steps {
+		fmt.Fprintf(tw, "%d\t%s\t%s\t%d\t%s\n",
+			s.SequenceNumber, impactMark(s.Impact), s.TargetNode, len(s.Moves), truncate(s.Rationale, 58))
+	}
+	tw.Flush()
+
+	// Lead with the action, as the UI does: the operator's next move is the
+	// point of the page, not the inventory above it.
+	if next := firstRunnable(p); next != nil {
+		fmt.Fprintf(w, "\n%s\n  dencer run --steps %d\n",
+			bold("Next:")+fmt.Sprintf(" drain %s (%s)", next.TargetNode, strings.TrimSpace(stripANSI(impactMark(next.Impact)))),
+			next.SequenceNumber)
+	}
+	if n := countRed(p); n > 0 {
+		fmt.Fprintf(w, "\n%s %d step(s) are Red and need an open MaintenanceWindow.\n", red("■"), n)
+	}
+}
+
+// firstRunnable is the first step that does not need a maintenance window.
+func firstRunnable(p *model.Plan) *model.PlanStep {
+	for i := range p.Steps {
+		if p.Steps[i].Impact != model.ImpactRed {
+			return &p.Steps[i]
+		}
+	}
+	return nil
+}
+
+func countRed(p *model.Plan) int {
+	n := 0
+	for _, s := range p.Steps {
+		if s.Impact == model.ImpactRed {
+			n++
+		}
+	}
+	return n
+}
+
+// PrintStep renders one step and why it is rated as it is.
+func PrintStep(w io.Writer, env *StepEnvelope) {
+	s := env.Step
+	fmt.Fprintf(w, "%s  %s\n", bold(fmt.Sprintf("step %d", s.SequenceNumber)), impactMark(s.Impact))
+	fmt.Fprintf(w, "drains %s, moving %d pod(s)\n\n", s.TargetNode, len(s.Moves))
+	fmt.Fprintf(w, "%s\n", s.Rationale)
+
+	if len(s.Reasons) > 0 {
+		fmt.Fprintf(w, "\n%s\n", bold("Because"))
+		for _, r := range s.Reasons {
+			line := "  - " + r.Kind
+			if r.Subject != "" {
+				line += " " + r.Subject
+			}
+			if r.Detail != "" {
+				line += ": " + r.Detail
+			}
+			fmt.Fprintln(w, line)
+		}
+	}
+
+	if len(s.Moves) > 0 {
+		fmt.Fprintf(w, "\n%s\n", bold("Moves"))
+		tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(tw, "  POD\tFROM\tTO")
+		for _, m := range s.Moves {
+			fmt.Fprintf(tw, "  %s/%s\t%s\t%s\n", m.Namespace, m.Pod, m.FromNode, m.ToNode)
+		}
+		tw.Flush()
+	}
+
+	blocked := 0
+	for _, pc := range env.Constraints {
+		if !pc.Movable {
+			blocked++
+		}
+	}
+	if blocked > 0 {
+		fmt.Fprintf(w, "\n%s %d of the pods on this node cannot move. Run 'dencer why <ns>/<pod>' for one.\n",
+			yellow("▲"), blocked)
+	}
+}
+
+// PrintPodConstraints explains one pod.
+func PrintPodConstraints(w io.Writer, pc *constraints.PodConstraints) {
+	verdict := green("● can move")
+	if !pc.Movable {
+		verdict = red("■ cannot move")
+	}
+	fmt.Fprintf(w, "%s  %s\n", bold(pc.Key()), verdict)
+	if pc.NodeName != "" {
+		fmt.Fprintf(w, "on %s\n", pc.NodeName)
+	}
+
+	// Constraint.Explanation is described in the analyzer as "the single
+	// canonical human-readable description", and a test already asserts the
+	// Kagent agent reproduces it byte-for-byte. The same rule applies here: if
+	// the CLI paraphrased, the CLI, the UI and the agent could describe one
+	// constraint three ways and an operator would have no way to tell which to
+	// believe. So the explanation is printed as-is.
+	blockers := pc.Blockers()
+	if len(blockers) > 0 {
+		fmt.Fprintf(w, "\n%s\n", bold("Blocked by"))
+		for _, c := range blockers {
+			fmt.Fprintf(w, "  %s %s\n", red("■"), constraintLine(c))
+		}
+	}
+
+	var informational []constraints.Constraint
+	for _, c := range pc.Constraints {
+		if !c.Blocking {
+			informational = append(informational, c)
+		}
+	}
+	if len(informational) > 0 {
+		fmt.Fprintf(w, "\n%s\n", bold("Also constrained by"))
+		for _, c := range informational {
+			fmt.Fprintf(w, "  %s %s\n", dim("·"), constraintLine(c))
+		}
+	}
+
+	fmt.Fprintf(w, "\n%d node(s) could take it", len(pc.CandidateNodes))
+	if pc.Movable && len(pc.CandidateNodes) == 0 {
+		// The distinction the analyzer draws and a summary would lose: nothing
+		// forbids this pod moving, there is simply nowhere to put it.
+		fmt.Fprintf(w, " — %s: nothing forbids moving it, but nowhere has room", yellow("effectively stuck"))
+	}
+	fmt.Fprintln(w)
+}
+
+// PrintRun renders a run and its audit trail.
+func PrintRun(w io.Writer, env *RunEnvelope) {
+	r := env.Run
+	fmt.Fprintf(w, "%s  %s\n", bold("run "+r.ID), statusMark(r.Status))
+	fmt.Fprintf(w, "plan %s, steps %v, by %s\n", r.PlanID, r.Steps, r.Actor)
+	if r.Summary != "" {
+		fmt.Fprintf(w, "%s\n", r.Summary)
+	}
+	if len(env.Events) == 0 {
+		return
+	}
+	fmt.Fprintf(w, "\n%s\n", bold("Audit trail"))
+	for _, ev := range env.Events {
+		PrintEvent(w, ev)
+	}
+}
+
+// PrintEvent renders one audit event.
+func PrintEvent(w io.Writer, ev store.RunEvent) {
+	mark := " "
+	switch ev.Level {
+	case store.EventBlocked:
+		mark = yellow("▲")
+	case store.EventError:
+		mark = red("■")
+	}
+	where := ev.Node
+	if ev.Pod != "" {
+		where = ev.Pod
+	}
+	rule := ""
+	if ev.Rule != "" {
+		rule = " [" + ev.Rule + "]"
+	}
+	fmt.Fprintf(w, "  %s %s %-8s %-28s %s%s\n",
+		mark, dim(ev.At.Format("15:04:05")), ev.Action, truncate(where, 28), ev.Message, dim(rule))
+}
+
+// constraintLine renders a constraint without rewording it.
+func constraintLine(c constraints.Constraint) string {
+	head := string(c.Kind)
+	if c.Subject != "" {
+		head += " " + c.Subject
+	}
+	if c.Explanation == "" {
+		return head
+	}
+	return head + ": " + c.Explanation
+}
+
+func statusMark(s store.RunStatus) string {
+	switch s {
+	case store.RunSucceeded:
+		return green("Succeeded")
+	case store.RunFailed:
+		return red("Failed")
+	case store.RunBlocked:
+		return yellow("Blocked")
+	}
+	return string(s)
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	if n <= 1 {
+		return s[:n]
+	}
+	return s[:n-1] + "…"
+}
+
+// stripANSI removes colour codes, for when a coloured fragment is reused
+// inside a sentence that measures its own width.
+func stripANSI(s string) string {
+	for {
+		i := strings.Index(s, "\033[")
+		if i < 0 {
+			return s
+		}
+		j := strings.IndexByte(s[i:], 'm')
+		if j < 0 {
+			return s
+		}
+		s = s[:i] + s[i+j+1:]
+	}
+}


### PR DESCRIPTION
`dencer` is **a client of the REST API, not a second planner.** Everything it shows was computed by the planner; everything it asks for goes through the same SubjectAccessReview the UI does.

That's the load-bearing decision. Talking to the cluster directly would need its own copy of the constraint analyzer and the Safety Guard — and the interesting failure wouldn't be a bug in either, it would be **the two copies disagreeing about whether a step is Red**, with no way for an operator to tell which to believe.

```
dencer plan                   the plan, leading with the next action
dencer explain 3              why a step is rated as it is
dencer why shop/web-abcde     why a pod can or cannot move
dencer run --steps 1,3-5      execute and follow
dencer status                 the run in flight
```

## It works with nothing set up

No flags: it finds the `ui-backend` Service through your kubeconfig and port-forwards to it. `--server` skips that when the backend is behind an Ingress. Named `kubectl-dencer` on PATH it becomes `kubectl dencer plan` — verified against a live cluster, `kubectl plugin list` picks it up.

Live output:

```
plan 754f04015304  4s old, greedy-first-fit-decreasing
28 nodes now, 13 after, 15 reclaimable

STEP  IMPACT    DRAINS        PODS  WHY
1     ■ Red     kwok-node-12  3     Draining kwok-node-12 moves 3 pod(s). Rated Red…
2     ● Green   kwok-node-16  3     Draining kwok-node-16 moves 3 pod(s). No disrup…

Next: drain kwok-node-16 (● Green)
  dencer run --steps 2

■ 3 step(s) are Red and need an open MaintenanceWindow.
```

## Authentication, where this could have been quietly unhelpful

The backend verifies identity with `TokenReview`, which only understands **bearer tokens**. The default kubeconfig on k3d, kind and OrbStack authenticates with a **client certificate** — which proves who you are to the API server and means nothing to a TokenReview call.

Rather than forward nothing and let the server answer "unauthenticated", the client detects it and names the fix:

```
error: your kubeconfig authenticates with a client certificate, and the backend verifies
identity with TokenReview, which only accepts bearer tokens...

Mint one:
  dencer --token "$(kubectl create token dencer-operator -n k8s-dencer)" plan
```

403 likewise names the verb the RoleBinding is missing, not just "forbidden".

## Conventions carried over from the UI

- **Constraint explanations are printed verbatim.** The analyzer calls `Explanation` "the single canonical human-readable description", and a test already holds the Kagent agent to reproducing it byte-for-byte. A paraphrasing CLI would make three descriptions of one constraint.
- **Risk never travels by colour alone.** Every rating prints a glyph (`●▲■`) *and* its word; colour turns off when stdout isn't a terminal; `NO_COLOR` honoured. A test asserts the rating survives with colour stripped.
- **Exit codes carry the outcome.** A run refused by the Safety Guard exits non-zero — a pipeline must not read a refused consolidation as a completed one. Ctrl-C stops watching and says so; the executor owns the run and keeps going.

## Tests

Five, including one specifically for **envelope unwrapping** — reading `steps`/`status` off the top level yields a zero value indistinguishable from "no plan yet" and "still running". That's the mistake that cost a debugging session in `hack/e2e.sh` last week; now it can't recur silently.

## Release

`release.yml` gains a job attaching static CLI binaries for linux and darwin on both architectures, with checksums.

`go vet`, `go test -race`, `gofmt`, `make lint`, typecheck, density test all clean. Verified end to end against the live cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)