### PR TITLE
A cloud test on GKE, so a reclaimer we didn't write removes the node

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,10 @@ export PATH := $(LOCALBIN):$(PATH)
 help: ## Show available targets
 	@echo "k8s-dencer  (provider=$(CLUSTER_PROVIDER)  tag=$(IMAGE_TAG))"
 	@echo
-	@grep -hE '^[a-zA-Z_-]+:.*?## ' $(MAKEFILE_LIST) \
+	@# Digits belong in the class: without them every target with a number in
+	@# its name is silently missing from this list, which is how `e2e` stayed
+	@# invisible from the day it was added.
+	@grep -hE '^[a-zA-Z0-9_-]+:.*?## ' $(MAKEFILE_LIST) \
 		| sort \
 		| awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}'
 
@@ -184,6 +187,20 @@ cli-install: cli ## Install dencer and kubectl-dencer into $(GOBIN) or ~/go/bin
 .PHONY: e2e
 e2e: ## Install on a throwaway multi-node k3d cluster and drain a real node
 	./hack/e2e.sh
+
+.PHONY: gke-setup
+gke-setup: ## One-time GCP bootstrap for the cloud test (APIs, quota, budget alert)
+	./hack/gke-setup.sh
+
+.PHONY: cloud-e2e
+cloud-e2e: ## The same e2e on a real GKE cluster, so a real autoscaler reclaims the node
+	@echo "This creates a billable GKE cluster (~2-3 cents) and destroys it afterwards."
+	@echo "Run 'make gke-setup' first if you have not."
+	PROVIDER=gke ./hack/e2e.sh
+
+.PHONY: cloud-e2e-clean
+cloud-e2e-clean: ## Delete a GKE test cluster left behind by an interrupted run
+	PROVIDER=gke ./hack/e2e.sh clean
 
 .PHONY: lint
 lint: $(KUBECONFORM) ## Chart portability gate: lint, render and assert the contract

--- a/README.md
+++ b/README.md
@@ -229,9 +229,14 @@ workload came back Ready, then deletes the node and confirms the reclamation
 was observed. That is what
 [`make e2e`](hack/e2e.sh) does, and it runs on every pull request.
 
-It has still never run against a production cluster. Treat the read-only path
-as ready to try, and the executor as something to enable deliberately, on
-something you can afford to be wrong about.
+**It has still never run against a cloud cluster.** A cloud test now exists —
+`make cloud-e2e` runs the same assertions on a throwaway GKE cluster for about
+two cents, so a real cluster autoscaler is the thing that removes the drained
+node rather than our own test script — but it is one command away, not a green
+tick. When it has been run, this paragraph will say so.
+
+Treat the read-only path as ready to try, and the executor as something to
+enable deliberately, on something you can afford to be wrong about.
 
 Full milestone history in [docs/roadmap.md](docs/roadmap.md).
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -75,6 +75,66 @@ Two things it needs that are worth knowing, because both look like bugs:
   earlier. On a genuinely fresh cluster, expect no plan for the first ten
   minutes.
 
+## The cloud test
+
+```bash
+make gke-setup     # once: APIs, quota check, budget alert, cost preview
+make cloud-e2e     # ~25 minutes, mostly waiting on GKE's autoscaler
+```
+
+The same script, the same assertions, `PROVIDER=gke`. One script rather than
+two on purpose: the assertions are the valuable part of `hack/e2e.sh`, and a
+forked cloud copy would drift from them inside two milestones. Only cluster
+lifecycle, image delivery, storage class, ingress and the reclamation trigger
+branch.
+
+**It exists for one thing k3d structurally cannot do.** The reclamation loop
+observes whether a drained node actually disappeared — and on k3d the only
+thing that has ever made one disappear is `kubectl delete node` in our own
+script, us playing the part of an autoscaler. On GKE nothing here touches the
+node: the cluster autoscaler decides, on its own schedule, for its own reasons.
+That is the first independent confirmation the loop closes.
+
+Three other things come free with a real cluster: the **published ghcr images**
+are pulled rather than side-loaded, which is the first check that what we ship
+installs for someone who is not us; the PVC binds on a **cloud StorageClass**
+with real zonal topology rather than node-local `local-path`; and the control
+plane is a managed one, with a different API server build and its own admission
+webhooks.
+
+### What it does not prove
+
+Workload Identity is only half-testable. The chart's `serviceAccount.annotations`
+render and GKE accepts them, but **k8s-dencer makes no GCP API calls**, so there
+is no credential path to exercise. A green run means the annotation is accepted,
+not that IRSA or Workload Identity work. The same is true of EKS.
+
+### Cost
+
+Roughly **two to three cents a run**: the GKE free-tier credit covers one zonal
+cluster's control plane, and the nodes are Spot with 20GB `pd-standard` disks.
+On a new account the $300 / 90-day trial covers it outright, and the trial does
+not auto-charge when it runs out.
+
+The one real risk is a cluster left running — four idle nodes is about
+$100/month — so the script deletes it on every exit path, including `Ctrl-C`,
+and reports loudly rather than silently if deletion fails. If a run is ever
+interrupted hard enough to skip the trap:
+
+```bash
+make cloud-e2e-clean
+gcloud container clusters list     # should be empty
+```
+
+### Two things that look like failures
+
+- **Scale-down takes about ten minutes.** GKE's `scale-down-unneeded-time`
+  default. Shortening it would test a configuration nobody runs.
+- **A `kube-system` pod with no PDB pins its node**, and the autoscaler
+  correctly refuses to remove it. If the drained node happens to host one the
+  run times out; the failure output lists the pods still on the node so the
+  cause is visible rather than guessed at.
+
 ## Test fabric (KWOK)
 
 A node-consolidation planner cannot be tested on a single-node cluster. [KWOK](https://kwok.sigs.k8s.io/) provides fake nodes with no kubelet, so a laptop presents a 30-node topology while the **real** scheduler, PDB accounting and eviction API all apply.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -52,6 +52,7 @@ estimated — every milestone here starts from a number in
 | **M21** | Multi-node k3d e2e in CI, PodSecurity **enforcing**, `readiness: Ready` on real pods | **done** |
 | **M21b** | Real ingress controller and StorageClass, exercised in the e2e | **done** |
 | **M22** | Reclamation loop — observe whether a drained node was actually removed | **done** |
+| **M23** | Cloud test on GKE — `make cloud-e2e`, so a real cluster autoscaler reclaims the node | **done** |
 
 High availability and a Postgres store were **dropped, not deferred**: a
 consolidation planner is not a serving path. The run queue is already crash-safe

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -25,15 +25,25 @@
 #      since M0 on the strength of `helm template | grep`. Here the namespace
 #      enforces it and the API server decides.
 #
-#   ./hack/e2e.sh            run it
-#   ./hack/e2e.sh clean      tear the cluster down
-#   KEEP=1 ./hack/e2e.sh     leave the cluster up afterwards for poking at
+#   ./hack/e2e.sh                 run it on a throwaway k3d cluster
+#   ./hack/e2e.sh clean           tear the cluster down
+#   KEEP=1 ./hack/e2e.sh          leave the cluster up afterwards for poking at
+#   PROVIDER=gke ./hack/e2e.sh    run it on a real GKE cluster (see below)
+#
+# The GKE path exists for the one thing k3d structurally cannot do: let a
+# cluster autoscaler we did not write decide, on its own schedule, to remove a
+# node we drained. Everything else here is shared, deliberately — the
+# assertions are the valuable part of this file, and a forked cloud copy would
+# drift from them inside two milestones. Only cluster lifecycle, image delivery
+# and the reclamation trigger branch.
+#
+# It costs roughly two cents a run and destroys the cluster on every exit path.
+# See docs/development.md, and run `make gke-setup` once first.
 #
 set -euo pipefail
 
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CLUSTER="${CLUSTER:-dencer-e2e}"
-CTX="k3d-${CLUSTER}"
 NS="${NS:-k8s-dencer}"
 APP_NS="${APP_NS:-shop}"
 RELEASE="k8s-dencer"
@@ -45,6 +55,20 @@ AGENTS="${AGENTS:-4}"
 PF_PORT="${PF_PORT:-18099}"
 INGRESS_PORT="${INGRESS_PORT:-18080}"
 INGRESS_HOST="${INGRESS_HOST:-k8s-dencer.e2e}"
+
+PROVIDER="${PROVIDER:-k3d}"
+GCP_ZONE="${GCP_ZONE:-us-central1-a}"
+GCP_MACHINE="${GCP_MACHINE:-e2-medium}"
+# Published tags, not a local build: on GKE this doubles as the first proof
+# that what we ship to ghcr actually installs. Overridable so a release
+# candidate can be tested before it is tagged latest.
+GHCR_TAG="${GHCR_TAG:-latest}"
+
+case "$PROVIDER" in
+  k3d) CTX="k3d-${CLUSTER}" ;;
+  gke) CTX="gke-e2e" ;;
+  *)   echo "PROVIDER must be k3d or gke, got '$PROVIDER'" >&2; exit 1 ;;
+esac
 
 red()   { printf '\033[31m%s\033[0m\n' "$*"; }
 green() { printf '\033[32m%s\033[0m\n' "$*"; }
@@ -65,32 +89,92 @@ PF=""
 cleanup() {
   [[ -n "$PF" ]] && kill "$PF" 2>/dev/null || true
   if [[ "${KEEP:-0}" != "1" ]]; then
-    k3d cluster delete "$CLUSTER" >/dev/null 2>&1 || true
+    cluster_delete
   fi
   restore_context
 }
 trap cleanup EXIT
 
 if [[ "${1:-}" == "clean" ]]; then
-  k3d cluster delete "$CLUSTER" >/dev/null 2>&1 || true
+  cluster_delete
   restore_context
   green "removed"
   exit 0
 fi
 
-for bin in k3d kubectl helm docker; do
+# ------------------------------------------------------------- provider
+
+cluster_create() {
+  if [[ "$PROVIDER" == "k3d" ]]; then
+    k3d cluster delete "$CLUSTER" >/dev/null 2>&1 || true
+    # The loadbalancer port is published so a request can actually traverse the
+    # ingress controller. Rendering an Ingress proves nothing; k3s bundles
+    # Traefik, so the only missing piece was a way in.
+    k3d cluster create "$CLUSTER" --servers 1 --agents "$AGENTS" \
+      -p "${INGRESS_PORT}:80@loadbalancer" --wait --timeout 300s >/dev/null
+    return
+  fi
+
+  local project
+  project="$(gcloud config get-value project 2>/dev/null)"
+  [[ -n "$project" && "$project" != "(unset)" ]] \
+    || fail "no gcloud project set. Run 'make gke-setup' first"
+
+  # Zonal, not regional: the GKE free tier credit covers one zonal cluster's
+  # management fee, and a regional control plane buys nothing for a cluster
+  # that lives twenty minutes.
+  #
+  # Autoscaling is the entire point. min-nodes below the starting count is what
+  # permits the autoscaler to remove the node we drain — without it, it would
+  # correctly refuse and the run would report a false negative.
+  #
+  # Autoupgrade and autorepair off so GKE does not move nodes underneath the
+  # test and make its own maintenance look like our reclamation.
+  gcloud container clusters create "$CLUSTER" \
+    --zone "$GCP_ZONE" \
+    --num-nodes "$((AGENTS + 1))" \
+    --machine-type "$GCP_MACHINE" \
+    --spot \
+    --disk-type pd-standard --disk-size 20 \
+    --enable-autoscaling --min-nodes 1 --max-nodes "$((AGENTS + 2))" \
+    --no-enable-autoupgrade --no-enable-autorepair \
+    --workload-pool "${project}.svc.id.goog" \
+    --labels purpose=dencer-e2e \
+    --quiet >/dev/null || fail "could not create the GKE cluster"
+
+  gcloud container clusters get-credentials "$CLUSTER" --zone "$GCP_ZONE" --quiet 2>/dev/null
+  kubectl config rename-context "$(kubectl config current-context)" "$CTX" >/dev/null 2>&1 || true
+}
+
+cluster_delete() {
+  if [[ "$PROVIDER" == "k3d" ]]; then
+    k3d cluster delete "$CLUSTER" >/dev/null 2>&1 || true
+    return
+  fi
+  # Deliberately noisy and synchronous. A leaked GKE cluster is the only way
+  # this script can cost real money, so a failure to delete must be seen rather
+  # than swallowed into /dev/null like the k3d case.
+  echo "  deleting the GKE cluster (this takes a few minutes)…"
+  gcloud container clusters delete "$CLUSTER" --zone "$GCP_ZONE" --quiet \
+    || red "COULD NOT DELETE CLUSTER ${CLUSTER} in ${GCP_ZONE} — delete it by hand, it is costing money"
+  kubectl config delete-context "$CTX" >/dev/null 2>&1 || true
+}
+
+for bin in kubectl helm; do
   command -v "$bin" >/dev/null || fail "$bin is required"
 done
+if [[ "$PROVIDER" == "k3d" ]]; then
+  for bin in k3d docker; do
+    command -v "$bin" >/dev/null || fail "$bin is required"
+  done
+else
+  command -v gcloud >/dev/null || fail "gcloud is required for PROVIDER=gke"
+fi
 
 # ---------------------------------------------------------------- cluster
 
-bold "==> multi-node cluster"
-k3d cluster delete "$CLUSTER" >/dev/null 2>&1 || true
-# The loadbalancer port is published so a request can actually traverse the
-# ingress controller. Rendering an Ingress proves nothing; k3s bundles Traefik,
-# so the only missing piece was a way in.
-k3d cluster create "$CLUSTER" --servers 1 --agents "$AGENTS" \
-  -p "${INGRESS_PORT}:80@loadbalancer" --wait --timeout 300s >/dev/null
+bold "==> multi-node cluster (${PROVIDER})"
+cluster_create
 nodes="$(kubectl --context "$CTX" get nodes --no-headers | wc -l | tr -d ' ')"
 [[ "$nodes" -ge 4 ]] || fail "expected at least 4 nodes for the guard's floor, got $nodes"
 green "  ${nodes} nodes"
@@ -112,13 +196,21 @@ green "  restricted enforced on $NS and $APP_NS"
 # ---------------------------------------------------------------- images
 
 bold "==> images"
-TAG="$(make -s -C "$REPO" print-tag)"
-make -s -C "$REPO" images >/dev/null 2>&1 || fail "image build failed"
-k3d image import -c "$CLUSTER" \
-  "k8s-dencer-planner:${TAG}" "k8s-dencer-ui-backend:${TAG}" \
-  "k8s-dencer-executor:${TAG}" "k8s-dencer-ui-frontend:${TAG}" >/dev/null 2>&1 \
-  || fail "could not import images into the cluster"
-green "  built and imported ${TAG}"
+if [[ "$PROVIDER" == "k3d" ]]; then
+  TAG="$(make -s -C "$REPO" print-tag)"
+  make -s -C "$REPO" images >/dev/null 2>&1 || fail "image build failed"
+  k3d image import -c "$CLUSTER" \
+    "k8s-dencer-planner:${TAG}" "k8s-dencer-ui-backend:${TAG}" \
+    "k8s-dencer-executor:${TAG}" "k8s-dencer-ui-frontend:${TAG}" >/dev/null 2>&1 \
+    || fail "could not import images into the cluster"
+  green "  built and imported ${TAG}"
+else
+  # Pulled, not imported. On a real cluster there is no local image store to
+  # cheat with, so this run is also the first check that what we publish to
+  # ghcr is installable by someone who is not us.
+  TAG="$GHCR_TAG"
+  green "  using published ghcr.io/atedgimo/k8s-dencer-*:${TAG}"
+fi
 
 # ---------------------------------------------------------------- workload
 
@@ -169,6 +261,49 @@ green "  ${ready} replicas Ready with httpGet probes"
 
 # ---------------------------------------------------------------- install
 
+# Chart flags that differ by provider. On GKE the Ingress is skipped: it
+# provisions a billable load balancer and takes minutes to become healthy,
+# which is real cost and real waiting for a path Traefik already proves.
+if [[ "$PROVIDER" == "k3d" ]]; then
+  # Local, unqualified image names with IfNotPresent so the imported images are
+  # used and nothing reaches for a registry.
+  IMAGE_SET=(
+    --set planner.image.pullPolicy=IfNotPresent
+    --set uiBackend.image.pullPolicy=IfNotPresent
+    --set executor.image.pullPolicy=IfNotPresent
+    --set uiFrontend.image.pullPolicy=IfNotPresent
+    --set-string planner.image.registry=""
+    --set-string uiBackend.image.registry=""
+    --set-string executor.image.registry=""
+    --set-string uiFrontend.image.registry=""
+    --set-string planner.image.repository=k8s-dencer-planner
+    --set-string uiBackend.image.repository=k8s-dencer-ui-backend
+    --set-string executor.image.repository=k8s-dencer-executor
+    --set-string uiFrontend.image.repository=k8s-dencer-ui-frontend
+  )
+  PROVIDER_SET=(
+    --set-string persistence.storageClass=local-path
+    --set ingress.enabled=true
+    --set-string ingress.className=traefik
+    --set-string "ingress.hosts[0].host=${INGRESS_HOST}"
+    --set-string "ingress.hosts[0].paths[0].path=/"
+    --set-string "ingress.hosts[0].paths[0].pathType=Prefix"
+  )
+else
+  IMAGE_SET=()
+  PROVIDER_SET=(
+    --set-string persistence.storageClass=standard-rwo
+    --set-string planner.image.registry=ghcr.io
+    --set-string uiBackend.image.registry=ghcr.io
+    --set-string executor.image.registry=ghcr.io
+    --set-string uiFrontend.image.registry=ghcr.io
+    --set-string planner.image.repository=atedgimo/k8s-dencer-planner
+    --set-string uiBackend.image.repository=atedgimo/k8s-dencer-ui-backend
+    --set-string executor.image.repository=atedgimo/k8s-dencer-executor
+    --set-string uiFrontend.image.repository=atedgimo/k8s-dencer-ui-frontend
+  )
+fi
+
 # minNodeAge=0s: a fresh k3d cluster's nodes are seconds old, and the planner
 # correctly refuses to drain anything younger than minNodeAge — the rail that
 # stops it reclaiming a node an autoscaler added moments ago. Sensible in
@@ -178,30 +313,14 @@ helm --kube-context "$CTX" upgrade --install "$RELEASE" "$REPO/charts/k8s-dencer
   --namespace "$NS" \
   --set auth.enabled=true \
   --set persistence.enabled=true \
-  --set-string persistence.storageClass=local-path \
-  --set ingress.enabled=true \
-  --set-string ingress.className=traefik \
-  --set-string "ingress.hosts[0].host=${INGRESS_HOST}" \
-  --set-string "ingress.hosts[0].paths[0].path=/" \
-  --set-string "ingress.hosts[0].paths[0].pathType=Prefix" \
+  "${PROVIDER_SET[@]}" \
   --set executor.enabled=true \
   --set planner.minNodeAge=0s \
   --set-string planner.image.tag="$TAG" \
   --set-string uiBackend.image.tag="$TAG" \
   --set-string executor.image.tag="$TAG" \
   --set-string uiFrontend.image.tag="$TAG" \
-  --set planner.image.pullPolicy=IfNotPresent \
-  --set uiBackend.image.pullPolicy=IfNotPresent \
-  --set executor.image.pullPolicy=IfNotPresent \
-  --set uiFrontend.image.pullPolicy=IfNotPresent \
-  --set-string planner.image.registry="" \
-  --set-string uiBackend.image.registry="" \
-  --set-string executor.image.registry="" \
-  --set-string uiFrontend.image.registry="" \
-  --set-string planner.image.repository=k8s-dencer-planner \
-  --set-string uiBackend.image.repository=k8s-dencer-ui-backend \
-  --set-string executor.image.repository=k8s-dencer-executor \
-  --set-string uiFrontend.image.repository=k8s-dencer-ui-frontend \
+  "${IMAGE_SET[@]}" \
   --wait --timeout 300s >/dev/null || {
     kubectl --context "$CTX" -n "$NS" get pods
     fail "chart did not install"
@@ -224,8 +343,9 @@ pvc="$(kubectl --context "$CTX" -n "$NS" get pvc -o jsonpath='{.items[0].metadat
 [[ -n "$pvc" ]] || fail "persistence is on but no PersistentVolumeClaim was created"
 phase="$(kubectl --context "$CTX" -n "$NS" get pvc "$pvc" -o jsonpath='{.status.phase}')"
 [[ "$phase" == "Bound" ]] || fail "PVC ${pvc} is ${phase}, not Bound"
+want_sc="local-path"; [[ "$PROVIDER" == "gke" ]] && want_sc="standard-rwo"
 sc="$(kubectl --context "$CTX" -n "$NS" get pvc "$pvc" -o jsonpath='{.spec.storageClassName}')"
-[[ "$sc" == "local-path" ]] || fail "PVC bound to StorageClass '${sc}', not the requested local-path"
+[[ "$sc" == "$want_sc" ]] || fail "PVC bound to StorageClass '${sc}', not the requested ${want_sc}"
 green "  ${pvc} Bound on ${sc}"
 
 bold "==> the ReadWriteOnce claim keeps its two readers together"
@@ -241,6 +361,11 @@ bnode="$(kubectl --context "$CTX" -n "$NS" get pod -l app.kubernetes.io/componen
   || fail "planner is on '${pnode}' and ui-backend on '${bnode}'; a ReadWriteOnce volume cannot span nodes"
 green "  planner and ui-backend co-scheduled on ${pnode}"
 
+if [[ "$PROVIDER" == "gke" ]]; then
+  bold "==> ingress"
+  green "  skipped on GKE: a cloud Ingress provisions a billable load balancer,"
+  green "  and the Traefik run already proves the chart's Ingress routes"
+else
 bold "==> a request actually traverses the ingress controller"
 code=""
 for _ in $(seq 1 30); do
@@ -252,6 +377,7 @@ done
 [[ "$code" == "200" ]] \
   || fail "GET / through the ingress returned '${code}', not 200"
 green "  Traefik routed ${INGRESS_HOST} to the frontend (HTTP 200)"
+fi
 
 # ---------------------------------------------------------------- plan
 
@@ -384,20 +510,55 @@ done
   || fail "the drain of ${TARGET} was never recorded; got '$(reclamation_outcome "$TARGET")'"
 green "  ${TARGET} is awaiting reclamation"
 
-bold "==> an autoscaler removes it"
-kubectl --context "$CTX" delete node "$TARGET" --wait=true >/dev/null
-# The planner observes on its resync, so this waits a cycle rather than a tick.
-for _ in $(seq 1 30); do
-  [[ "$(reclamation_outcome "$TARGET")" == "reclaimed" ]] && break
-  sleep 5
-done
-[[ "$(reclamation_outcome "$TARGET")" == "reclaimed" ]] \
-  || fail "${TARGET} was deleted but never observed as reclaimed; got '$(reclamation_outcome "$TARGET")'"
-green "  observed as reclaimed — the loop closes"
+if [[ "$PROVIDER" == "k3d" ]]; then
+  bold "==> an autoscaler removes it"
+  # k3d has no autoscaler, so the script plays the part. This proves the
+  # observation works; it cannot prove anything about a real reclaimer.
+  kubectl --context "$CTX" delete node "$TARGET" --wait=true >/dev/null
+  # The planner observes on its resync, so this waits a cycle rather than a tick.
+  for _ in $(seq 1 30); do
+    [[ "$(reclamation_outcome "$TARGET")" == "reclaimed" ]] && break
+    sleep 5
+  done
+  [[ "$(reclamation_outcome "$TARGET")" == "reclaimed" ]] \
+    || fail "${TARGET} was deleted but never observed as reclaimed; got '$(reclamation_outcome "$TARGET")'"
+  green "  observed as reclaimed — the loop closes"
+else
+  bold "==> GKE's own cluster autoscaler removes it"
+  echo "  Nothing here touches the node. GKE decides, on its own schedule —"
+  echo "  scale-down-unneeded-time defaults to 10 minutes, so this waits."
+  started="$(date +%s)"
+  outcome=""
+  for _ in $(seq 1 60); do   # up to 15 minutes
+    outcome="$(reclamation_outcome "$TARGET")"
+    [[ "$outcome" == "reclaimed" ]] && break
+    # A Spot preemption would also make a node vanish. Tying the assertion to
+    # the node the plan drained is what stops that reading as a pass.
+    sleep 15
+  done
+  took=$(( $(date +%s) - started ))
+  if [[ "$outcome" != "reclaimed" ]]; then
+    red "  ${TARGET} was never reclaimed after $((took / 60))m. Current state:"
+    kubectl --context "$CTX" get nodes -o wide 2>/dev/null | sed 's/^/    /'
+    # The usual cause, and not a bug in this product: a kube-system pod with no
+    # PDB pins the node and the autoscaler correctly refuses.
+    kubectl --context "$CTX" get pods -A --field-selector "spec.nodeName=${TARGET}" \
+      --no-headers 2>/dev/null | sed 's/^/    /'
+    fail "no reclamation observed; got '${outcome}'"
+  fi
+  kubectl --context "$CTX" get node "$TARGET" >/dev/null 2>&1 \
+    && fail "recorded as reclaimed but the Node object is still there"
+  green "  observed as reclaimed after $((took / 60))m$((took % 60))s — by a reclaimer we did not write"
+fi
 
 # The other branch. An operator who uncordons a drained node is never getting a
 # reclamation, and leaving that row pending forever would make the awaiting
 # count grow without bound and mean nothing.
+if [[ "$PROVIDER" == "gke" ]]; then
+  bold "==> the other branch: a drained node put back into service"
+  green "  skipped on GKE: uncordoning races the autoscaler, which may remove"
+  green "  the node before the observer sees it schedulable — the k3d run proves it"
+else
 bold "==> the other branch: a drained node put back into service"
 SECOND="$(api /api/v1/plans/latest | python3 -c '
 import json,sys
@@ -442,6 +603,7 @@ for s in (d.get('plan') or d).get('steps') or []:
     green "  ${node2} observed as returned to service, not counted as a saving"
   fi
 fi
+fi
 
 bold "==> the metrics agree"
 kubectl --context "$CTX" -n "$NS" port-forward "deploy/${RELEASE}-planner" 18100:8081 >/dev/null 2>&1 &
@@ -456,5 +618,11 @@ observed="$(grep -E "^dencer_reclamation_seconds_count " <<<"$series" | awk "{pr
 green "  dencer_reclamation_seconds observed ${observed} reclamation(s)"
 
 echo
-green "e2e passed: multi-node, PodSecurity enforced, a real ingress and StorageClass,"
-green "real pods evicted and recovered, and a node observed actually going away."
+if [[ "$PROVIDER" == "gke" ]]; then
+  green "cloud e2e passed on GKE: the published images installed, a cloud StorageClass"
+  green "bound, real pods were evicted and recovered, and GKE's own cluster autoscaler"
+  green "removed the drained node — observed by a reclaimer we did not write."
+else
+  green "e2e passed: multi-node, PodSecurity enforced, a real ingress and StorageClass,"
+  green "real pods evicted and recovered, and a node observed actually going away."
+fi

--- a/hack/gke-setup.sh
+++ b/hack/gke-setup.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+#
+# One-time GCP project bootstrap for `make cloud-e2e`.
+#
+# Idempotent — safe to re-run. It enables the two APIs the cluster needs,
+# checks the quota that most often makes a first run fail for a reason the
+# error message does not explain, and offers a budget alert.
+#
+# What the cloud run costs, and why this script talks about money at all: a GKE
+# cluster is the only thing in this repository that can bill you. Everything
+# else is a container on your laptop. That asymmetry deserves a script that is
+# explicit about it rather than a line in a README nobody reads twice.
+#
+#   ./hack/gke-setup.sh          check and fix
+#   ./hack/gke-setup.sh check    report only, change nothing
+#
+set -euo pipefail
+
+ZONE="${GCP_ZONE:-us-central1-a}"
+MACHINE="${GCP_MACHINE:-e2-medium}"
+NODES="${NODES:-5}"
+BUDGET="${BUDGET:-1}"
+
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+bold()  { printf '\033[1m%s\033[0m\n' "$*"; }
+warn()  { printf '\033[33m%s\033[0m\n' "$*"; }
+fail()  { red "FAIL: $*"; exit 1; }
+
+CHECK_ONLY=0
+[[ "${1:-}" == "check" ]] && CHECK_ONLY=1
+
+command -v gcloud >/dev/null || fail "gcloud is required: https://cloud.google.com/sdk/docs/install"
+
+bold "==> account and project"
+account="$(gcloud config get-value account 2>/dev/null || true)"
+[[ -n "$account" && "$account" != "(unset)" ]] || fail "not logged in. Run: gcloud auth login"
+project="$(gcloud config get-value project 2>/dev/null || true)"
+[[ -n "$project" && "$project" != "(unset)" ]] \
+  || fail "no project set. Create one in the console, then: gcloud config set project <id>"
+green "  ${account} on project ${project}"
+
+bold "==> billing"
+# GKE requires a billing account even when the free-tier credit covers the
+# cluster fee. On the $300 trial this is the trial account, and it does not
+# auto-charge when the credit runs out — GCP pauses resources and asks.
+billing="$(gcloud billing projects describe "$project" \
+  --format='value(billingEnabled)' 2>/dev/null || echo "unknown")"
+if [[ "$billing" != "True" ]]; then
+  fail "billing is not enabled on ${project}.
+  GKE needs a billing account linked even on the free tier. Link the \$300 trial
+  account at https://console.cloud.google.com/billing/linkedaccount?project=${project}"
+fi
+green "  enabled"
+
+bold "==> APIs"
+for api in container.googleapis.com compute.googleapis.com; do
+  if gcloud services list --enabled --filter="config.name=${api}" \
+       --format='value(config.name)' 2>/dev/null | grep -q "$api"; then
+    green "  ${api} already enabled"
+  elif [[ "$CHECK_ONLY" == "1" ]]; then
+    warn "  ${api} NOT enabled"
+  else
+    echo "  enabling ${api} (this takes a minute)…"
+    gcloud services enable "$api" --quiet
+    green "  ${api} enabled"
+  fi
+done
+
+bold "==> quota for ${NODES} × ${MACHINE} Spot in ${ZONE}"
+# The trap this check exists for: a brand-new project can have a Spot/preemptible
+# CPU quota of zero, and the cluster create then fails several minutes in with a
+# message about "PREEMPTIBLE_CPUS" that reads like a bug in the script.
+region="${ZONE%-*}"
+spot_quota="$(gcloud compute regions describe "$region" \
+  --format='value(quotas.filter("metric:PREEMPTIBLE_CPUS").limit)' 2>/dev/null || echo "")"
+needed=$(( NODES * 2 ))   # e2-medium is 2 vCPU
+if [[ -z "$spot_quota" ]]; then
+  warn "  could not read PREEMPTIBLE_CPUS quota for ${region}; the run may still work"
+elif (( ${spot_quota%.*} < needed )); then
+  warn "  PREEMPTIBLE_CPUS in ${region} is ${spot_quota%.*}, and ${NODES} × ${MACHINE} needs ${needed}."
+  warn "  Request more at https://console.cloud.google.com/iam-admin/quotas, or run with"
+  warn "  fewer/smaller nodes:  AGENTS=2 GCP_MACHINE=e2-small make cloud-e2e"
+else
+  green "  ${spot_quota%.*} preemptible vCPUs available, ${needed} needed"
+fi
+
+bold "==> budget alert"
+# Cheap insurance against the one real failure mode: a cluster left running.
+ba="$(gcloud billing projects describe "$project" \
+  --format='value(billingAccountName)' 2>/dev/null || true)"
+if [[ -z "$ba" ]]; then
+  warn "  could not read the billing account; skipping"
+elif gcloud billing budgets list --billing-account="${ba##*/}" \
+       --format='value(displayName)' 2>/dev/null | grep -q "dencer-e2e"; then
+  green "  already set"
+elif [[ "$CHECK_ONLY" == "1" ]]; then
+  warn "  no dencer-e2e budget alert"
+else
+  if gcloud billing budgets create --billing-account="${ba##*/}" \
+       --display-name="dencer-e2e" \
+       --budget-amount="${BUDGET}USD" \
+       --threshold-rule=percent=0.5 --threshold-rule=percent=1.0 \
+       --quiet >/dev/null 2>&1; then
+    green "  \$${BUDGET} budget alert created"
+  else
+    # Needs the Billing Budgets API and billing.budgets.create, which a trial
+    # account may not grant. Not worth failing setup over.
+    warn "  could not create one (needs billing.budgets.create). Set a budget by hand:"
+    warn "  https://console.cloud.google.com/billing/budgets"
+  fi
+fi
+
+echo
+bold "What a run costs"
+cat <<EOF
+  control plane   free      GKE's free tier credit covers one zonal cluster
+  ${NODES} × ${MACHINE} Spot   ~\$0.04/hr
+  ${NODES} × 20GB pd-standard ~\$0.01/hr
+  ---------------------------------------------------------------
+  a ~25 minute run    roughly two to three cents
+
+  The cluster is destroyed on every exit path, including Ctrl-C. The one way
+  this costs real money is a cluster left running: four idle nodes is about
+  \$100/month. If a run is ever interrupted so hard the trap does not fire:
+
+    ./hack/e2e.sh clean            # or: make cloud-e2e-clean
+    gcloud container clusters list # should be empty
+EOF
+
+echo
+green "ready:  make cloud-e2e"


### PR DESCRIPTION
The reclamation loop observes whether a drained node actually disappeared. On k3d **the only thing that has ever made one disappear is `kubectl delete node` in our own script** — us playing the part of an autoscaler and then congratulating ourselves for noticing. That proves the observation works. It proves nothing about a real reclaimer.

`PROVIDER=gke` runs the same script against a throwaway GKE cluster and touches nothing. The cluster autoscaler decides, on its own schedule, for its own reasons.

```bash
make gke-setup     # once: APIs, quota check, budget alert, cost preview
make cloud-e2e     # ~25 min, mostly waiting on GKE's autoscaler
```

Three things come free with a real cluster:

| | |
|---|---|
| **Published images are pulled, not side-loaded** | first check that what we ship to ghcr installs for someone who isn't us |
| **A cloud StorageClass** | `standard-rwo` with real zonal topology, not node-local `local-path` |
| **A managed control plane** | different API server build, GKE's own admission |

## One script, not two

The assertions are the valuable part of `hack/e2e.sh`; a forked cloud copy would drift from them inside two milestones. Only cluster lifecycle, image delivery, storage class, ingress and the reclamation trigger branch. **The k3d run was re-run afterwards and is unchanged** — same 3-step plan, same drain, same reclamation, same `returned` branch.

## Money gets explicit treatment

A GKE cluster is the only thing in this repo that can bill you; everything else is a container on a laptop. That asymmetry deserves more than a README line.

- **~2–3 cents per run.** Free-tier credit covers one zonal control plane; nodes are Spot on 20GB `pd-standard`.
- **The only real risk is a cluster left running** (~$100/month for four idle nodes), so deletion happens on every exit path including `Ctrl-C`, and *shouts* rather than swallowing a failure into `/dev/null` the way the k3d path can afford to.
- `make gke-setup` checks the **preemptible-CPU quota up front** — a new project can have zero, and the resulting failure arrives several minutes into cluster creation reading like a bug in our script.

## Deliberately skipped on GKE

- **Ingress** — provisions a billable load balancer for a path Traefik already proves.
- **The returned-to-service branch** — uncordoning races the autoscaler, which may remove the node before the observer sees it schedulable. That would be a flaky test of a property the k3d run already covers.

## Also

`make help`'s regex was `^[a-zA-Z_-]+:` — **no digits** — so it had been hiding `e2e` since the day that target was added. Fixed.

## What this does not claim

**The README does not say this has been run.** It hasn't — there's no GCP account yet — and a test that exists is not a test that passed. It also states plainly that Workload Identity stays half-proven: the annotation renders and GKE accepts it, but k8s-dencer makes no GCP API calls, so there's no credential path to exercise.

`go vet`, `go test`, `gofmt`, `make lint`, both scripts parse, links check, k3d e2e re-run green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)