### PR TITLE
Security policy, and put the CLI where people look for it

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,11 +109,24 @@ No real workloads required — the demo stands up a fabric of fake nodes with
 
 ```bash
 make demo     # fake-node fabric + 30-node topology + build images + install
-make token    # mint an operator token; the UI asks for one
+make token    # mint an operator token
 make ui       # port-forward and print the URL
 ```
 
-Then open the printed URL. To clean up:
+Then open the printed URL.
+
+Or skip the browser entirely:
+
+```bash
+make cli-install                       # installs dencer and kubectl-dencer
+export DENCER_TOKEN="$(make -s token)"
+dencer plan                            # or: kubectl dencer plan
+```
+
+`dencer` finds the backend through your kubeconfig on its own — no
+port-forward, no flags. See **[docs/cli.md](docs/cli.md)**.
+
+To clean up:
 
 ```bash
 make fabric-reset   # uncordon every fake node after an executor run
@@ -216,6 +229,13 @@ as ready to try, and the executor as something to enable deliberately, on
 something you can afford to be wrong about.
 
 Full milestone history in [docs/roadmap.md](docs/roadmap.md).
+
+## Security
+
+Found a vulnerability? Please report it privately through
+[GitHub's private reporting](https://github.com/atedgimo/k8s-dencer/security/advisories/new)
+rather than opening an issue — see [SECURITY.md](SECURITY.md) for scope and
+what to expect.
 
 ## Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,85 @@
+# Security policy
+
+k8s-dencer can cordon nodes and evict pods. A vulnerability here does not leak
+data so much as move production workloads, so please report privately rather
+than opening an issue.
+
+## Reporting a vulnerability
+
+Use **[GitHub private vulnerability reporting](https://github.com/atedgimo/k8s-dencer/security/advisories/new)**.
+It is enabled on this repository and goes only to the maintainers.
+
+If that is unavailable to you, email **atedgimo@gmail.com** with `k8s-dencer
+security` in the subject.
+
+Please include the version or commit, the chart values that matter (especially
+whether `executor.enabled` and `auth.enabled` are on), and what an attacker
+would gain. A proof of concept is welcome but not required.
+
+**What to expect:** an acknowledgement within 3 working days, an assessment
+within 10, and credit in the advisory unless you would rather not be named.
+This is a small project maintained by one person — those are honest targets,
+not a contractual SLA.
+
+Please give a reasonable window to ship a fix before disclosing publicly.
+
+## Supported versions
+
+Only the latest release. There are no maintenance branches; fixes land on
+`main` and go out in the next tag.
+
+## What counts
+
+**In scope**
+
+- Anything that lets a caller cordon or evict without holding
+  `create consolidations.dencer.io`, or read plans without
+  `get plans.dencer.io`.
+- Any path that reaches the eviction API while bypassing the Safety Guard's
+  rails, or that executes a Red step with no open `MaintenanceWindow`.
+- Privilege escalation out of any of the four workloads — in particular
+  anything that lets the network-reachable `ui-backend` perform an action only
+  the `executor` should.
+- Authentication or authorization bypass in the API, the CLI, or the MCP
+  surface exposed to Kagent.
+- Anything in the chart that grants more than the documented RBAC, or that
+  makes the executor reachable over the network.
+
+**Out of scope**
+
+- Findings against a deployment with `auth.enabled=false`. That configuration
+  is unauthenticated by definition, the chart refuses to enable the executor
+  alongside it, and `make lint` fails the build if any shipped profile turns it
+  off.
+- The KWOK demo fabric and `demo/`. They exist to fake nodes on a laptop and
+  are not for production.
+- Credentials in `hack/`. Those IdPs are throwaway containers that live for the
+  length of one script, and their passwords are generated per run.
+- Denial of service through legitimately expensive requests. The measured
+  ceiling is documented in [docs/benchmarks.md](docs/benchmarks.md).
+- Anything requiring cluster-admin to set up. An attacker who is already
+  cluster-admin does not need this tool.
+
+## The security model, briefly
+
+Worth knowing before reporting, because several apparent problems are
+deliberate:
+
+- **There is no credential store.** Identity is verified by `TokenReview` and
+  permissions by `SubjectAccessReview`, both answered by the Kubernetes API
+  server. k8s-dencer holds no passwords, no sessions and no user database.
+- **Eviction, never deletion.** Disruption goes through the `policy/v1`
+  eviction subresource, so PodDisruptionBudgets are enforced by the API server
+  rather than by code here. The executor is deliberately *not* granted
+  `delete pods`.
+- **The component reachable over the network cannot evict.** `ui-backend` has a
+  Service and no write verbs; `executor` can evict and has no Service. Chart
+  lint assertions hold both halves, including one that fails if scraping ever
+  gives the executor a Service.
+- **Execution is off by default**, and the chart refuses `executor.enabled=true`
+  without authentication and persistence.
+
+Full detail in [docs/security.md](docs/security.md) and
+[docs/execution.md](docs/execution.md), including instructions for verifying
+the privilege split against your own cluster rather than taking these claims on
+trust.

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@
 | **[Development](development.md)** | The local loop, the KWOK fake-node fabric, the CI gates, and cutting a release |
 | **[Benchmarks](benchmarks.md)** | Measured cost per operation, and where each stage stops being usable |
 | **[Roadmap and status](roadmap.md)** | What is built, what is planned, and what was dropped |
+| **[Security policy](../SECURITY.md)** | Reporting a vulnerability, and what is in scope |
 | **[Design document](k8s-consolidation-agent-architecture.md)** | The original architecture and the reasoning behind it |
 
 ---

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -11,12 +11,13 @@ step is Red.
 
 ## Install
 
-Download a binary from the [latest release](https://github.com/atedgimo/k8s-dencer/releases),
-or build from a checkout:
-
 ```bash
 make cli-install    # installs dencer and kubectl-dencer into $GOBIN
 ```
+
+Prebuilt binaries are attached to GitHub releases from the first tag after
+v0.1.0 — that release published the images and the chart but predates the CLI,
+so building from a checkout is the only route until then.
 
 The symlink is what makes `kubectl dencer plan` work — kubectl treats any
 `kubectl-*` binary on PATH as a plugin. Every global flag is spelled the way

--- a/docs/execution.md
+++ b/docs/execution.md
@@ -202,6 +202,26 @@ and pruning it would leave the log pointing at nothing.
 curl -H "Authorization: Bearer $TOKEN" localhost:8090/api/v1/runs/<runId> | jq .events
 ```
 
+## Running steps from a terminal
+
+Everything below is reachable from the [CLI](cli.md) as well as the UI, through
+the same API and the same authorization:
+
+```bash
+dencer plan                    # what would be reclaimed, and what each step costs
+dencer explain 3               # why step 3 is rated as it is
+dencer run --steps 1,3-5       # execute, with a confirmation prompt
+dencer run --steps 2 --dry-run # every guard check, nothing cordoned or evicted
+dencer status                  # the run in flight, plus its audit trail
+```
+
+`--dry-run` is worth reaching for first on an unfamiliar cluster: it runs the
+full guard chain and emits the same events, so a step that would be refused
+tells you which rail refuses it before anything is disrupted.
+
+A run refused by the Safety Guard exits non-zero, so a pipeline cannot mistake
+a refused consolidation for a completed one.
+
 ---
 
 [← Documentation index](README.md) · [Project README](../README.md)

--- a/docs/install.md
+++ b/docs/install.md
@@ -74,6 +74,31 @@ Runs `helm lint` and `kubeconform --strict` across every profile, then asserts t
 
 ---
 
+## The CLI
+
+The chart installs the server side. The CLI is a separate binary an operator
+puts on their own machine:
+
+```bash
+make cli-install
+```
+
+That also drops a `kubectl-dencer` symlink beside it, which is all
+`kubectl dencer plan` needs.
+
+> **Prebuilt binaries start with the next release.** v0.1.0 published the
+> images and the chart but predates the CLI, so there is nothing to download
+> yet. From the next tag onward, static builds for linux and darwin on both
+> architectures are attached to the GitHub release with checksums:
+>
+> ```bash
+> curl -sSLo dencer \
+>   https://github.com/atedgimo/k8s-dencer/releases/latest/download/dencer-$(uname -s | tr 'A-Z' 'a-z')-$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+> chmod +x dencer && sudo mv dencer /usr/local/bin/
+> ```
+
+Full usage in [cli.md](cli.md).
+
 ---
 
 [← Documentation index](README.md) · [Project README](../README.md)

--- a/docs/security.md
+++ b/docs/security.md
@@ -182,6 +182,32 @@ against the group rather than the person.
 
 ---
 
+## Credentials for the CLI
+
+The [CLI](cli.md) authenticates exactly as the UI does — it sends a bearer
+token and the backend resolves it with `TokenReview`. What differs is where the
+token comes from.
+
+**With OIDC single sign-on**, the ID token already in your kubeconfig *is* a
+Kubernetes credential, and the CLI uses it directly. Nothing to mint.
+
+**With a client-certificate kubeconfig** — the default on k3d, kind and
+OrbStack — there is no token at all. A certificate proves who you are to the
+API server and means nothing to a `TokenReview` call, so one has to be minted:
+
+```bash
+export DENCER_TOKEN="$(kubectl create token dencer-operator -n k8s-dencer)"
+```
+
+The CLI detects this case and prints that command rather than letting the
+server answer "unauthenticated", which would send you looking in the wrong
+place.
+
+Whatever the source, the token is only ever an identity. What it may *do* is
+decided by `SubjectAccessReview` against your cluster's RBAC: `get
+plans.dencer.io` to read, `create consolidations.dencer.io` to execute. A 403
+from the CLI names the missing verb.
+
 ---
 
 [← Documentation index](README.md) · [Project README](../README.md)


### PR DESCRIPTION
## SECURITY.md

A public tool that evicts pods had **no private route for reporting a vulnerability** — the only option was a public issue describing how to disrupt someone's workloads.

**GitHub private vulnerability reporting is now enabled on the repo** (verified: `{"enabled":true}`), so the link in the policy resolves rather than 404ing.

The scope section is specific, because several apparent problems here are deliberate and a reporter deserves to know before spending time on them:

- `auth.enabled=false` is unauthenticated by definition; the chart refuses to enable the executor beside it and `make lint` fails if a shipped profile turns it off
- the KWOK fabric and `demo/` are not for production
- `hack/` credentials are generated per run and live for the length of one script

## The CLI, where people actually look

It was documented only in `docs/cli.md`. Now:

| Where | What |
|---|---|
| README quick start | offered as an alternative to opening a browser |
| `docs/execution.md` | the same steps through `dencer` alongside the API, incl. `--dry-run` |
| `docs/install.md` | installing the binary and the `kubectl-dencer` symlink |
| `docs/security.md` | where the token comes from — including the case that trips people up |

That last one matters: with OIDC the ID token in your kubeconfig already *is* a Kubernetes credential, but a client-certificate kubeconfig has **no bearer token at all** for `TokenReview` to review, and it is not obvious why.

## One correction

The install instructions I first wrote pointed at `releases/latest/download/...`, which would have **404'd twice over** — v0.1.0 predates the CLI, and there is no GitHub release object at all, because the job that creates one shipped after the tag. Both documents now say binaries start with the next release, and building from a checkout is the route until then.

Verified `make -s token` really does emit a bare token before putting `export DENCER_TOKEN="$(make -s token)"` in the README.

`go vet`, `go test`, `gofmt`, `make lint` clean; every relative link checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)