### PR TITLE
Check whether draining actually removed anything

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ happens to be able to execute, not an autoscaler with a UI.
   API server itself enforces your PodDisruptionBudgets.
 - **Refuses steps that became unsafe** between planning and execution, naming
   the rule that stopped it.
+- **Checks whether draining actually saved anything.** k8s-dencer never deletes
+  a node — something else does — so it watches, and tells you when a node you
+  drained is still sitting there.
 - **Answers questions in natural language** through an optional Kagent agent
   that quotes the analyzer rather than re-deriving anything.
 - **Works without the UI.** `dencer` (also a `kubectl` plugin) does everything

--- a/cmd/dencer/main.go
+++ b/cmd/dencer/main.go
@@ -37,6 +37,7 @@ Commands:
   why <ns>/<pod>        why a pod can or cannot move
   run --steps 1,3-5     execute selected steps and watch them
   status                the run in flight, or the last one
+  reclamations          what actually became of the nodes you drained
   version
 
 Global flags:
@@ -54,6 +55,7 @@ Examples:
   dencer explain 3
   dencer why shop/web-7d9f-abcde
   dencer run --steps 1,2 --dry-run
+  dencer reclamations
   dencer plan -o json | jq '.plan.steps[] | select(.impact=="Red")'
 `
 
@@ -105,6 +107,8 @@ func run() error {
 		return cmdRun(ctx, args)
 	case "status":
 		return cmdStatus(ctx, args)
+	case "reclamations", "reclaim":
+		return cmdReclamations(ctx, args)
 	default:
 		return fmt.Errorf("unknown command %q\n\n%s", cmd, usage)
 	}
@@ -165,7 +169,13 @@ func cmdPlan(ctx context.Context, args []string) error {
 	if g.format != cli.FormatText {
 		return cli.Encode(os.Stdout, g.format, env)
 	}
-	cli.PrintPlan(os.Stdout, env)
+	// Best-effort: a backend without tracking, or an older one, must not stop
+	// the plan printing.
+	awaiting := 0
+	if rec, err := c.Reclamations(ctx); err == nil && rec.Tracking {
+		awaiting = rec.Stats.Awaiting
+	}
+	cli.PrintPlan(os.Stdout, env, awaiting)
 	return nil
 }
 
@@ -386,4 +396,27 @@ func confirm(plan *cli.PlanEnvelope, want []int) (bool, error) {
 	_, _ = fmt.Scanln(&answer)
 	answer = strings.ToLower(strings.TrimSpace(answer))
 	return answer == "y" || answer == "yes", nil
+}
+
+func cmdReclamations(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("reclamations", flag.ExitOnError)
+	g := bind(fs)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	c, err := connect(ctx, g)
+	if err != nil {
+		return err
+	}
+	defer c.Close()
+
+	env, err := c.Reclamations(ctx)
+	if err != nil {
+		return err
+	}
+	if g.format != cli.FormatText {
+		return cli.Encode(os.Stdout, g.format, env)
+	}
+	cli.PrintReclamations(os.Stdout, env)
+	return nil
 }

--- a/cmd/executor/main.go
+++ b/cmd/executor/main.go
@@ -98,6 +98,7 @@ func run(ctx context.Context, log *slog.Logger) error {
 		Windows:       windows,
 		Readiness:     executor.Readiness(env("EXECUTOR_READINESS", string(executor.ReadinessReady))),
 		Metrics:       metrics,
+		Reclamations:  db,
 	})
 
 	health := &httpserver.Health{}

--- a/cmd/planner/main.go
+++ b/cmd/planner/main.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -27,6 +28,7 @@ import (
 	"github.com/atedgimo/k8s-dencer/internal/impact"
 	"github.com/atedgimo/k8s-dencer/internal/model"
 	"github.com/atedgimo/k8s-dencer/internal/planner"
+	"github.com/atedgimo/k8s-dencer/internal/reclaim"
 	"github.com/atedgimo/k8s-dencer/internal/store"
 	sqlitestore "github.com/atedgimo/k8s-dencer/internal/store/sqlite"
 	"github.com/atedgimo/k8s-dencer/internal/telemetry"
@@ -272,6 +274,11 @@ func collect(
 	m.PlanProduced(time.Now())
 	m.PlanCycleTime.Observe(time.Since(cycleStart).Seconds())
 
+	// The planner is the only component watching nodes continuously, so it is
+	// the one that can tell whether a node the executor drained was actually
+	// removed. Done against the snapshot just taken, so it costs no API calls.
+	observeReclamations(ctx, log, db, snap, m)
+
 	stored, err := db.Save(ctx, store.Record{
 		Plan:     plan,
 		Snapshot: snap,
@@ -369,4 +376,60 @@ func duration(log *slog.Logger, key string, fallback time.Duration) time.Duratio
 		return fallback
 	}
 	return d
+}
+
+// observeReclamations closes out drained nodes that have since been removed or
+// put back into service.
+//
+// Runs every cycle against the snapshot already in hand. The whole rule lives
+// in internal/reclaim as a pure function so it is testable without a cluster;
+// this is only the plumbing around it.
+//
+// Failures are logged and dropped. Reclamation tracking is a measurement laid
+// over the product, and a database hiccup must not stop the planner planning.
+func observeReclamations(ctx context.Context, log *slog.Logger, db store.Store,
+	snap *model.ClusterSnapshot, m *telemetry.Metrics) {
+	tracker, ok := db.(store.ReclamationStore)
+	if !ok {
+		return
+	}
+
+	pending, err := tracker.PendingReclamations(ctx)
+	if err != nil {
+		log.Error("could not read pending reclamations", "error", err)
+		return
+	}
+	m.NodesAwaitingReclamation.Set(float64(len(pending)))
+	if len(pending) == 0 {
+		return
+	}
+
+	now := time.Now().UTC()
+	for _, t := range reclaim.Resolve(pending, snap, now) {
+		if err := tracker.ResolveReclamation(ctx, t.Reclamation.Node, t.Reclamation.DrainedAt, t.Outcome, t.At); err != nil {
+			if !errors.Is(err, store.ErrNotFound) {
+				log.Error("could not resolve reclamation", "node", t.Reclamation.Node, "error", err)
+			}
+			continue
+		}
+		switch t.Outcome {
+		case store.ReclaimedGone:
+			// The moment the product exists to produce, and the first time it
+			// has ever been recorded rather than assumed.
+			log.Info("node reclaimed", "node", t.Reclamation.Node,
+				"after", t.Took.Round(time.Second), "run", t.Reclamation.RunID)
+			m.ReclamationSeconds.Observe(t.Took.Seconds())
+		case store.ReclaimedReturned:
+			log.Info("drained node returned to service", "node", t.Reclamation.Node,
+				"run", t.Reclamation.RunID)
+			m.NodesReturnedTotal.Inc()
+		}
+	}
+
+	// Recount rather than subtract: a drain recorded by the executor between
+	// the read above and now would make arithmetic wrong, and this gauge is
+	// the one an operator alerts on.
+	if remaining, err := tracker.PendingReclamations(ctx); err == nil {
+		m.NodesAwaitingReclamation.Set(float64(len(remaining)))
+	}
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -130,6 +130,7 @@ GET /api/v1/plans/{id}/graph                         Cytoscape elements + stat t
 GET /api/v1/plans/{id}/snapshot                      the cluster state it was planned against
 GET /api/v1/plans/{id}/constraints[/{ns}/{pod}]      constraint analysis
 GET /api/v1/events                                   live plan changes and run progress (SSE)
+GET /api/v1/reclamations                             what became of drained nodes (observed)
 GET /api/v1/runs                                     the in-flight run, if any
 GET /api/v1/runs/{runId}                             one run plus its full audit trail
 GET /api/v1/plans/{id}/runs                          runs against a plan

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -101,6 +101,16 @@ non-zero, because a pipeline must not treat a refused consolidation as a
 completed one. Ctrl-C stops watching but does not stop the run — the executor
 owns it, and the CLI says so on the way out.
 
+### `dencer reclamations`
+
+What actually became of the nodes you drained — the only figure in the product
+derived from observation rather than from the plan.
+
+The awaiting list comes first because it is the one with teeth: those are nodes
+this tool told someone to drain, which nothing has removed. Anything over a day
+old is flagged, since a node still sitting there after 24 hours is not waiting
+for an autoscaler that is about to act.
+
 ### `dencer status`
 
 The run in flight, or a specific one with `--run <id>`, plus its audit trail.

--- a/docs/execution.md
+++ b/docs/execution.md
@@ -161,6 +161,50 @@ To put a drained node back into service:
 kubectl uncordon <node>      # or: make fabric-reset, for the whole KWOK fabric
 ```
 
+### And k8s-dencer checks whether it happened
+
+The handoff used to be where the product stopped caring. It reported
+"15 reclaimable" and the UI called a drained node reclaimed, so a prediction
+was presented as an outcome and nothing ever verified it. On a cluster with no
+reclaimer at all — the KWOK fabric, a fixed node pool, a cluster whose
+autoscaler is at its minimum size — every one of those numbers was wrong and
+nothing said so.
+
+Three states now, and only the last is a saving:
+
+| State | Means |
+|---|---|
+| **reclaimable** | the plan would free this node, if executed |
+| **awaiting reclamation** | drained and cordoned; the machine is still there |
+| **reclaimed** | the `Node` object is gone — something removed it |
+| **returned** | someone uncordoned it instead; not a saving |
+
+The executor opens a record the moment a node is emptied. The planner, which
+watches nodes continuously anyway, closes it: a node absent from the snapshot
+was reclaimed, a node that is present and schedulable again was returned, and a
+node that is present and still cordoned is still waiting. No cloud API, no
+autoscaler-specific detection, nothing to configure.
+
+```bash
+dencer reclamations
+```
+
+```
+Awaiting reclamation
+  NODE            DRAINED   RUN
+▲ ip-10-0-4-21    3d ago    9d251edd
+
+▲ 1 node(s) drained over a day ago and still present.
+  Draining frees capacity; something else has to remove the machine.
+  If nothing is going to, uncordon them: kubectl uncordon <node>
+
+Observed (last 30 days)
+  6 reclaimed, median 3m
+```
+
+`dencer_nodes_awaiting_reclamation` is the metric to alert on. Rising without
+falling means nothing is reclaiming what you drained.
+
 ## Abort means uncordon, not rollback
 
 **Evicted pods are not restored.** Eviction cannot be undone, and calling the

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -38,7 +38,14 @@ series is a question; a series pinned at zero is a wrong answer.
 **Planner** — `dencer_plan_age_seconds`, `dencer_plan_steps{impact}`,
 `dencer_plan_nodes_reclaimable`, `dencer_snapshot_nodes`,
 `dencer_snapshot_pods`, `dencer_plan_cycle_seconds`,
-`dencer_snapshot_failures_total`
+`dencer_snapshot_failures_total`, `dencer_nodes_awaiting_reclamation`,
+`dencer_reclamation_seconds`, `dencer_nodes_returned_total`
+
+The reclamation series are the only ones that describe an outcome rather than a
+plan. **`dencer_nodes_awaiting_reclamation` is the one to alert on**: it counts
+nodes this product told someone to drain whose machine is still there. Rising
+without falling means nothing is reclaiming them, and the capacity is
+unavailable and still being paid for.
 
 **Executor** — `dencer_runs_total{status}`, `dencer_guard_refusals_total{rule}`,
 `dencer_eviction_duration_seconds`, `dencer_evictions_total{outcome}`,

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -51,16 +51,14 @@ estimated — every milestone here starts from a number in
 | **M20** | `/metrics` on all three components; monitors that scrape a real path; CI; published images | **done** |
 | **M21** | Multi-node k3d e2e in CI, PodSecurity **enforcing**, `readiness: Ready` on real pods | **done** |
 | **M21b** | Real ingress controller and StorageClass | planned |
+| **M22** | Reclamation loop — observe whether a drained node was actually removed | **done** |
 
 High availability and a Postgres store were **dropped, not deferred**: a
 consolidation planner is not a serving path. The run queue is already crash-safe
 and resumes, the planner replans on restart, and a minute of UI downtime costs
 nothing.
 
-Deferred: scheduled automatic execution,
-Postgres store, multi-agent orchestration, and **closing the reclamation loop**
-— today a drained node looks the same whether an autoscaler is about to remove
-it or nothing ever will (see [Draining is not removing](execution.md#draining-is-not-removing)).
+Deferred: scheduled automatic execution and multi-agent orchestration.
 
 ## What actually runs today
 

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -305,5 +305,108 @@ after_ready="$(kubectl --context "$CTX" -n "$APP_NS" get deploy web -o jsonpath=
   || fail "readyReplicas ${before_ready} -> ${after_ready}: the workload did not fully recover"
 green "  all ${after_ready} replicas Ready again — on the Ready path, with real probes"
 
+# ------------------------------------------------------- reclamation loop
+
+# Draining is not removing. k8s-dencer empties a node and something else takes
+# the machine away — and until the reclamation loop existed, nothing checked
+# whether anything ever did, so "15 reclaimable" was a prediction reported as
+# an outcome.
+#
+# k3d lets us play both parts, which no cloud test would do as cheaply.
+
+reclamation_outcome() {
+  api /api/v1/reclamations | python3 -c "
+import json,sys
+d = json.load(sys.stdin)
+node = sys.argv[1]
+for r in d.get('recent') or []:
+    if r['node'] == node:
+        print(r.get('outcome') or 'pending'); break
+else:
+    print('missing')
+" "$1"
+}
+
+bold "==> the drain was recorded as awaiting reclamation"
+for _ in $(seq 1 20); do
+  [[ "$(reclamation_outcome "$TARGET")" == "pending" ]] && break
+  sleep 3
+done
+[[ "$(reclamation_outcome "$TARGET")" == "pending" ]] \
+  || fail "the drain of ${TARGET} was never recorded; got '$(reclamation_outcome "$TARGET")'"
+green "  ${TARGET} is awaiting reclamation"
+
+bold "==> an autoscaler removes it"
+kubectl --context "$CTX" delete node "$TARGET" --wait=true >/dev/null
+# The planner observes on its resync, so this waits a cycle rather than a tick.
+for _ in $(seq 1 30); do
+  [[ "$(reclamation_outcome "$TARGET")" == "reclaimed" ]] && break
+  sleep 5
+done
+[[ "$(reclamation_outcome "$TARGET")" == "reclaimed" ]] \
+  || fail "${TARGET} was deleted but never observed as reclaimed; got '$(reclamation_outcome "$TARGET")'"
+green "  observed as reclaimed — the loop closes"
+
+# The other branch. An operator who uncordons a drained node is never getting a
+# reclamation, and leaving that row pending forever would make the awaiting
+# count grow without bound and mean nothing.
+bold "==> the other branch: a drained node put back into service"
+SECOND="$(api /api/v1/plans/latest | python3 -c '
+import json,sys
+d = json.load(sys.stdin)
+p = d.get("plan") or d
+for s in p.get("steps") or []:
+    if s.get("impact") != "Red" and s.get("moves"):
+        print(s["sequenceNumber"]); break
+else:
+    print("")
+')"
+if [[ -z "$SECOND" ]]; then
+  green "  skipped: no second runnable step on this cluster"
+else
+  planid2="$(api /api/v1/plans/latest | python3 -c 'import json,sys; d=json.load(sys.stdin); print((d.get("plan") or d)["id"])')"
+  node2="$(api "/api/v1/plans/${planid2}" | python3 -c "
+import json,sys
+d = json.load(sys.stdin)
+for s in (d.get('plan') or d).get('steps') or []:
+    if s['sequenceNumber'] == int(sys.argv[1]):
+        print(s.get('targetNode','')); break
+" "$SECOND")"
+
+  run2="$(api "/api/v1/plans/${planid2}/execute" -X POST -H 'Content-Type: application/json' \
+    -d "{\"steps\":[${SECOND}]}")"
+  runid2="$(printf '%s' "$run2" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("runId",""))')"
+  for _ in $(seq 1 60); do
+    st="$(api "/api/v1/runs/${runid2}" | python3 -c 'import json,sys; d=json.load(sys.stdin); print((d.get("run") or d).get("status",""))' 2>/dev/null || true)"
+    case "$st" in Succeeded|Failed|Blocked) break;; esac
+    sleep 5
+  done
+  if [[ "$st" != "Succeeded" ]]; then
+    green "  skipped: second run ended ${st}, which is a guard doing its job rather than a failure here"
+  else
+    kubectl --context "$CTX" uncordon "$node2" >/dev/null
+    for _ in $(seq 1 30); do
+      [[ "$(reclamation_outcome "$node2")" == "returned" ]] && break
+      sleep 5
+    done
+    [[ "$(reclamation_outcome "$node2")" == "returned" ]] \
+      || fail "${node2} was uncordoned but recorded as '$(reclamation_outcome "$node2")', not returned"
+    green "  ${node2} observed as returned to service, not counted as a saving"
+  fi
+fi
+
+bold "==> the metrics agree"
+kubectl --context "$CTX" -n "$NS" port-forward "deploy/${RELEASE}-planner" 18100:8081 >/dev/null 2>&1 &
+MPF=$!
+sleep 4
+series="$(curl -s --max-time 10 http://localhost:18100/metrics || true)"
+kill $MPF 2>/dev/null || true
+grep -q "dencer_reclamation_seconds_count" <<<"$series" \
+  || fail "the planner publishes no dencer_reclamation_seconds"
+observed="$(grep -E "^dencer_reclamation_seconds_count " <<<"$series" | awk "{print \$2}")"
+[[ "${observed%.*}" -ge 1 ]] || fail "dencer_reclamation_seconds_count is ${observed}; the reclamation was never timed"
+green "  dencer_reclamation_seconds observed ${observed} reclamation(s)"
+
 echo
-green "e2e passed: multi-node, PodSecurity enforced, real pods evicted and recovered."
+green "e2e passed: multi-node, PodSecurity enforced, real pods evicted and recovered,"
+green "and the reclamation loop observed a node actually going away."

--- a/internal/api/graph/graph.go
+++ b/internal/api/graph/graph.go
@@ -102,14 +102,23 @@ type Data struct {
 
 // Stats are the headline figures for the UI's tile row.
 type Stats struct {
-	NodesBefore     int            `json:"nodesBefore"`
-	NodesAfter      int            `json:"nodesAfter"`
-	Reclaimed       int            `json:"reclaimed"`
-	Steps           int            `json:"steps"`
-	Ratings         map[string]int `json:"ratings"`
-	PodsMoved       int            `json:"podsMoved"`
-	CPUReclaimed    int64          `json:"cpuReclaimedMilli"`
-	MemoryReclaimed int64          `json:"memoryReclaimedBytes"`
+	NodesBefore int `json:"nodesBefore"`
+
+	// Reclaimable, not "reclaimed": what the plan *would* free if executed in
+	// full. Whether anything actually removed a drained node is a separate,
+	// observed fact — see /api/v1/reclamations. This field was called
+	// "reclaimed" until the reclamation loop landed, which is precisely how
+	// the product came to report a prediction in the language of an outcome.
+	Reclaimable int            `json:"reclaimable"`
+	Steps       int            `json:"steps"`
+	Ratings     map[string]int `json:"ratings"`
+	PodsMoved   int            `json:"podsMoved"`
+
+	// nodesAfter, cpuReclaimedMilli and memoryReclaimedBytes used to live
+	// here. Nothing read any of them, and the freed-capacity pair were
+	// plan-time predictions dressed in the past tense besides. Removed when a
+	// guard over this struct was finally written; they can come back the day
+	// something reads them.
 }
 
 // Build renders the payload at default detail.
@@ -163,15 +172,8 @@ func BuildWith(plan *model.Plan, snap *model.ClusterSnapshot, analysis *constrai
 		}
 	}
 
-	var reclaimedCPU, reclaimedMem int64
-
 	for _, n := range snap.Nodes {
 		requested := snap.RequestedOnNode(n.Name)
-		_, isDrained := drainStep[n.Name]
-		if isDrained {
-			reclaimedCPU += n.Allocatable.MilliCPU
-			reclaimedMem += n.Allocatable.MemoryBytes
-		}
 		p.Elements = append(p.Elements, Element{
 			Data: Data{
 				ID:             nodeID(n.Name),
@@ -195,7 +197,7 @@ func BuildWith(plan *model.Plan, snap *model.ClusterSnapshot, analysis *constrai
 	if p.Aggregated {
 		// The node elements above already carry everything the density view
 		// draws. Skipping the pod loop is the entire saving.
-		p.Stats = buildStats(plan, targets, reclaimedCPU, reclaimedMem)
+		p.Stats = buildStats(plan, targets)
 		return p
 	}
 
@@ -228,25 +230,22 @@ func BuildWith(plan *model.Plan, snap *model.ClusterSnapshot, analysis *constrai
 		p.Elements = append(p.Elements, Element{Data: data})
 	}
 
-	p.Stats = buildStats(plan, targets, reclaimedCPU, reclaimedMem)
+	p.Stats = buildStats(plan, targets)
 	return p
 }
 
-func buildStats(plan *model.Plan, targets map[string]model.Move, reclaimedCPU, reclaimedMem int64) Stats {
+func buildStats(plan *model.Plan, targets map[string]model.Move) Stats {
 	ratings := plan.CountByRating()
 	return Stats{
 		NodesBefore: plan.NodesBefore,
-		NodesAfter:  plan.NodesAfter,
-		Reclaimed:   plan.ReclaimedNodes(),
+		Reclaimable: plan.ReclaimedNodes(),
 		Steps:       len(plan.Steps),
 		Ratings: map[string]int{
 			"Green":  ratings[model.ImpactGreen],
 			"Yellow": ratings[model.ImpactYellow],
 			"Red":    ratings[model.ImpactRed],
 		},
-		PodsMoved:       len(targets),
-		CPUReclaimed:    reclaimedCPU,
-		MemoryReclaimed: reclaimedMem,
+		PodsMoved: len(targets),
 	}
 }
 

--- a/internal/api/graph/graph_contract_test.go
+++ b/internal/api/graph/graph_contract_test.go
@@ -78,17 +78,40 @@ func TestUITypeDoesNotDeclareFieldsThePayloadNoLongerSends(t *testing.T) {
 	}
 }
 
+// jsonTags collects the json field names off a struct in graph.go.
 func jsonTags(t *testing.T) []string {
+	return jsonTagsOf(t, "Data")
+}
+
+// Stats is checked too. It was not, and the omission cost something real: the
+// M22 rename of Stats.Reclaimed to Reclaimable passed every test while
+// ui/src/api.ts still declared "reclaimed", which would have read as undefined
+// at runtime and rendered the headline figure blank. Data was guarded and
+// Stats was not, for no reason other than Data being the one that had gone
+// wrong before.
+func TestEveryStatsFieldIsReadByTheUI(t *testing.T) {
+	ui := uiSources(t)
+	for _, f := range jsonTagsOf(t, "Stats") {
+		pat := regexp.MustCompile(`[.\[]\s*["']?` + regexp.QuoteMeta(f) + `\b`)
+		if !pat.MatchString(ui) {
+			t.Errorf("Stats.%s is sent to every client but the UI never reads it; "+
+				"remove it, or wire it up", f)
+		}
+	}
+}
+
+func jsonTagsOf(t *testing.T, typeName string) []string {
 	t.Helper()
 	fset := token.NewFileSet()
 	f, err := parser.ParseFile(fset, "graph.go", nil, 0)
 	if err != nil {
 		t.Fatalf("parse graph.go: %v", err)
 	}
+	_ = typeName
 	var out []string
 	ast.Inspect(f, func(n ast.Node) bool {
 		ts, ok := n.(*ast.TypeSpec)
-		if !ok || ts.Name.Name != "Data" {
+		if !ok || ts.Name.Name != typeName {
 			return true
 		}
 		st, ok := ts.Type.(*ast.StructType)

--- a/internal/api/rest/reclamations.go
+++ b/internal/api/rest/reclamations.go
@@ -1,0 +1,62 @@
+package rest
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/atedgimo/k8s-dencer/internal/store"
+)
+
+// reclamationWindow bounds the summary. Long enough that a weekly consolidation
+// habit still shows a median, short enough that a number from six months ago
+// does not describe a cluster that has since changed shape.
+const reclamationWindow = 30 * 24 * time.Hour
+
+// handleReclamations reports what actually became of drained nodes.
+//
+// The endpoint exists because every other number the product publishes about
+// reclamation is a plan-time prediction. This is the only one derived from
+// observation, and the "awaiting" list is the part with teeth: those are nodes
+// this product told someone to drain, which nothing has removed.
+func (s *Server) handleReclamations(w http.ResponseWriter, r *http.Request) {
+	tracker, ok := s.store.(store.ReclamationStore)
+	if !ok {
+		// A store without tracking is a configuration, not an error. Report
+		// the absence explicitly rather than an empty list, which would read
+		// as "nothing drained yet".
+		writeJSON(w, http.StatusOK, map[string]any{"tracking": false})
+		return
+	}
+
+	ctx := r.Context()
+	pending, err := tracker.PendingReclamations(ctx)
+	if err != nil {
+		s.fail(w, err)
+		return
+	}
+	recent, err := tracker.Reclamations(ctx, 50)
+	if err != nil {
+		s.fail(w, err)
+		return
+	}
+	stats, err := tracker.ReclamationSummary(ctx, time.Now().Add(-reclamationWindow))
+	if err != nil {
+		s.fail(w, err)
+		return
+	}
+
+	// Seconds rather than the Go duration's nanoseconds: every consumer here
+	// is JavaScript or jq, and 180000000000 is not a number anyone reads.
+	writeJSON(w, http.StatusOK, map[string]any{
+		"tracking": true,
+		"awaiting": pending,
+		"recent":   recent,
+		"stats": map[string]any{
+			"awaiting":                 stats.Awaiting,
+			"reclaimed":                stats.Reclaimed,
+			"returned":                 stats.Returned,
+			"medianReclamationSeconds": stats.MedianTime.Seconds(),
+			"windowDays":               int(reclamationWindow.Hours() / 24),
+		},
+	})
+}

--- a/internal/api/rest/rest.go
+++ b/internal/api/rest/rest.go
@@ -106,6 +106,7 @@ func (s *Server) Routes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/v1/authinfo", s.handleAuthInfo)
 
 	read("/api/v1/version", s.handleVersion)
+	read("/api/v1/reclamations", s.handleReclamations)
 	read("/api/v1/plans", s.handleListPlans)
 	read("/api/v1/plans/latest", s.handleLatestPlan)
 	read("/api/v1/plans/{id}", s.handlePlan)

--- a/internal/api/rest/rest_test.go
+++ b/internal/api/rest/rest_test.go
@@ -218,8 +218,14 @@ func TestGraphPayloadShape(t *testing.T) {
 	}
 
 	stats, _ := body["stats"].(map[string]any)
-	if stats["reclaimed"] != float64(1) {
-		t.Errorf("stats.reclaimed = %v, want 1", stats["reclaimed"])
+	// "reclaimable", not "reclaimed": this is what the plan would free, and
+	// whether anything removed the node is observed separately at
+	// /api/v1/reclamations. The old name reported a prediction as an outcome.
+	if stats["reclaimable"] != float64(1) {
+		t.Errorf("stats.reclaimable = %v, want 1", stats["reclaimable"])
+	}
+	if _, gone := stats["reclaimed"]; gone {
+		t.Error("stats still carries the old 'reclaimed' key")
 	}
 }
 

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -177,3 +177,30 @@ func min(a, b int) int {
 	}
 	return b
 }
+
+// ReclamationsEnvelope is what GET /api/v1/reclamations returns.
+type ReclamationsEnvelope struct {
+	Tracking bool                `json:"tracking"`
+	Awaiting []store.Reclamation `json:"awaiting"`
+	Recent   []store.Reclamation `json:"recent"`
+	Stats    ReclamationStats    `json:"stats"`
+}
+
+// ReclamationStats mirrors the API's summary. Seconds, not a Go duration: the
+// wire format is what jq and the browser see.
+type ReclamationStats struct {
+	Awaiting                 int     `json:"awaiting"`
+	Reclaimed                int     `json:"reclaimed"`
+	Returned                 int     `json:"returned"`
+	MedianReclamationSeconds float64 `json:"medianReclamationSeconds"`
+	WindowDays               int     `json:"windowDays"`
+}
+
+// Reclamations reports what became of drained nodes.
+func (c *Client) Reclamations(ctx context.Context) (*ReclamationsEnvelope, error) {
+	var out ReclamationsEnvelope
+	if err := c.get(ctx, "/api/v1/reclamations", &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -107,7 +107,7 @@ func Encode(w io.Writer, f Format, v any) error {
 }
 
 // PrintPlan renders a plan as a table.
-func PrintPlan(w io.Writer, env *PlanEnvelope) {
+func PrintPlan(w io.Writer, env *PlanEnvelope, awaiting int) {
 	p := env.Plan
 	age := time.Since(p.GeneratedAt).Round(time.Second)
 
@@ -137,6 +137,14 @@ func PrintPlan(w io.Writer, env *PlanEnvelope) {
 	}
 	if n := countRed(p); n > 0 {
 		fmt.Fprintf(w, "\n%s %d step(s) are Red and need an open MaintenanceWindow.\n", red("■"), n)
+	}
+	if awaiting > 0 {
+		// Worth saying on this page rather than only under `reclamations`:
+		// planning to drain more nodes while previously drained ones were
+		// never removed is the situation an operator most needs pointed out.
+		fmt.Fprintf(w, "\n%s %d previously drained node(s) are still awaiting reclamation.\n",
+			yellow("▲"), awaiting)
+		fmt.Fprintln(w, "  dencer reclamations")
 	}
 }
 
@@ -335,5 +343,86 @@ func stripANSI(s string) string {
 			return s
 		}
 		s = s[:i] + s[i+j+1:]
+	}
+}
+
+// PrintReclamations renders what actually became of drained nodes.
+//
+// The awaiting list comes first and is the point. Those are nodes this product
+// told someone to drain, which nothing has removed — capacity that is
+// unavailable and still being paid for. Everything else on this page is
+// reassurance; that list is the bill.
+func PrintReclamations(w io.Writer, env *ReclamationsEnvelope) {
+	if !env.Tracking {
+		fmt.Fprintln(w, "Reclamation tracking is not available on this backend.")
+		return
+	}
+	s := env.Stats
+	now := time.Now()
+
+	if len(env.Awaiting) == 0 && s.Reclaimed == 0 && s.Returned == 0 {
+		fmt.Fprintln(w, "No nodes have been drained yet.")
+		return
+	}
+
+	if len(env.Awaiting) > 0 {
+		fmt.Fprintf(w, "%s\n", bold("Awaiting reclamation"))
+		tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(tw, "  NODE\tDRAINED\tRUN")
+		for _, r := range env.Awaiting {
+			age := r.Age(now)
+			mark := "  "
+			// A node that has sat for a day is not waiting for an autoscaler
+			// that is about to act. Something is not coming, and the operator
+			// is paying for a machine doing nothing.
+			if age > 24*time.Hour {
+				mark = yellow("▲ ")
+			}
+			fmt.Fprintf(tw, "%s%s\t%s ago\t%s\n", mark, r.Node, humanDuration(age), r.RunID)
+		}
+		tw.Flush()
+
+		if stale := countOlderThan(env.Awaiting, 24*time.Hour, now); stale > 0 {
+			fmt.Fprintf(w, "\n%s %d node(s) drained over a day ago and still present.\n",
+				yellow("▲"), stale)
+			fmt.Fprintln(w, "  Draining frees capacity; something else has to remove the machine.")
+			fmt.Fprintln(w, "  If nothing is going to, uncordon them: kubectl uncordon <node>")
+		}
+		fmt.Fprintln(w)
+	}
+
+	fmt.Fprintf(w, "%s (last %d days)\n", bold("Observed"), s.WindowDays)
+	fmt.Fprintf(w, "  %s reclaimed", green(fmt.Sprintf("%d", s.Reclaimed)))
+	if s.Reclaimed > 0 && s.MedianReclamationSeconds > 0 {
+		fmt.Fprintf(w, ", median %s", humanDuration(time.Duration(s.MedianReclamationSeconds)*time.Second))
+	}
+	fmt.Fprintln(w)
+	if s.Returned > 0 {
+		fmt.Fprintf(w, "  %d returned to service instead\n", s.Returned)
+	}
+}
+
+func countOlderThan(rs []store.Reclamation, d time.Duration, now time.Time) int {
+	n := 0
+	for _, r := range rs {
+		if r.Age(now) > d {
+			n++
+		}
+	}
+	return n
+}
+
+// humanDuration prefers coarse units. "3d" reads faster than "76h12m9s", and
+// nobody chasing a stuck reclamation cares about the seconds.
+func humanDuration(d time.Duration) string {
+	switch {
+	case d >= 48*time.Hour:
+		return fmt.Sprintf("%dd", int(d.Hours()/24))
+	case d >= 2*time.Hour:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	case d >= time.Minute:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	default:
+		return fmt.Sprintf("%ds", int(d.Seconds()))
 	}
 }

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -46,6 +46,10 @@ type Options struct {
 	// leave it nil.
 	Metrics *telemetry.Metrics
 
+	// Reclamations records drained nodes so the planner can later observe
+	// whether anything removed them. Nil disables tracking.
+	Reclamations store.ReclamationStore
+
 	// StepTimeout bounds a single step end to end. Exceeding it aborts.
 	StepTimeout time.Duration
 
@@ -101,6 +105,9 @@ type Executor struct {
 	log     *slog.Logger
 	opts    Options
 	metrics *telemetry.Metrics
+	// reclamations is optional: nil disables tracking rather than failing, so
+	// a caller that has not wired a store still drains.
+	reclamations store.ReclamationStore
 }
 
 // New builds an executor.
@@ -111,13 +118,14 @@ func New(cluster Cluster, runs store.ExecutionStore, plans store.Store, log *slo
 		guard = guard.WithWindows(opts.Windows)
 	}
 	return &Executor{
-		cluster: cluster,
-		runs:    runs,
-		plans:   plans,
-		guard:   guard,
-		log:     log,
-		opts:    opts,
-		metrics: opts.Metrics,
+		cluster:      cluster,
+		runs:         runs,
+		plans:        plans,
+		guard:        guard,
+		log:          log,
+		opts:         opts,
+		metrics:      opts.Metrics,
+		reclamations: opts.Reclamations,
 	}
 }
 
@@ -356,7 +364,41 @@ func (e *Executor) drain(ctx context.Context, run store.Run, step model.PlanStep
 	}
 	e.metrics.RecoveryWaitSeconds.Observe(time.Since(recoverStart).Seconds())
 	e.metrics.NodesDrainedTotal.Inc()
+	e.recordDrain(ctx, run, step)
 	return nil
+}
+
+// recordDrain opens a reclamation record for the node just emptied.
+//
+// Draining is where this component's responsibility ends: something else
+// removes the machine, and whether anything does is the question the product
+// could not previously answer. The record is opened here, at the one moment we
+// know for certain the node is empty and cordoned, and the planner closes it
+// when the node disappears or comes back.
+//
+// A store failure is logged and swallowed, exactly as the audit trail is: the
+// node is already drained, and abandoning a completed step to preserve a
+// measurement would be the worse trade.
+func (e *Executor) recordDrain(ctx context.Context, run store.Run, step model.PlanStep) {
+	if e.reclamations == nil || step.TargetNode == "" {
+		return
+	}
+	// Detached: a cancelled context must not lose the record of work that
+	// already happened.
+	writeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+	defer cancel()
+
+	err := e.reclamations.RecordDrain(writeCtx, store.Reclamation{
+		Node:      step.TargetNode,
+		DrainedAt: time.Now().UTC(),
+		RunID:     run.ID,
+		PlanID:    run.PlanID,
+		Step:      step.SequenceNumber,
+	})
+	if err != nil {
+		e.log.Error("could not record the drain for reclamation tracking",
+			"node", step.TargetNode, "run", run.ID, "error", err)
+	}
 }
 
 // waitGone blocks until the pod has left the API server's view.

--- a/internal/reclaim/observer.go
+++ b/internal/reclaim/observer.go
@@ -1,0 +1,101 @@
+// Package reclaim decides what became of a drained node.
+//
+// k8s-dencer cordons a node and empties it; it never deletes one, and its
+// ServiceAccount holds no delete verb on nodes. Something else does the
+// removing — Karpenter, cluster-autoscaler, a managed node pool, a person.
+//
+// Until this existed, nothing checked whether anything did. The plan reported
+// "15 reclaimable" and the UI called a merely-drained node reclaimed, so the
+// product's central claim was a prediction wearing the clothes of an outcome.
+//
+// Rather than predict which reclaimer will act — vendor-specific, and wrong in
+// ways a user cannot check — this observes whether one did. The rule is
+// deliberately small enough to state in a sentence: the node is gone, the node
+// came back, or we are still waiting.
+package reclaim
+
+import (
+	"time"
+
+	"github.com/atedgimo/k8s-dencer/internal/model"
+	"github.com/atedgimo/k8s-dencer/internal/store"
+)
+
+// Transition is one pending reclamation reaching an outcome.
+type Transition struct {
+	Reclamation store.Reclamation
+	Outcome     store.ReclamationOutcome
+	At          time.Time
+	// Took is how long the node waited. Meaningful only for ReclaimedGone.
+	Took time.Duration
+}
+
+// Resolve decides which pending reclamations have reached an outcome.
+//
+// Pure, and takes the snapshot the planner already has, so the whole rule is
+// testable from a fixture with no cluster — the same reason internal/model has
+// no Kubernetes imports.
+//
+// Three cases, and the third is the one worth naming:
+//
+//   - the node is absent from the snapshot: something removed it. Reclaimed.
+//   - the node is present and schedulable again: someone uncordoned it, whether
+//     by hand or through an abort. Returned — not a saving, and leaving it
+//     pending forever would make "awaiting" grow without bound and mean nothing.
+//   - the node is present and still cordoned: still waiting. On a cluster with
+//     no reclaimer at all this is the permanent, correct answer, and saying so
+//     is the entire point.
+func Resolve(pending []store.Reclamation, snap *model.ClusterSnapshot, now time.Time) []Transition {
+	if len(pending) == 0 || snap == nil {
+		return nil
+	}
+
+	// Cordoned state by node name, from the snapshot the planner just took.
+	present := make(map[string]bool, len(snap.Nodes))
+	cordoned := make(map[string]bool, len(snap.Nodes))
+	for _, n := range snap.Nodes {
+		present[n.Name] = true
+		cordoned[n.Name] = n.Unschedulable
+	}
+
+	var out []Transition
+	for _, r := range pending {
+		if !r.Pending() {
+			// Already resolved. Not expected from PendingReclamations, but
+			// resolving one twice would attribute a second outcome to the same
+			// observation, so it is refused here rather than trusted upstream.
+			continue
+		}
+
+		switch {
+		case !present[r.Node]:
+			out = append(out, Transition{
+				Reclamation: r,
+				Outcome:     store.ReclaimedGone,
+				At:          now,
+				Took:        now.Sub(r.DrainedAt),
+			})
+		case !cordoned[r.Node]:
+			out = append(out, Transition{
+				Reclamation: r,
+				Outcome:     store.ReclaimedReturned,
+				At:          now,
+			})
+		}
+	}
+	return out
+}
+
+// Awaiting counts pending reclamations older than the given age.
+//
+// Used for the gauge and for the CLI's "drained N days ago and still here"
+// line, which is the observation an operator most needs and never had.
+func Awaiting(pending []store.Reclamation, olderThan time.Duration, now time.Time) []store.Reclamation {
+	var out []store.Reclamation
+	for _, r := range pending {
+		if r.Pending() && r.Age(now) >= olderThan {
+			out = append(out, r)
+		}
+	}
+	return out
+}

--- a/internal/reclaim/observer_test.go
+++ b/internal/reclaim/observer_test.go
@@ -1,0 +1,133 @@
+package reclaim
+
+import (
+	"testing"
+	"time"
+
+	"github.com/atedgimo/k8s-dencer/internal/model"
+	"github.com/atedgimo/k8s-dencer/internal/store"
+)
+
+func snap(nodes ...model.Node) *model.ClusterSnapshot {
+	return &model.ClusterSnapshot{Nodes: nodes}
+}
+
+func drained(name string, ago time.Duration, now time.Time) store.Reclamation {
+	return store.Reclamation{Node: name, DrainedAt: now.Add(-ago), RunID: "r1"}
+}
+
+func TestResolve(t *testing.T) {
+	now := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+	resolved := now.Add(-time.Hour)
+
+	cases := []struct {
+		name    string
+		pending []store.Reclamation
+		snap    *model.ClusterSnapshot
+		want    []store.ReclamationOutcome
+	}{
+		{
+			name:    "node gone means something reclaimed it",
+			pending: []store.Reclamation{drained("n1", 5*time.Minute, now)},
+			snap:    snap(model.Node{Name: "n2"}),
+			want:    []store.ReclamationOutcome{store.ReclaimedGone},
+		},
+		{
+			name:    "node uncordoned means it came back",
+			pending: []store.Reclamation{drained("n1", 5*time.Minute, now)},
+			snap:    snap(model.Node{Name: "n1", Unschedulable: false}),
+			want:    []store.ReclamationOutcome{store.ReclaimedReturned},
+		},
+		{
+			// The permanent, correct answer on a cluster with no reclaimer. If
+			// this ever resolved, the product would go back to claiming a
+			// saving that never happened.
+			name:    "still cordoned and present means keep waiting",
+			pending: []store.Reclamation{drained("n1", 30*24*time.Hour, now)},
+			snap:    snap(model.Node{Name: "n1", Unschedulable: true}),
+			want:    nil,
+		},
+		{
+			name: "already resolved is never resolved twice",
+			pending: []store.Reclamation{{
+				Node: "n1", DrainedAt: now.Add(-time.Hour),
+				ResolvedAt: &resolved, Outcome: store.ReclaimedGone,
+			}},
+			snap: snap(),
+			want: nil,
+		},
+		{
+			name: "a mixed batch resolves each on its own facts",
+			pending: []store.Reclamation{
+				drained("gone", time.Minute, now),
+				drained("back", time.Minute, now),
+				drained("waiting", time.Minute, now),
+			},
+			snap: snap(
+				model.Node{Name: "back", Unschedulable: false},
+				model.Node{Name: "waiting", Unschedulable: true},
+			),
+			want: []store.ReclamationOutcome{store.ReclaimedGone, store.ReclaimedReturned},
+		},
+		{
+			name:    "no snapshot resolves nothing",
+			pending: []store.Reclamation{drained("n1", time.Minute, now)},
+			snap:    nil,
+			want:    nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Resolve(tc.pending, tc.snap, now)
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %d transitions, want %d: %+v", len(got), len(tc.want), got)
+			}
+			for i, want := range tc.want {
+				if got[i].Outcome != want {
+					t.Errorf("transition %d = %q, want %q", i, got[i].Outcome, want)
+				}
+			}
+		})
+	}
+}
+
+// The duration is the number the whole feature exists to produce, and it is
+// only meaningful for a node that actually went away.
+func TestResolveTimesOnlyGenuineReclamations(t *testing.T) {
+	now := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+
+	gone := Resolve([]store.Reclamation{drained("n1", 7*time.Minute, now)}, snap(), now)
+	if len(gone) != 1 || gone[0].Took != 7*time.Minute {
+		t.Fatalf("reclaimed node should record 7m, got %+v", gone)
+	}
+
+	back := Resolve([]store.Reclamation{drained("n1", 7*time.Minute, now)},
+		snap(model.Node{Name: "n1"}), now)
+	if len(back) != 1 {
+		t.Fatalf("expected one transition, got %+v", back)
+	}
+	if back[0].Took != 0 {
+		t.Errorf("an uncordoned node timed %v; that measures how long someone "+
+			"took to change their mind, not how long reclamation takes", back[0].Took)
+	}
+}
+
+func TestAwaitingFiltersByAge(t *testing.T) {
+	now := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+	resolved := now
+	pending := []store.Reclamation{
+		drained("fresh", time.Minute, now),
+		drained("stale", 48*time.Hour, now),
+		{Node: "done", DrainedAt: now.Add(-72 * time.Hour), ResolvedAt: &resolved},
+	}
+
+	all := Awaiting(pending, 0, now)
+	if len(all) != 2 {
+		t.Errorf("got %d awaiting, want 2 (the resolved one must not count)", len(all))
+	}
+	old := Awaiting(pending, 24*time.Hour, now)
+	if len(old) != 1 || old[0].Node != "stale" {
+		t.Errorf("got %+v, want only the 48h-old node", old)
+	}
+}

--- a/internal/store/sqlite/reclamation.go
+++ b/internal/store/sqlite/reclamation.go
@@ -1,0 +1,169 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/atedgimo/k8s-dencer/internal/store"
+)
+
+// Reclamation tracking. See store.Reclamation for why this exists: the product
+// reported "reclaimable" as though it were "reclaimed", and nothing checked.
+
+// RecordDrain notes that a node was drained and now awaits reclamation.
+func (s *Store) RecordDrain(ctx context.Context, r store.Reclamation) error {
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO reclamations (node, drained_at, run_id, plan_id, step)
+		VALUES (?, ?, ?, ?, ?)
+		ON CONFLICT (node, drained_at) DO NOTHING`,
+		r.Node, r.DrainedAt.UTC().Format(time.RFC3339Nano), r.RunID, r.PlanID, r.Step)
+	if err != nil {
+		return fmt.Errorf("record drain of %s: %w", r.Node, err)
+	}
+	return nil
+}
+
+// PendingReclamations returns every node still awaiting an outcome.
+func (s *Store) PendingReclamations(ctx context.Context) ([]store.Reclamation, error) {
+	return s.queryReclamations(ctx, `
+		SELECT node, drained_at, run_id, plan_id, step, resolved_at, outcome
+		FROM reclamations WHERE resolved_at IS NULL
+		ORDER BY drained_at`)
+}
+
+// Reclamations returns recent records, newest first.
+func (s *Store) Reclamations(ctx context.Context, limit int) ([]store.Reclamation, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	return s.queryReclamations(ctx, `
+		SELECT node, drained_at, run_id, plan_id, step, resolved_at, outcome
+		FROM reclamations ORDER BY drained_at DESC LIMIT ?`, limit)
+}
+
+// ResolveReclamation closes out one pending record.
+//
+// Scoped to pending rows: an outcome is observed once and never revised. A node
+// that is deleted, recreated with the same name and drained again gets a new
+// row by virtue of a different drained_at, so re-resolving an old one would be
+// attributing a fresh event to a stale record.
+func (s *Store) ResolveReclamation(ctx context.Context, node string, drainedAt time.Time,
+	outcome store.ReclamationOutcome, at time.Time) error {
+	res, err := s.db.ExecContext(ctx, `
+		UPDATE reclamations SET resolved_at = ?, outcome = ?
+		WHERE node = ? AND drained_at = ? AND resolved_at IS NULL`,
+		at.UTC().Format(time.RFC3339Nano), string(outcome),
+		node, drainedAt.UTC().Format(time.RFC3339Nano))
+	if err != nil {
+		return fmt.Errorf("resolve reclamation for %s: %w", node, err)
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		// Not an error worth failing a planning cycle over — two observers, or
+		// a restart replaying a cycle, would both land here — but the caller
+		// should not report a transition it did not cause.
+		return store.ErrNotFound
+	}
+	return nil
+}
+
+// ReclamationSummary aggregates records since the given time.
+func (s *Store) ReclamationSummary(ctx context.Context, since time.Time) (store.ReclamationStats, error) {
+	var out store.ReclamationStats
+
+	// Pending is deliberately not filtered by `since`: a node drained two
+	// months ago and still sitting there is the single most interesting row in
+	// this table, and windowing it out would hide exactly the failure this
+	// mechanism exists to surface.
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM reclamations WHERE resolved_at IS NULL`).Scan(&out.Awaiting); err != nil {
+		return out, fmt.Errorf("count pending reclamations: %w", err)
+	}
+
+	cutoff := since.UTC().Format(time.RFC3339Nano)
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT outcome, drained_at, resolved_at FROM reclamations
+		WHERE resolved_at IS NOT NULL AND resolved_at >= ?`, cutoff)
+	if err != nil {
+		return out, fmt.Errorf("summarise reclamations: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var durations []time.Duration
+	for rows.Next() {
+		var outcome, drainedAt, resolvedAt string
+		if err := rows.Scan(&outcome, &drainedAt, &resolvedAt); err != nil {
+			return out, err
+		}
+		switch store.ReclamationOutcome(outcome) {
+		case store.ReclaimedGone:
+			out.Reclaimed++
+			// Only genuine reclamations contribute to the timing. A node that
+			// was uncordoned tells us how long someone took to change their
+			// mind, which is a different question and would skew the answer to
+			// "how long does reclamation take".
+			// parseTime yields the zero time on anything unparseable, matching
+			// the rest of this file. A pair that did not parse would produce a
+			// nonsense duration, so skip it rather than poison the median.
+			d, r := parseTime(drainedAt), parseTime(resolvedAt)
+			if !d.IsZero() && !r.IsZero() {
+				durations = append(durations, r.Sub(d))
+			}
+		case store.ReclaimedReturned:
+			out.Returned++
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return out, err
+	}
+	out.MedianTime = median(durations)
+	return out, nil
+}
+
+func median(d []time.Duration) time.Duration {
+	if len(d) == 0 {
+		return 0
+	}
+	sort.Slice(d, func(i, j int) bool { return d[i] < d[j] })
+	mid := len(d) / 2
+	if len(d)%2 == 1 {
+		return d[mid]
+	}
+	return (d[mid-1] + d[mid]) / 2
+}
+
+func (s *Store) queryReclamations(ctx context.Context, query string, args ...any) ([]store.Reclamation, error) {
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	// Non-nil so the API serialises an empty result as [] rather than null —
+	// the same trap planResponse already guards against.
+	out := []store.Reclamation{}
+	for rows.Next() {
+		var (
+			r                      store.Reclamation
+			drainedAt              string
+			runID, planID, outcome sql.NullString
+			step                   sql.NullInt64
+			resolvedAt             sql.NullString
+		)
+		if err := rows.Scan(&r.Node, &drainedAt, &runID, &planID, &step, &resolvedAt, &outcome); err != nil {
+			return nil, err
+		}
+		r.DrainedAt = parseTime(drainedAt)
+		r.RunID, r.PlanID = runID.String, planID.String
+		r.Step = int(step.Int64)
+		if resolvedAt.Valid {
+			t := parseTime(resolvedAt.String)
+			r.ResolvedAt = &t
+			r.Outcome = store.ReclamationOutcome(outcome.String)
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}

--- a/internal/store/sqlite/reclamation_test.go
+++ b/internal/store/sqlite/reclamation_test.go
@@ -1,0 +1,185 @@
+package sqlite_test
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/atedgimo/k8s-dencer/internal/store"
+	sqlitestore "github.com/atedgimo/k8s-dencer/internal/store/sqlite"
+)
+
+func reclamationStore(t *testing.T) *sqlitestore.Store {
+	t.Helper()
+	db, err := sqlitestore.Open(filepath.Join(t.TempDir(), "r.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := db.Migrate(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	return db
+}
+
+func TestReclamationRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	db := reclamationStore(t)
+	drained := time.Now().Add(-10 * time.Minute).UTC().Truncate(time.Millisecond)
+
+	rec := store.Reclamation{Node: "n1", DrainedAt: drained, RunID: "run-1", PlanID: "plan-1", Step: 3}
+	if err := db.RecordDrain(ctx, rec); err != nil {
+		t.Fatal(err)
+	}
+
+	pending, err := db.PendingReclamations(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pending) != 1 {
+		t.Fatalf("pending = %d, want 1", len(pending))
+	}
+	got := pending[0]
+	if got.Node != "n1" || got.RunID != "run-1" || got.PlanID != "plan-1" || got.Step != 3 {
+		t.Errorf("provenance lost: %+v", got)
+	}
+	if !got.Pending() {
+		t.Error("a freshly recorded drain should be pending")
+	}
+	if !got.DrainedAt.Equal(drained) {
+		t.Errorf("drainedAt = %v, want %v", got.DrainedAt, drained)
+	}
+
+	resolvedAt := drained.Add(4 * time.Minute)
+	if err := db.ResolveReclamation(ctx, "n1", drained, store.ReclaimedGone, resolvedAt); err != nil {
+		t.Fatal(err)
+	}
+	if p, _ := db.PendingReclamations(ctx); len(p) != 0 {
+		t.Errorf("still %d pending after resolving", len(p))
+	}
+
+	recent, err := db.Reclamations(ctx, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(recent) != 1 || recent[0].Outcome != store.ReclaimedGone {
+		t.Fatalf("recent = %+v", recent)
+	}
+	if recent[0].Age(time.Now()) != 4*time.Minute {
+		t.Errorf("age = %v, want 4m (measured drain to resolution, not to now)", recent[0].Age(time.Now()))
+	}
+}
+
+// An outcome is observed once. Resolving twice would attribute a second event
+// to the same observation, and on a restart that replays a cycle it would
+// happen routinely.
+func TestResolveIsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	db := reclamationStore(t)
+	drained := time.Now().Add(-time.Minute).UTC()
+
+	if err := db.RecordDrain(ctx, store.Reclamation{Node: "n1", DrainedAt: drained}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.ResolveReclamation(ctx, "n1", drained, store.ReclaimedGone, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	err := db.ResolveReclamation(ctx, "n1", drained, store.ReclaimedReturned, time.Now())
+	if !errors.Is(err, store.ErrNotFound) {
+		t.Errorf("second resolve returned %v, want ErrNotFound", err)
+	}
+
+	recent, _ := db.Reclamations(ctx, 10)
+	if recent[0].Outcome != store.ReclaimedGone {
+		t.Errorf("outcome was overwritten to %q; the first observation must stand", recent[0].Outcome)
+	}
+}
+
+// The same node can be drained, uncordoned and drained again. Keying on the
+// node alone would make the second attempt overwrite the first, losing the
+// record that it came back.
+func TestTheSameNodeCanBeDrainedTwice(t *testing.T) {
+	ctx := context.Background()
+	db := reclamationStore(t)
+	first := time.Now().Add(-2 * time.Hour).UTC()
+	second := time.Now().Add(-1 * time.Hour).UTC()
+
+	for _, at := range []time.Time{first, second} {
+		if err := db.RecordDrain(ctx, store.Reclamation{Node: "n1", DrainedAt: at}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := db.ResolveReclamation(ctx, "n1", first, store.ReclaimedReturned, first.Add(time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+
+	pending, _ := db.PendingReclamations(ctx)
+	if len(pending) != 1 || !pending[0].DrainedAt.Equal(second) {
+		t.Fatalf("expected only the second attempt pending, got %+v", pending)
+	}
+	all, _ := db.Reclamations(ctx, 10)
+	if len(all) != 2 {
+		t.Errorf("got %d records, want 2 — each drain is its own observation", len(all))
+	}
+}
+
+// Recording the same drain twice must not fail: the executor may retry, and a
+// crash between the eviction and the record is a normal thing to recover from.
+func TestRecordDrainIsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	db := reclamationStore(t)
+	at := time.Now().UTC()
+
+	for i := 0; i < 2; i++ {
+		if err := db.RecordDrain(ctx, store.Reclamation{Node: "n1", DrainedAt: at, RunID: "r1"}); err != nil {
+			t.Fatalf("record %d: %v", i, err)
+		}
+	}
+	if p, _ := db.PendingReclamations(ctx); len(p) != 1 {
+		t.Errorf("got %d pending, want 1", len(p))
+	}
+}
+
+func TestReclamationSummary(t *testing.T) {
+	ctx := context.Background()
+	db := reclamationStore(t)
+	now := time.Now().UTC()
+
+	// Three reclaimed at 2, 4 and 10 minutes; one returned; one still pending.
+	for i, d := range []time.Duration{2 * time.Minute, 4 * time.Minute, 10 * time.Minute} {
+		at := now.Add(-time.Hour).Add(time.Duration(i) * time.Second)
+		if err := db.RecordDrain(ctx, store.Reclamation{Node: nodeName(i), DrainedAt: at}); err != nil {
+			t.Fatal(err)
+		}
+		if err := db.ResolveReclamation(ctx, nodeName(i), at, store.ReclaimedGone, at.Add(d)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	returnedAt := now.Add(-30 * time.Minute)
+	_ = db.RecordDrain(ctx, store.Reclamation{Node: "returned", DrainedAt: returnedAt})
+	_ = db.ResolveReclamation(ctx, "returned", returnedAt, store.ReclaimedReturned, returnedAt.Add(time.Hour))
+	_ = db.RecordDrain(ctx, store.Reclamation{Node: "waiting", DrainedAt: now.Add(-90 * 24 * time.Hour)})
+
+	stats, err := db.ReclamationSummary(ctx, now.Add(-24*time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.Reclaimed != 3 {
+		t.Errorf("reclaimed = %d, want 3", stats.Reclaimed)
+	}
+	if stats.Returned != 1 {
+		t.Errorf("returned = %d, want 1", stats.Returned)
+	}
+	// The 90-day-old pending node is the most interesting row in the table and
+	// must not be windowed out of the count.
+	if stats.Awaiting != 1 {
+		t.Errorf("awaiting = %d, want 1 — a long-pending node must still be counted", stats.Awaiting)
+	}
+	if stats.MedianTime != 4*time.Minute {
+		t.Errorf("median = %v, want 4m (median of 2m, 4m, 10m — a mean would give 5m20s)", stats.MedianTime)
+	}
+}
+
+func nodeName(i int) string { return string(rune('a' + i)) }

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -56,7 +56,7 @@ func Open(path string) (*Store, error) {
 // Close releases the database handle.
 func (s *Store) Close() error { return s.db.Close() }
 
-const schemaVersion = 2
+const schemaVersion = 3
 
 // Migrate creates or upgrades the schema.
 func (s *Store) Migrate(ctx context.Context) error {
@@ -82,6 +82,11 @@ func (s *Store) Migrate(ctx context.Context) error {
 	if current < 2 {
 		if _, err := tx.ExecContext(ctx, schemaV2); err != nil {
 			return fmt.Errorf("apply schema v2: %w", err)
+		}
+	}
+	if current < 3 {
+		if _, err := tx.ExecContext(ctx, schemaV3); err != nil {
+			return fmt.Errorf("apply schema v3: %w", err)
 		}
 	}
 
@@ -170,6 +175,32 @@ CREATE TABLE IF NOT EXISTS run_events (
     message   TEXT NOT NULL,
     PRIMARY KEY (run_id, sequence)
 );
+`
+
+// Phase 4. Closing the reclamation loop: what happened to a node after it was
+// drained.
+//
+// No foreign key to runs, and no cascade. A reclamation outlives the run that
+// caused it — the interesting records are precisely the ones still pending
+// weeks later, and Prune must not silently delete the evidence that a node was
+// drained and never removed.
+const schemaV3 = `
+CREATE TABLE IF NOT EXISTS reclamations (
+    node         TEXT NOT NULL,
+    drained_at   TEXT NOT NULL,
+    run_id       TEXT,
+    plan_id      TEXT,
+    step         INTEGER,
+    -- NULL while the node is still drained and still present.
+    resolved_at  TEXT,
+    outcome      TEXT,
+    -- Keyed on the attempt, not the node: the same node can be drained,
+    -- uncordoned and drained again, and each attempt is its own observation.
+    PRIMARY KEY (node, drained_at)
+);
+
+CREATE INDEX IF NOT EXISTS reclamations_pending ON reclamations (resolved_at);
+CREATE INDEX IF NOT EXISTS reclamations_recent ON reclamations (drained_at DESC);
 `
 
 // Save persists a record unless it duplicates the latest plan.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -48,6 +48,93 @@ type Summary struct {
 	StoredAt        time.Time        `json:"storedAt"`
 }
 
+// ReclamationOutcome is how a drained node's story ended.
+type ReclamationOutcome string
+
+const (
+	// ReclaimedGone means the Node object disappeared: something actually
+	// removed the machine, which is the outcome the product exists to produce.
+	ReclaimedGone ReclamationOutcome = "reclaimed"
+
+	// ReclaimedReturned means the node was uncordoned and put back into
+	// service instead. Not a failure — an operator changed their mind, or an
+	// abort reversed the cordon — but it is emphatically not a saving, and
+	// counting it as one would be the same overstatement this whole mechanism
+	// exists to remove.
+	ReclaimedReturned ReclamationOutcome = "returned"
+)
+
+// Reclamation records what happened to a node after it was drained.
+//
+// Draining is not removing. k8s-dencer cordons a node and empties it; something
+// else — Karpenter, cluster-autoscaler, a managed node pool, a human — removes
+// the machine, and until this existed nothing ever checked whether anything
+// did. A plan reporting "15 reclaimable" was a prediction presented as an
+// outcome.
+//
+// Rather than predict which reclaimer will act, which is vendor-specific and
+// can be wrong in ways a user cannot check, this observes whether one did.
+type Reclamation struct {
+	Node      string    `json:"node"`
+	DrainedAt time.Time `json:"drainedAt"`
+
+	// Provenance, so a pending reclamation can be traced to the run that
+	// caused it.
+	RunID  string `json:"runId,omitempty"`
+	PlanID string `json:"planId,omitempty"`
+	Step   int    `json:"step,omitempty"`
+
+	// ResolvedAt and Outcome are zero while the node is still awaiting
+	// reclamation.
+	ResolvedAt *time.Time         `json:"resolvedAt,omitempty"`
+	Outcome    ReclamationOutcome `json:"outcome,omitempty"`
+}
+
+// Pending reports whether this node is still drained and still present.
+func (r Reclamation) Pending() bool { return r.ResolvedAt == nil }
+
+// Age is how long the node has been waiting, or how long it waited.
+func (r Reclamation) Age(now time.Time) time.Duration {
+	if r.ResolvedAt != nil {
+		return r.ResolvedAt.Sub(r.DrainedAt)
+	}
+	return now.Sub(r.DrainedAt)
+}
+
+// ReclamationStats summarises observed reclamations over a window.
+type ReclamationStats struct {
+	Awaiting  int `json:"awaiting"`
+	Reclaimed int `json:"reclaimed"`
+	Returned  int `json:"returned"`
+	// Median rather than mean: one node that sat for a week before someone
+	// noticed would drag an average into uselessness, and the question being
+	// answered is "how long does this normally take".
+	MedianTime time.Duration `json:"medianReclamationSeconds"`
+}
+
+// ReclamationStore tracks drained nodes until something removes them.
+//
+// Separate from Store and ExecutionStore because the writers differ: the
+// executor records a drain, and the planner — the only component watching nodes
+// continuously — observes the outcome.
+type ReclamationStore interface {
+	// RecordDrain notes that a node was drained and is now awaiting
+	// reclamation. Idempotent on (node, drainedAt).
+	RecordDrain(ctx context.Context, r Reclamation) error
+
+	// PendingReclamations returns every node still awaiting an outcome.
+	PendingReclamations(ctx context.Context) ([]Reclamation, error)
+
+	// ResolveReclamation closes out one pending record.
+	ResolveReclamation(ctx context.Context, node string, drainedAt time.Time, outcome ReclamationOutcome, at time.Time) error
+
+	// Reclamations returns recent records, newest first.
+	Reclamations(ctx context.Context, limit int) ([]Reclamation, error)
+
+	// ReclamationSummary aggregates records resolved since the given time.
+	ReclamationSummary(ctx context.Context, since time.Time) (ReclamationStats, error)
+}
+
 // Store persists and retrieves plans.
 //
 // Implementations must be safe for concurrent readers. The planner is the only

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -44,6 +44,14 @@ type Metrics struct {
 	PlanCycleTime   prometheus.Histogram
 	SnapshotFailure prometheus.Counter
 
+	// Reclamation. Draining is not removing: k8s-dencer empties a node and
+	// something else removes the machine. These are the only series that say
+	// whether anything did — the difference between "we drained nodes" and
+	// "you are paying for fewer nodes".
+	NodesAwaitingReclamation prometheus.Gauge
+	ReclamationSeconds       prometheus.Histogram
+	NodesReturnedTotal       prometheus.Counter
+
 	// Executor.
 	RunsTotal           *prometheus.CounterVec
 	GuardRefusalsTotal  *prometheus.CounterVec
@@ -115,6 +123,23 @@ func NewMetrics(component Component) *Metrics {
 			Name: "dencer_snapshot_failures_total",
 			Help: "Snapshots that could not be taken.",
 		}),
+		NodesAwaitingReclamation: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "dencer_nodes_awaiting_reclamation",
+			Help: "Nodes drained and cordoned whose Node object is still present. Rising without falling means nothing is reclaiming them.",
+		}),
+		ReclamationSeconds: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Name: "dencer_reclamation_seconds",
+			Help: "Time from a node being drained to its Node object disappearing.",
+			// Spans a Karpenter consolidation, which is often under a minute,
+			// to a cluster-autoscaler scale-down delay, which defaults to ten
+			// minutes and is routinely raised — and then out to the timescale
+			// where the honest reading is that nothing is coming.
+			Buckets: []float64{30, 60, 300, 600, 1800, 3600, 21600, 86400},
+		}),
+		NodesReturnedTotal: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "dencer_nodes_returned_total",
+			Help: "Drained nodes that were uncordoned and put back into service instead of being reclaimed.",
+		}),
 
 		RunsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "dencer_runs_total",
@@ -165,6 +190,7 @@ func NewMetrics(component Component) *Metrics {
 		reg.MustRegister(
 			m.PlanSteps, m.NodesReclaimed, m.SnapshotNodes, m.SnapshotPods,
 			m.PlanCycleTime, m.SnapshotFailure,
+			m.NodesAwaitingReclamation, m.ReclamationSeconds, m.NodesReturnedTotal,
 		)
 	case ComponentExecutor:
 		reg.MustRegister(

--- a/internal/telemetry/metrics_test.go
+++ b/internal/telemetry/metrics_test.go
@@ -217,6 +217,9 @@ func TestComponentsPublishOnlyTheirOwnSeries(t *testing.T) {
 		m.SnapshotPods.Set(1)
 		m.PlanCycleTime.Observe(1)
 		m.SnapshotFailure.Inc()
+		m.NodesAwaitingReclamation.Set(1)
+		m.ReclamationSeconds.Observe(1)
+		m.NodesReturnedTotal.Inc()
 		m.RunsTotal.WithLabelValues("Succeeded").Inc()
 		m.GuardRefusalsTotal.WithLabelValues("PDBHeadroom").Inc()
 		m.EvictionDuration.Observe(1)
@@ -233,6 +236,10 @@ func TestComponentsPublishOnlyTheirOwnSeries(t *testing.T) {
 		"dencer_plan_age_seconds", "dencer_plan_steps", "dencer_snapshot_pods",
 		"dencer_snapshot_nodes", "dencer_plan_cycle_seconds", "dencer_snapshot_failures_total",
 		"dencer_plan_nodes_reclaimable",
+		// The planner observes reclamation because it is the only component
+		// watching nodes continuously; the executor drains and moves on.
+		"dencer_nodes_awaiting_reclamation", "dencer_reclamation_seconds",
+		"dencer_nodes_returned_total",
 	}
 	executorOnly := []string{
 		"dencer_runs_total", "dencer_eviction_duration_seconds", "dencer_nodes_drained_total",

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Impact, PlanStep } from "./api";
+import { api, Impact, PlanStep } from "./api";
 import Inspector, { Selection } from "./components/Inspector";
 import PackingField from "./components/PackingField";
 import { ConfirmRun, RunTrail } from "./components/RunPanel";
@@ -24,6 +24,33 @@ export default function App() {
 
   const [step, setStep] = useState(0);
   const [playing, setPlaying] = useState(false);
+
+  // Observed reclamation, as distinct from what the plan predicts. Polled
+  // rather than pushed: it changes on the planner's resync, which is tens of
+  // seconds, and it is never the reason someone is watching the screen.
+  const [reclaimed, setReclaimed] = useState({ awaiting: 0, reclaimed: 0 });
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      try {
+        const r = await api.reclamations();
+        if (!cancelled && r.tracking) {
+          setReclaimed({ awaiting: r.stats.awaiting, reclaimed: r.stats.reclaimed });
+        }
+      } catch {
+        // Reclamation tracking is supplementary. A backend that does not have
+        // it, or a transient failure, must never blank the page — the field
+        // and the ledger are what the operator came for.
+      }
+    };
+    void load();
+    const t = setInterval(load, 30_000);
+    return () => {
+      cancelled = true;
+      clearInterval(t);
+    };
+  }, []);
   const [selectedStep, setSelectedStep] = useState<number | null>(null);
   const [selection, setSelection] = useState<Selection>(null);
   const [focusedRating, setFocusedRating] = useState<Impact | null>(null);
@@ -184,6 +211,8 @@ export default function App() {
 
           <main className="workspace">
             <PackingField
+              awaiting={reclaimed.awaiting}
+              reclaimedForReal={reclaimed.reclaimed}
               graph={state.graph}
               steps={steps}
               step={step}

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -40,7 +40,6 @@ export interface Plan {
   status: string;
   steps: PlanStep[];
   nodesBefore: number;
-  nodesAfter: number;
 }
 
 export interface PlanResponse {
@@ -92,13 +91,10 @@ export interface GraphElement {
 
 export interface GraphStats {
   nodesBefore: number;
-  nodesAfter: number;
-  reclaimed: number;
+  reclaimable: number;
   steps: number;
   ratings: Record<Impact, number>;
   podsMoved: number;
-  cpuReclaimedMilli: number;
-  memoryReclaimedBytes: number;
 }
 
 export interface GraphPayload {
@@ -253,8 +249,41 @@ async function post<T>(path: string, body: unknown): Promise<T> {
   return (await res.json()) as T;
 }
 
+/**
+ * What actually became of a drained node.
+ *
+ * Every other reclamation figure in this app is a plan-time prediction. This
+ * one is observed: the planner watches nodes, and a drained node either
+ * disappears (something removed it) or comes back (someone uncordoned it).
+ */
+export interface Reclamation {
+  node: string;
+  drainedAt: string;
+  runId?: string;
+  planId?: string;
+  step?: number;
+  resolvedAt?: string;
+  outcome?: "reclaimed" | "returned";
+}
+
+export interface ReclamationsResponse {
+  tracking: boolean;
+  awaiting: Reclamation[];
+  recent: Reclamation[];
+  stats: {
+    awaiting: number;
+    reclaimed: number;
+    returned: number;
+    medianReclamationSeconds: number;
+    windowDays: number;
+  };
+}
+
 export const api = {
   latestPlan: (signal?: AbortSignal) => get<PlanResponse>("/api/v1/plans/latest", signal),
+
+  reclamations: (signal?: AbortSignal) =>
+    get<ReclamationsResponse>("/api/v1/reclamations", signal),
 
   /** A specific plan by id. Used to keep a pinned view on the plan an operator
    *  is actually working against, rather than whatever is newest. */

--- a/ui/src/components/PackingField.tsx
+++ b/ui/src/components/PackingField.tsx
@@ -53,6 +53,10 @@ interface Props {
   onSelectPod: (key: string | null) => void;
   selectedNode: string | null;
   selectedPod: string | null;
+  /** Nodes drained earlier whose machine is still present. Observed, not planned. */
+  awaiting?: number;
+  /** Nodes whose Node object actually disappeared. Observed, not planned. */
+  reclaimedForReal?: number;
 }
 
 export default function PackingField({
@@ -64,6 +68,8 @@ export default function PackingField({
   onSelectPod,
   selectedNode,
   selectedPod,
+  awaiting = 0,
+  reclaimedForReal = 0,
 }: Props) {
   const model: Model = useMemo(() => toModel(graph), [graph]);
   const peak = useMemo(() => peakOccupancy(model, steps), [model, steps]);
@@ -324,7 +330,7 @@ export default function PackingField({
         </div>
       </div>
 
-      <ReclaimedTray count={reclaimed.size} total={plannedDrains} />
+      <ReclaimedTray count={reclaimed.size} total={plannedDrains} awaiting={awaiting} reclaimedForReal={reclaimedForReal} />
     </div>
   );
 }
@@ -339,14 +345,43 @@ export default function PackingField({
  * your autoscaler or your node-pool tooling to take away", and the label has
  * to say that rather than implying the capacity is already gone.
  */
-function ReclaimedTray({ count, total }: { count: number; total: number }) {
+function ReclaimedTray({
+  count,
+  total,
+  awaiting,
+  reclaimedForReal,
+}: {
+  count: number;
+  total: number;
+  awaiting: number;
+  reclaimedForReal: number;
+}) {
   return (
     <div className="tray" aria-live="polite">
       <span className="tray-label mono">drained</span>
       <span className="tray-count num">{count}</span>
       <span className="tray-of mono">of {total}</span>
-      {count > 0 && (
+      {count > 0 && awaiting === 0 && reclaimedForReal === 0 && (
         <span className="tray-hint">empty and cordoned — ready to remove</span>
+      )}
+      {/* Observed, not planned. Separated from the scrubber tally above
+          because that one answers "what would this plan do" and these answer
+          "what actually happened last time", and merging them is exactly how
+          a prediction ends up being read as a result. */}
+      {reclaimedForReal > 0 && (
+        <span className="tray-observed">
+          <span className="tray-observed-count num">{reclaimedForReal}</span>
+          <span className="mono"> reclaimed</span>
+        </span>
+      )}
+      {awaiting > 0 && (
+        <span
+          className="tray-awaiting"
+          title="Drained earlier; the machine is still there. Something else has to remove it."
+        >
+          <span className="tray-awaiting-count num">{awaiting}</span>
+          <span className="mono"> awaiting</span>
+        </span>
       )}
       <div className="tray-marks" aria-hidden="true">
         {Array.from({ length: total }, (_, i) => (

--- a/ui/src/components/Verdict.tsx
+++ b/ui/src/components/Verdict.tsx
@@ -69,7 +69,7 @@ export default function Verdict({
           consolidation plan <PlanAge generatedAt={generatedAt} />
         </p>
         <h1 className="verdict-line">
-          Reclaim <span className="verdict-figure num">{stats.reclaimed}</span> of{" "}
+          Reclaim <span className="verdict-figure num">{stats.reclaimable}</span> of{" "}
           <span className="num">{stats.nodesBefore}</span> nodes
         </h1>
         {/* The nodes, named. "Run the 5 safe steps" is abstract; a list of

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1477,3 +1477,34 @@
 .box-reclaimed .box-density-count {
   color: var(--muted);
 }
+
+/* Observed reclamation, in the tray.
+   Deliberately quieter than the drained tally beside it. That number answers
+   "what would this plan do"; these answer "what actually happened", and the
+   two must not read as one figure — conflating them is how the product came
+   to report a prediction as a result. */
+.tray-observed,
+.tray-awaiting {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.2rem;
+  margin-left: 0.75rem;
+  font-size: 0.68rem;
+  color: var(--muted);
+}
+
+.tray-observed-count {
+  color: var(--chalk);
+  font-variant-numeric: tabular-nums;
+}
+
+/* Yellow, and only here, because a node drained-but-never-removed is capacity
+   you are still paying for. Never colour alone: the word "awaiting" carries
+   the same meaning for anyone who cannot see it. */
+.tray-awaiting {
+  color: var(--risk-yellow);
+}
+
+.tray-awaiting-count {
+  font-variant-numeric: tabular-nums;
+}


### PR DESCRIPTION
The product's headline number was **a prediction wearing the clothes of an outcome.**

`"15 reclaimable"` came from counting plan steps. The UI marked a node `box-reclaimed` from `steps[].targetNode <= step`. `graph.Stats.Reclaimed` was the same plan-time figure. **Nothing anywhere checked whether a single node ever went away** — on the KWOK fabric none ever do, and the UI still said reclaimed.

k8s-dencer cannot delete a node and still cannot; its ServiceAccount holds no `delete` verb and this adds none. Something else removes the machine. So rather than predict *which* reclaimer will act — vendor-specific, and wrong in ways a user cannot check — this observes whether one **did**.

## Three states, one of which is a saving

| State | Means | Set by |
|---|---|---|
| **reclaimable** | the plan would free this node | planner, at plan time |
| **awaiting reclamation** | drained and cordoned; machine still there | executor, on drain success |
| **reclaimed** | the `Node` object is gone | planner, by observation |
| **returned** | uncordoned instead — *not* a saving | planner, by observation |

The executor opens a record the moment a node is emptied. The planner — which watches nodes continuously anyway — closes it against the snapshot it already has. **No cloud API, no autoscaler detection, nothing to configure**, and the whole rule is a pure function over a snapshot, so it tests without a cluster.

`returned` earns its place: an operator who uncordons a drained node is never getting a reclamation, and leaving that row pending forever would make the awaiting count grow without bound and mean nothing.

## Surfaced where the claim used to be made

`dencer reclamations`, a footer on `dencer plan` when previously drained nodes are still sitting there, a UI tray that separates observed from planned, and three planner metrics. **`dencer_nodes_awaiting_reclamation` is the one to alert on** — rising without falling means nothing is reclaiming what you drained.

## A guard that immediately paid for itself

`Stats.Reclaimed` → `Stats.Reclaimable`, since it always described what a plan *would* free.

`Data` has had a contract test since M19; `Stats` had none, for no reason other than `Data` being the struct that had gone wrong before. Writing one found **three more fields sent to every client and read by nothing**: `nodesAfter`, `cpuReclaimedMilli`, `memoryReclaimedBytes`. The last two were freed-capacity predictions in the past tense — the same mistake in miniature. Removed.

Without that guard, the `Reclaimable` rename would itself have shipped silently as `undefined` in the browser, blanking the headline figure.

⚠️ **Breaking**: the graph payload's `stats.reclaimed` is now `stats.reclaimable`, and three fields are gone. Pre-1.0, one consumer, belongs in the release notes.

## Proven end to end, not argued

`hack/e2e.sh` plays both parts k3d makes cheap. Against a real five-node cluster:

```
==> the drain was recorded as awaiting reclamation
      k3d-dencer-e2e-agent-3 is awaiting reclamation
==> an autoscaler removes it
      observed as reclaimed — the loop closes
==> the other branch: a drained node put back into service
      k3d-dencer-e2e-agent-2 observed as returned to service, not counted as a saving
==> the metrics agree
      dencer_reclamation_seconds observed 1 reclamation(s)
```

`go vet`, `go test -race`, `gofmt`, `make lint`, typecheck, density probe, UI build, link check — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)