### PR TITLE
Release 0.2.0

### DIFF
--- a/charts/k8s-dencer/Chart.yaml
+++ b/charts/k8s-dencer/Chart.yaml
@@ -3,14 +3,15 @@ name: k8s-dencer
 description: |
   Continuously analyses Kubernetes scheduling constraints (PDBs, topology
   spread, affinity, taints) and builds a node consolidation plan as discrete,
-  impact-rated steps. Phase 1 is read-only: it plans and explains, it never
-  evicts.
+  impact-rated steps a human approves one at a time. Execution is off by
+  default; enabled, a separate workload drains through the eviction API so the
+  API server enforces your PodDisruptionBudgets.
 type: application
 
 # Chart version tracks the chart; appVersion tracks the images. Component image
 # tags default to appVersion so a chart release pins a coherent image set.
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.2.0
+appVersion: "0.2.0"
 
 # controller-runtime and the policy/v1 PDB API used here are stable from 1.21,
 # but the chart relies on 1.27-era defaults for restricted Pod Security


### PR DESCRIPTION
Bumps `version` and `appVersion` to `0.2.0`. `appVersion` selects the image tag and the release job refuses to publish if either disagrees with the git tag, so this has to land before `v0.2.0` exists.

**Also fixes something embarrassing.** The chart's description still read:

> Phase 1 is read-only: it plans and explains, it never evicts.

Wrong since M10, and it is the text **Artifact Hub renders** — so anyone browsing the chart was told the product cannot evict, twelve milestones after execution shipped. Rewritten to describe what it actually does, including that execution is off by default.

## Since 0.1.0

- The **reclamation loop** — the product now checks whether draining actually removed anything
- The **CLI** and its `kubectl` plugin
- `SECURITY.md` and private vulnerability reporting
- The **multi-node e2e** with PodSecurity enforcing and `readiness: Ready` on real pods
- **Ingress and StorageClass** claims exercised rather than rendered

## ⚠️ Breaking

The graph payload's `stats.reclaimed` is now `stats.reclaimable`, and `nodesAfter`, `cpuReclaimedMilli`, `memoryReclaimedBytes` are gone. Nothing read any of them, and the last two were plan-time predictions written in the past tense.

🤖 Generated with [Claude Code](https://claude.com/claude-code)