### PR TITLE
A header, a scale, and a way into a node

### DIFF
--- a/charts/k8s-dencer/templates/ui-backend/deployment.yaml
+++ b/charts/k8s-dencer/templates/ui-backend/deployment.yaml
@@ -127,6 +127,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            {{- with .Values.uiBackend.clusterLabel }}
+            - name: CLUSTER_LABEL
+              value: {{ . | quote }}
+            {{- end }}
             {{- with .Values.uiBackend.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/k8s-dencer/templates/ui-frontend/configmap.yaml
+++ b/charts/k8s-dencer/templates/ui-frontend/configmap.yaml
@@ -51,7 +51,12 @@ data:
             try_files $uri =404;
         }
 
+        # The entry HTML must revalidate on every load: without a
+        # Cache-Control it is heuristically cached, and because it names the
+        # hashed asset files a stale copy pins the browser to the previous
+        # release with no sign that a deploy happened.
         location / {
+            add_header Cache-Control "no-cache" always;
             try_files $uri $uri/ /index.html;
         }
     }

--- a/charts/k8s-dencer/values.yaml
+++ b/charts/k8s-dencer/values.yaml
@@ -151,6 +151,14 @@ planner:
 uiBackend:
   # Pinned to 1 while database.type is sqlite. Enforced by values.schema.json.
   replicaCount: 1
+
+  # Shown in the UI header so an operator can see which cluster they are about
+  # to act on. Empty renders nothing — a guessed environment name is worse than
+  # none, because the entire value of this field is being believed when it says
+  # "prod".
+  #
+  #   clusterLabel: prod-eu-west-1
+  clusterLabel: ""
   # How often to check the store for a new plan, to push over the event stream.
   # The planner is a separate process reached only through the shared volume,
   # so there is no event feed to subscribe to.

--- a/cmd/ui-backend/main.go
+++ b/cmd/ui-backend/main.go
@@ -101,6 +101,10 @@ func run(ctx context.Context, log *slog.Logger) error {
 		api = api.WithGraphPodDetailLimit(lim)
 		log.Info("graph detail limit overridden", "podDetailLimit", lim)
 	}
+	if label := env("CLUSTER_LABEL", ""); label != "" {
+		api = api.WithClusterLabel(label)
+		log.Info("cluster label set", "label", label)
+	}
 	api.Routes(mux)
 
 	// The Kagent agent reaches the same plan store over MCP. It is mounted on

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@
 | **[Authentication and authorization](security.md)** | TokenReview and SubjectAccessReview delegation, OIDC/SSO, and how to verify the privilege split yourself |
 | **[Execution and safety](execution.md)** | What the executor does per step, the Safety Guard's rails, maintenance windows, and the audit trail |
 | **[Observability](observability.md)** | Prometheus metrics and what each component publishes |
+| **[Running the cloud test on GCP](gcp-setup.md)** | Account, project, billing, quota — everything to do by hand, once |
 | **[Development](development.md)** | The local loop, the KWOK fake-node fabric, the CI gates, and cutting a release |
 | **[Benchmarks](benchmarks.md)** | Measured cost per operation, and where each stage stops being usable |
 | **[Roadmap and status](roadmap.md)** | What is built, what is planned, and what was dropped |

--- a/docs/gcp-setup.md
+++ b/docs/gcp-setup.md
@@ -1,0 +1,174 @@
+# Running the cloud test on GCP
+
+Everything you need to do by hand, once. About fifteen minutes, most of it
+waiting for GCP.
+
+The end result is `make cloud-e2e`: a throwaway GKE cluster that installs the
+published chart, drains a real node, and waits for **GKE's own cluster
+autoscaler** to remove it. That last part is the reason this exists — on k3d the
+only thing that has ever removed a drained node is our own test script.
+
+---
+
+## What it will cost
+
+**Nothing, on a new account.** The $300 / 90-day free trial covers it many
+thousand times over.
+
+| | |
+|---|---|
+| GKE control plane | **free** — the GKE free tier credit covers one *zonal* cluster |
+| 5 × `e2-medium` Spot | ~$0.04/hr |
+| 5 × 20GB `pd-standard` | ~$0.01/hr |
+| **A ~25 minute run** | **about 2–3 cents** |
+
+Two things worth knowing before you start:
+
+- **The free trial does not auto-charge.** When the credit runs out or expires,
+  GCP pauses resources and asks you to upgrade. It will not quietly start
+  billing your card.
+- **The only real risk is a cluster left running.** Five idle nodes is roughly
+  $100/month. The script deletes the cluster on every exit path including
+  `Ctrl-C`, and shouts if deletion fails — but if a run is ever killed hard
+  enough to skip that, see [If something goes wrong](#if-something-goes-wrong).
+
+---
+
+## 1. Create the account
+
+1. Go to **<https://cloud.google.com/free>** and click *Get started for free*.
+2. Sign in with a Google account.
+3. Accept the **$300 / 90-day** trial.
+
+You will be asked for a **credit card**. This is an identity check —
+Google states the trial does not charge it, and does not begin charging when
+the credit runs out unless you explicitly upgrade to a paid account.
+
+## 2. Create a project
+
+In the console, top bar, the project dropdown → **New project**.
+
+- **Name**: anything. `dencer-e2e` is fine.
+- Note the **project ID** it generates — it may differ from the name, and the
+  ID is what you need below.
+
+## 3. Link billing
+
+New projects are not always linked to the trial billing account automatically,
+and GKE will not start without one — even though the free-tier credit covers
+the cluster fee.
+
+**<https://console.cloud.google.com/billing/linkedaccount>** → select your
+project → link the trial billing account.
+
+`make gke-setup` checks this and tells you if it is missing.
+
+## 4. Install the gcloud CLI
+
+```bash
+brew install --cask google-cloud-sdk     # macOS
+```
+
+Anything else: <https://cloud.google.com/sdk/docs/install>
+
+## 5. Log in and select the project
+
+```bash
+gcloud auth login
+gcloud config set project YOUR_PROJECT_ID
+```
+
+## 6. Bootstrap
+
+```bash
+make gke-setup
+```
+
+Idempotent, and safe to re-run. It:
+
+- confirms you are logged in and billing is linked
+- enables `container.googleapis.com` and `compute.googleapis.com`
+- **checks your preemptible-CPU quota** — a brand-new project can have zero,
+  and without this check the failure arrives several minutes into cluster
+  creation with a message that reads like a bug in our script
+- offers to create a **$1 budget alert**
+- prints what a run costs
+
+## 7. Run it
+
+```bash
+make cloud-e2e
+```
+
+About 25 minutes. Most of that is one wait: GKE's `scale-down-unneeded-time`
+defaults to ten minutes, so after the drain the script sits watching for the
+autoscaler to act. That is the real behaviour of the thing being tested.
+
+Expect roughly:
+
+```
+==> multi-node cluster (gke)                5 nodes
+==> namespace with PodSecurity enforcing
+==> images                                  using published ghcr.io/... :latest
+==> real workloads                          6 replicas Ready with httpGet probes
+==> install                                 executor readiness=Ready
+==> storage, on a named StorageClass        Bound on standard-rwo
+==> the ReadWriteOnce claim keeps its two readers together
+==> a plan against real state               plan with N steps
+==> execute it                              run Succeeded
+==> the drain was recorded as awaiting reclamation
+==> GKE's own cluster autoscaler removes it
+      observed as reclaimed after 11m — by a reclaimer we did not write
+```
+
+**Send me the output either way.** If it fails I would rather see the real
+message than guess.
+
+---
+
+## If something goes wrong
+
+**Check nothing is left running.** This is the only step that costs money if
+skipped:
+
+```bash
+gcloud container clusters list      # should be empty
+make cloud-e2e-clean                # if it is not
+```
+
+### Failures I would expect first
+
+**`PREEMPTIBLE_CPUS` quota exceeded.** New projects often start at zero. Either
+request an increase at
+<https://console.cloud.google.com/iam-admin/quotas>, or run smaller:
+
+```bash
+AGENTS=2 GCP_MACHINE=e2-small make cloud-e2e
+```
+
+**The node is never reclaimed, and it times out after 15 minutes.** Most likely
+a `kube-system` pod with no PodDisruptionBudget is pinned to that node, and the
+autoscaler is correctly refusing to remove it. The failure output lists the pods
+still on the node so you can see which. This is a limitation of the test setup,
+not of the product.
+
+**`Spot` capacity unavailable in the zone.** Try another:
+
+```bash
+GCP_ZONE=us-east1-b make cloud-e2e
+```
+
+### Cleaning up entirely
+
+When you are finished with the whole experiment:
+
+```bash
+gcloud projects delete YOUR_PROJECT_ID
+```
+
+Deleting the project is the only way to be certain nothing is left behind
+anywhere in it.
+
+---
+
+[← Documentation index](README.md) · [Project README](../README.md)

--- a/internal/api/rest/rest.go
+++ b/internal/api/rest/rest.go
@@ -49,6 +49,17 @@ type Server struct {
 	// as a knob because the right threshold depends on the operator's machine
 	// as much as on the cluster.
 	graphOpts graph.Options
+
+	// clusterLabel is what the UI shows in its header so an operator can see
+	// which cluster they are about to act on. Operator-set; empty means the
+	// header shows nothing rather than a guess.
+	clusterLabel string
+}
+
+// WithClusterLabel sets the human name shown in the UI header.
+func (s *Server) WithClusterLabel(label string) *Server {
+	s.clusterLabel = label
+	return s
 }
 
 // WithGraphPodDetailLimit overrides the pod count above which the graph
@@ -146,6 +157,26 @@ func (s *Server) handleVersion(w http.ResponseWriter, r *http.Request) {
 		resp["latestPlanId"] = latest.Plan.ID
 		resp["planGeneratedAt"] = latest.Plan.GeneratedAt
 	}
+
+	// Who is asking, and which cluster they are looking at.
+	//
+	// Carried on this response rather than a new route: it is already
+	// authenticated and already fetched on load, and a new endpoint would be
+	// two more things to guard for data the client needs on every page anyway.
+	//
+	// The UI showed neither before, which for a tool that evicts pods is a
+	// safety gap rather than a cosmetic one — "am I about to drain production?"
+	// had no answer on screen.
+	if id, ok := auth.IdentityFrom(r.Context()); ok {
+		resp["identity"] = id.Username
+	}
+	// Empty unless an operator set it. Nothing in a cluster reliably names
+	// itself, and a guessed environment label is worse than none: the whole
+	// value of this field is being trusted when it says "prod".
+	if s.clusterLabel != "" {
+		resp["clusterLabel"] = s.clusterLabel
+	}
+
 	writeJSON(w, http.StatusOK, resp)
 }
 

--- a/ui/nginx.conf
+++ b/ui/nginx.conf
@@ -34,7 +34,19 @@ server {
         try_files $uri =404;
     }
 
+    # The entry HTML must revalidate on every load.
+    #
+    # Without this it carries no Cache-Control at all, so browsers fall back to
+    # heuristic caching off Last-Modified and can serve a stale index.html for
+    # hours. Because that document is what names the hashed asset files, a
+    # stale copy pins the whole app to the previous release — a deploy lands,
+    # the pod serves new bundles, and the operator's browser keeps rendering
+    # the old one with no indication anything happened.
+    #
+    # no-cache permits caching but forces revalidation, so the common case is
+    # still a cheap 304 rather than a re-download.
     location / {
+        add_header Cache-Control "no-cache" always;
         try_files $uri $uri/ /index.html;
     }
 }

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { api, Impact, PlanStep } from "./api";
+import { api, Impact, PlanStep, VersionResponse } from "./api";
 import Inspector, { Selection } from "./components/Inspector";
 import PackingField from "./components/PackingField";
 import { ConfirmRun, RunTrail } from "./components/RunPanel";
@@ -7,6 +7,7 @@ import Scrubber from "./components/Scrubber";
 import { SignIn } from "./components/SignIn";
 import StepLedger from "./components/StepLedger";
 import Verdict from "./components/Verdict";
+import AppBar from "./components/AppBar";
 import { authInfo, token as tokenStore } from "./auth";
 import { onRenewed } from "./oidc";
 import { runtimeConfig } from "./runtime-config";
@@ -29,6 +30,41 @@ export default function App() {
   // rather than pushed: it changes on the planner's resync, which is tens of
   // seconds, and it is never the reason someone is watching the screen.
   const [reclaimed, setReclaimed] = useState({ awaiting: 0, reclaimed: 0 });
+
+  // Identity and cluster, for the header. Fetched once — neither changes
+  // within a session, and re-polling them would be noise.
+  const [server, setServer] = useState<VersionResponse | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .version()
+      .then((v) => {
+        if (!cancelled) setServer(v);
+      })
+      .catch(() => {
+        // The header simply shows less. Failing to learn the cluster name is
+        // not a reason to withhold the plan.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Sign out clears the credential this tab is carrying, and asks the OIDC
+  // provider to forget the session too when there is one. Without the second
+  // half, "sign out" would silently re-authenticate on the next page load.
+  const handleSignOut = useCallback(async () => {
+    try {
+      const info = await authInfo();
+      if (info.oidc.enabled) {
+        const { signOut } = await import("./oidc");
+        await signOut(info);
+      }
+    } catch {
+      // Clearing the local token is the part that must happen regardless.
+    }
+    tokenStore.clear();
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -160,12 +196,23 @@ export default function App() {
 
   return (
     <div className="shell">
+      <AppBar
+        clusterLabel={server?.clusterLabel}
+        identity={server?.identity}
+        onSignOut={handleSignOut}
+      />
       {state.status === "loading" && <Placeholder title="Reading the cluster…" />}
 
       {state.status === "empty" && (
         <Placeholder
           title="No plan yet"
-          detail="The planner publishes one once it has read the cluster. This takes a few seconds after install."
+          detail="The planner publishes one once it has read the cluster."
+          /* The cause an operator hits and cannot otherwise guess: the planner
+             refuses to touch a node younger than minNodeAge, ten minutes by
+             default, so a freshly built cluster shows nothing and looks
+             broken. Naming it here is the difference between waiting and
+             filing a bug. */
+          hint="On a cluster built in the last few minutes this is expected — the planner will not consider a node younger than 10 minutes."
         />
       )}
 
@@ -234,6 +281,8 @@ export default function App() {
                 onToggle={toggleStep}
               />
               <Inspector
+                onSelectPod={(key) => setSelection({ kind: "pod", key })}
+                onSelectNode={(name) => setSelection({ kind: "node", name })}
                 planId={planId ?? ""}
                 graph={state.graph}
                 steps={steps}
@@ -278,19 +327,31 @@ export default function App() {
   );
 }
 
+/**
+ * An empty screen is an invitation to act, and an error is a thing to fix.
+ *
+ * Both used to be a heading and a sentence. Neither said what to do next, in a
+ * product where "no plan yet" almost always has a cause the operator can
+ * either fix or wait out — if someone tells them which.
+ */
 function Placeholder({
   title,
   detail,
+  hint,
   tone = "muted",
 }: {
   title: string;
   detail?: string;
+  /** The cause, or the next action. Quieter than detail, and often the only
+   *  part that actually helps. */
+  hint?: string;
   tone?: "muted" | "error";
 }) {
   return (
     <div className={`placeholder placeholder-${tone}`}>
       <h2>{title}</h2>
       {detail && <p>{detail}</p>}
+      {hint && <p className="placeholder-hint">{hint}</p>}
     </div>
   );
 }

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -279,7 +279,26 @@ export interface ReclamationsResponse {
   };
 }
 
+/**
+ * Who the API server says you are, and which cluster you are looking at.
+ *
+ * identity is what TokenReview verified — not a claim this page decoded from a
+ * token it happens to be holding. clusterLabel is operator-set and absent
+ * unless someone configured it, because a guessed environment name is worse
+ * than none.
+ */
+export interface VersionResponse {
+  version: string;
+  readOnly: boolean;
+  latestPlanId?: string;
+  planGeneratedAt?: string;
+  identity?: string;
+  clusterLabel?: string;
+}
+
 export const api = {
+  version: (signal?: AbortSignal) => get<VersionResponse>("/api/v1/version", signal),
+
   latestPlan: (signal?: AbortSignal) => get<PlanResponse>("/api/v1/plans/latest", signal),
 
   reclamations: (signal?: AbortSignal) =>

--- a/ui/src/components/AppBar.tsx
+++ b/ui/src/components/AppBar.tsx
@@ -1,0 +1,63 @@
+/**
+ * The frame around the instrument.
+ *
+ * It exists because of a gap that looked cosmetic and is not: before this, the
+ * UI showed neither who you were signed in as nor which cluster you were
+ * looking at. For a tool whose entire pitch is that a human approves before
+ * pods are evicted, the human was absent from the screen — and so was the
+ * answer to "am I about to drain production?"
+ *
+ * Every console an SRE actually trusts puts account and environment in the top
+ * bar, for exactly that reason.
+ *
+ * Deliberately quiet: a hairline, no fill, no colour. Colour on this surface
+ * means risk, and a header competing for that signal would undo the thing that
+ * makes a Green/Yellow/Red rating land.
+ */
+
+interface Props {
+  /** Operator-set. Empty renders nothing rather than a guess. */
+  clusterLabel?: string;
+  /** The identity the API server verified, not one the browser asserted. */
+  identity?: string;
+  onSignOut?: () => void;
+}
+
+export default function AppBar({ clusterLabel, identity, onSignOut }: Props) {
+  return (
+    <header className="appbar">
+      <div className="appbar-brand">
+        <span className="appbar-mark">k8s-dencer</span>
+        {clusterLabel && (
+          <>
+            <span className="appbar-sep" aria-hidden="true" />
+            {/* Not a status dot. It is a neutral marker for "this is the
+                cluster", and it stays achromatic so it cannot be read as a
+                health signal. */}
+            <span className="appbar-cluster mono" title="The cluster this view is showing">
+              <span className="appbar-cluster-dot" aria-hidden="true" />
+              {clusterLabel}
+            </span>
+          </>
+        )}
+      </div>
+
+      <div className="appbar-actions">
+        {identity && (
+          /* The full RBAC principal, which for a ServiceAccount is long and
+             gets truncated. The title carries the whole thing, because the
+             part that gets cut is often the part that distinguishes two
+             accounts. */
+          <span className="appbar-identity mono" title={identity}>
+            {identity}
+          </span>
+        )}
+        {onSignOut && (
+          <button type="button" className="appbar-signout" onClick={onSignOut}>
+            Sign out
+          </button>
+        )}
+      </div>
+    </header>
+  );
+}

--- a/ui/src/components/Inspector.tsx
+++ b/ui/src/components/Inspector.tsx
@@ -14,6 +14,8 @@ interface Props {
   selection: Selection;
   onClose: () => void;
   onSelectStep: (seq: number) => void;
+  onSelectPod: (key: string) => void;
+  onSelectNode: (name: string) => void;
 }
 
 /**
@@ -31,8 +33,20 @@ export default function Inspector({
   selection,
   onClose,
   onSelectStep,
+  onSelectPod,
+  onSelectNode,
 }: Props) {
   if (!selection) return null;
+
+  // Where a pod lives, so a pod opened from a node offers a way back up. The
+  // graph carries it as the parent; in density mode there are no pod elements
+  // and the answer is simply unavailable, which is why this is optional.
+  const parentNode =
+    selection.kind === "pod"
+      ? graph.elements
+          .find((e) => e.data.kind === "pod" && `${e.data.namespace}/${e.data.label}` === selection.key)
+          ?.data.parent?.replace(/^node:/, "")
+      : undefined;
 
   return (
     <section className="inspector" aria-label="Constraint inspector">
@@ -42,11 +56,30 @@ export default function Inspector({
           ✕
         </button>
       </header>
-      {selection.kind === "pod" ? (
-        <PodPanel planId={planId} podKey={selection.key} />
-      ) : (
-        <NodePanel graph={graph} steps={steps} name={selection.name} onSelectStep={onSelectStep} />
+
+      {/* Drilling down without a way back is a trapdoor. */}
+      {parentNode && (
+        <button type="button" className="inspector-up mono" onClick={() => onSelectNode(parentNode)}>
+          ← {parentNode}
+        </button>
       )}
+
+      {/* Keyed so React remounts on every change: the panel animates in, and
+          without a key the content would swap silently inside a box that never
+          moved, which reads as nothing having happened. */}
+      <div className="inspector-swap" key={selection.kind === "pod" ? selection.key : selection.name}>
+        {selection.kind === "pod" ? (
+          <PodPanel planId={planId} podKey={selection.key} />
+        ) : (
+          <NodePanel
+            graph={graph}
+            steps={steps}
+            name={selection.name}
+            onSelectStep={onSelectStep}
+            onSelectPod={onSelectPod}
+          />
+        )}
+      </div>
     </section>
   );
 }
@@ -127,11 +160,13 @@ function NodePanel({
   steps,
   name,
   onSelectStep,
+  onSelectPod,
 }: {
   graph: GraphPayload;
   steps: PlanStep[];
   name: string;
   onSelectStep: (seq: number) => void;
+  onSelectPod: (key: string) => void;
 }) {
   const node = graph.elements.find((e) => e.data.kind === "node" && e.data.label === name)?.data;
   const pods = graph.elements.filter(
@@ -140,6 +175,13 @@ function NodePanel({
   const drainStep = node?.drainStep ?? 0;
   const step = steps.find((s) => s.sequenceNumber === drainStep);
   const blocked = pods.filter((p) => p.data.blocked);
+
+  // Above the graph endpoint's detail limit there are no pod elements at all,
+  // so counting them would report every node as empty — a node holding 40 pods
+  // rendering as "0 pods" reads as a successful drain rather than a missing
+  // payload. The server sends the tallies for exactly this case.
+  const podCount = graph.aggregated ? (node?.podCount ?? 0) : pods.length;
+  const blockedCount = graph.aggregated ? (node?.blockedCount ?? 0) : blocked.length;
 
   if (!node) return <div className="inspector-body muted">Node not found in this plan.</div>;
 
@@ -162,8 +204,52 @@ function NodePanel({
           {formatBytes(node.memRequested ?? 0)} / {formatBytes(node.memAllocatable ?? 0)}
         </dd>
         <dt>Pods</dt>
-        <dd>{pods.length}</dd>
+        <dd>{podCount}</dd>
       </dl>
+
+      {/* The list, not just the count. Without it a node is a dead end: you can
+          see that four pods are here and have no way to ask about any of them,
+          which is the question the count immediately provokes. */}
+      {pods.length > 0 && (
+        <div className="podlist">
+          <h3 className="eyebrow podlist-head">Pods on this node</h3>
+          <ul className="podlist-items">
+            {pods.map((p, i) => {
+              const key = `${p.data.namespace}/${p.data.label}`;
+              return (
+                <li key={key}>
+                  <button
+                    type="button"
+                    className="podlist-row"
+                    /* Staggered so the list assembles rather than appearing,
+                       which makes it read as a consequence of the click. */
+                    style={{ "--i": i } as React.CSSProperties}
+                    onClick={() => onSelectPod(key)}
+                  >
+                    <span className="podlist-name mono">{p.data.label}</span>
+                    <span className="podlist-ns mono">{p.data.namespace}</span>
+                    {p.data.blocked ? (
+                      <span className="podlist-flag podlist-flag-blocked mono">■ blocked</span>
+                    ) : p.data.movable === false ? (
+                      <span className="podlist-flag mono">pinned</span>
+                    ) : (
+                      <span className="podlist-flag podlist-flag-ok mono">movable</span>
+                    )}
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      )}
+
+      {graph.aggregated && podCount > 0 && (
+        <p className="podlist-elided">
+          {podCount} pods on this node. Individual pods are not listed above the
+          graph endpoint&rsquo;s detail limit — at that size the payload would be
+          tens of megabytes.
+        </p>
+      )}
 
       {drainStep > 0 && step ? (
         <div className="inspector-callout">
@@ -182,8 +268,8 @@ function NodePanel({
             <span>Not drained by this plan</span>
           </div>
           <p className="constraint-text">
-            {blocked.length > 0
-              ? `${blocked.length} pod(s) here cannot be evicted, so the node cannot be emptied. Select a pod to see why.`
+            {blockedCount > 0
+              ? `${blockedCount} pod(s) here cannot be evicted, so the node cannot be emptied. Select one above to see why.`
               : "This node is either a destination for other pods, excluded by policy, or already reclaimable."}
           </p>
         </div>

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -7,9 +7,110 @@
 
 .shell {
   display: grid;
-  grid-template-rows: auto 1fr auto auto;
+  grid-template-rows: auto auto 1fr auto auto;
   height: 100%;
   background: var(--ink);
+}
+
+/* ------------------------------------------------------------- app bar
+
+   Context, always visible. Quiet by construction: one hairline, no fill, no
+   colour — colour on this surface means risk, and a header that competed for
+   that signal would undo the thing that makes a rating land. */
+
+.appbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+  padding: var(--space-3) var(--space-6);
+  border-bottom: 1px solid var(--border-strong);
+  background: var(--surface-1);
+  min-height: 52px;
+}
+
+.appbar-brand,
+.appbar-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  min-width: 0;
+}
+
+.appbar-mark {
+  font-family: var(--font-display);
+  font-size: var(--text-lg);
+  font-weight: 700;
+  letter-spacing: var(--tracking-display);
+  color: var(--chalk);
+}
+
+.appbar-sep {
+  width: 1px;
+  height: 16px;
+  background: var(--border-strong);
+}
+
+.appbar-cluster {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-1) var(--space-3);
+  border: 1px solid var(--border-strong);
+  border-radius: 999px;
+  background: var(--surface-2);
+  font-size: var(--text-xs);
+  color: var(--chalk);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Achromatic on purpose. A coloured dot here would read as a health status,
+   and this is an identifier, not a judgement. */
+.appbar-cluster-dot {
+  width: 6px;
+  height: 6px;
+  flex: none;
+  border-radius: 50%;
+  background: var(--fill-75);
+}
+
+.appbar-identity {
+  font-size: var(--text-xs);
+  color: var(--graphite);
+  max-width: 26ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.appbar-signout {
+  padding: var(--space-1) var(--space-3);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--graphite);
+  font-size: var(--text-xs);
+  transition: color var(--step-fast) var(--ease-out),
+    border-color var(--step-fast) var(--ease-out);
+}
+
+.appbar-signout:hover {
+  color: var(--chalk);
+  border-color: var(--border-strong);
+}
+
+/* Below this the identity is the first thing worth dropping: the cluster is
+   what stops you draining the wrong thing. */
+@media (max-width: 640px) {
+  .appbar {
+    padding-inline: var(--space-4);
+  }
+  .appbar-identity {
+    display: none;
+  }
 }
 
 /* ------------------------------------------------------------- verdict */
@@ -17,16 +118,16 @@
 .verdict {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto auto;
-  gap: 2.5rem;
+  gap: var(--space-8);
   align-items: center;
-  padding: 1.4rem 1.75rem;
+  padding: var(--space-6) var(--space-6);
   background: var(--panel);
   border-bottom: 1px solid var(--edge);
 }
 
 .verdict-eyebrow {
   margin: 0 0 0.35rem;
-  font-size: 0.68rem;
+  font-size: var(--text-2xs);
   letter-spacing: 0.16em;
   text-transform: uppercase;
   color: var(--graphite-dim);
@@ -37,7 +138,7 @@
 .verdict-line {
   margin: 0;
   font-family: var(--font-display);
-  font-size: clamp(1.5rem, 2.6vw, 2.1rem);
+  font-size: clamp(var(--text-xl), 2.6vw, var(--text-2xl));
   font-weight: 700;
   letter-spacing: -0.035em;
   line-height: 1.05;
@@ -53,12 +154,12 @@
   margin: 0.5rem 0 0;
   max-width: 46ch;
   color: var(--graphite);
-  font-size: 0.85rem;
+  font-size: var(--text-md);
 }
 
 .verdict-breakdown {
   display: flex;
-  gap: 0.5rem;
+  gap: var(--space-2);
 }
 
 .tally {
@@ -68,8 +169,8 @@
     "glyph count"
     "word  word"
     "cap   cap";
-  gap: 0 0.4rem;
-  padding: 0.6rem 0.8rem;
+  gap: 0 var(--space-2);
+  padding: var(--space-3) var(--space-3);
   text-align: left;
   background: transparent;
   border: 1px solid var(--edge);
@@ -95,13 +196,13 @@
 .tally-glyph {
   grid-area: glyph;
   align-self: center;
-  font-size: 0.8rem;
+  font-size: var(--text-sm);
   line-height: 1;
 }
 
 .tally-count {
   grid-area: count;
-  font-size: 1.35rem;
+  font-size: var(--text-xl);
   font-weight: 600;
   line-height: 1;
   color: var(--chalk);
@@ -110,13 +211,13 @@
 .tally-word {
   grid-area: word;
   margin-top: 0.25rem;
-  font-size: 0.72rem;
+  font-size: var(--text-xs);
   font-weight: 600;
 }
 
 .tally-caption {
   grid-area: cap;
-  font-size: 0.68rem;
+  font-size: var(--text-2xs);
   color: var(--graphite-dim);
   white-space: nowrap;
 }
@@ -137,14 +238,14 @@
 
 .verdict-actions {
   display: grid;
-  gap: 0.4rem;
+  gap: var(--space-2);
   justify-items: stretch;
 }
 
 .btn {
-  padding: 0.5rem 0.9rem;
+  padding: var(--space-2) var(--space-4);
   font-family: var(--font-body);
-  font-size: 0.82rem;
+  font-size: var(--text-sm);
   color: var(--chalk);
   background: transparent;
   border: 1px solid var(--edge);
@@ -170,13 +271,13 @@
 
 .btn-icon {
   width: 2.1rem;
-  padding: 0.4rem 0;
+  padding: var(--space-2) 0;
   text-align: center;
 }
 
 .verdict-note {
   margin: 0;
-  font-size: 0.68rem;
+  font-size: var(--text-2xs);
   color: var(--graphite-dim);
   text-align: center;
 }
@@ -200,7 +301,7 @@
 .field-scroll {
   position: relative;
   overflow: auto;
-  padding: 1.5rem;
+  padding: var(--space-6);
   background:
     radial-gradient(circle at 1px 1px, var(--edge-soft) 1px, transparent 0) 0 0 / 28px 28px,
     var(--ink);
@@ -253,12 +354,28 @@
   border-color: var(--chalk);
 }
 
+/* These carry role="button" and a tabindex and have done since M11, but had
+   neither a pointer nor a hover state — so nothing on screen said a node could
+   be opened. The drill-down was undiscoverable for want of a cursor. */
+.box {
+  cursor: pointer;
+}
+
+.box:hover {
+  border-color: var(--border-strong);
+  background: var(--surface-2);
+}
+
+.box:hover .box-name {
+  color: var(--chalk);
+}
+
 .box-head {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-  padding: 0.25rem 0.4rem 0;
-  font-size: 0.66rem;
+  padding: var(--space-1) var(--space-2) 0;
+  font-size: var(--text-2xs);
 }
 
 .box-name {
@@ -360,29 +477,29 @@
 
 .tray {
   display: flex;
-  gap: 0.55rem;
+  gap: var(--space-2);
   align-items: baseline;
-  padding: 0.6rem 1.5rem;
+  padding: var(--space-3) var(--space-6);
   background: var(--panel-sunken);
   border-top: 1px solid var(--edge);
 }
 
 .tray-label {
-  font-size: 0.68rem;
+  font-size: var(--text-2xs);
   letter-spacing: 0.14em;
   text-transform: uppercase;
   color: var(--graphite-dim);
 }
 
 .tray-count {
-  font-size: 1.5rem;
+  font-size: var(--text-xl);
   font-weight: 600;
   line-height: 1;
   color: var(--chalk);
 }
 
 .tray-of {
-  font-size: 0.72rem;
+  font-size: var(--text-xs);
   color: var(--graphite-dim);
 }
 
@@ -418,7 +535,7 @@
 
 .panel-title {
   margin: 0;
-  font-size: 0.68rem;
+  font-size: var(--text-2xs);
   font-weight: 500;
   letter-spacing: 0.16em;
   text-transform: uppercase;
@@ -436,12 +553,12 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0.85rem 1rem 0.5rem;
+  padding: var(--space-3) var(--space-4) var(--space-2);
 }
 
 .ledger-clear {
-  padding: 0.1rem 0.4rem;
-  font-size: 0.66rem;
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--text-2xs);
   color: var(--graphite);
   background: transparent;
   border: 1px solid var(--edge);
@@ -450,7 +567,7 @@
 
 .ledger-list {
   margin: 0;
-  padding: 0 0 0.6rem;
+  padding: 0 0 var(--space-3);
   overflow-y: auto;
   list-style: none;
 }
@@ -458,10 +575,10 @@
 .row {
   display: grid;
   grid-template-columns: 1.6rem 0.9rem minmax(0, 1fr) 1.6rem auto;
-  gap: 0.5rem;
+  gap: var(--space-2);
   align-items: baseline;
   width: 100%;
-  padding: 0.34rem 1rem;
+  padding: var(--space-1) var(--space-4);
   text-align: left;
   background: transparent;
   border: 0;
@@ -483,31 +600,31 @@
 }
 
 .row-seq {
-  font-size: 0.7rem;
+  font-size: var(--text-2xs);
   color: var(--graphite-dim);
 }
 
 .row-glyph {
-  font-size: 0.7rem;
+  font-size: var(--text-2xs);
   line-height: 1;
 }
 
 .row-node {
   overflow: hidden;
-  font-size: 0.74rem;
+  font-size: var(--text-xs);
   color: var(--chalk);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .row-moves {
-  font-size: 0.7rem;
+  font-size: var(--text-2xs);
   color: var(--graphite-dim);
   text-align: right;
 }
 
 .row-rating {
-  font-size: 0.66rem;
+  font-size: var(--text-2xs);
   font-weight: 600;
 }
 
@@ -528,14 +645,14 @@
 .row-why {
   margin: 0 1rem 0.6rem 3rem;
   color: var(--graphite);
-  font-size: 0.76rem;
+  font-size: var(--text-xs);
   line-height: 1.5;
 }
 
 .ledger-empty {
-  padding: 0 1rem 1rem;
+  padding: 0 var(--space-4) var(--space-4);
   color: var(--graphite-dim);
-  font-size: 0.76rem;
+  font-size: var(--text-xs);
 }
 
 /* -------------------------------------------------------------- scrubber */
@@ -543,9 +660,9 @@
 .scrub {
   display: grid;
   grid-template-columns: auto minmax(0, 1fr) auto;
-  gap: 1rem;
+  gap: var(--space-4);
   align-items: center;
-  padding: 0.7rem 1.75rem;
+  padding: var(--space-3) var(--space-6);
   background: var(--panel);
   border-top: 1px solid var(--edge);
 }
@@ -621,14 +738,14 @@
 
 .scrub-read {
   display: flex;
-  gap: 0.35rem;
+  gap: var(--space-2);
   align-items: baseline;
   margin: 0;
-  font-size: 0.72rem;
+  font-size: var(--text-xs);
 }
 
 .scrub-now {
-  font-size: 1rem;
+  font-size: var(--text-lg);
   font-weight: 600;
   color: var(--chalk);
 }
@@ -647,10 +764,10 @@
 
 .statusbar {
   display: flex;
-  gap: 1.25rem;
+  gap: var(--space-6);
   align-items: center;
-  padding: 0.4rem 1.75rem;
-  font-size: 0.66rem;
+  padding: var(--space-2) var(--space-6);
+  font-size: var(--text-2xs);
   color: var(--graphite-dim);
   background: var(--panel-sunken);
   border-top: 1px solid var(--edge);
@@ -671,16 +788,31 @@
 .placeholder {
   display: grid;
   place-content: center;
-  gap: 0.5rem;
+  justify-items: center;
+  max-width: 52ch;
+  margin-inline: auto;
+  gap: var(--space-2);
   grid-row: 1 / -1;
-  padding: 3rem;
+  padding: var(--space-8);
   text-align: center;
+}
+
+/* Quieter than the detail above it, and monospaced where it carries a command
+   or a threshold — those are values to read exactly, not prose. */
+.placeholder-hint {
+  padding: var(--space-3) var(--space-4);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface-1);
+  color: var(--graphite);
+  font-size: var(--text-sm);
+  text-align: left;
 }
 
 .placeholder h2 {
   margin: 0;
   font-family: var(--font-display);
-  font-size: 1.05rem;
+  font-size: var(--text-lg);
   font-weight: 650;
   letter-spacing: -0.02em;
 }
@@ -689,7 +821,7 @@
   margin: 0;
   max-width: 34rem;
   color: var(--graphite);
-  font-size: 0.85rem;
+  font-size: var(--text-md);
   /* A 403 carries the kubectl command that grants the permission; collapsing
      it onto one line would make it unreadable and un-copyable. */
   white-space: pre-line;
@@ -706,7 +838,7 @@
   align-self: center;
   justify-self: center;
   width: min(30rem, calc(100vw - 3rem));
-  padding: 1.75rem;
+  padding: var(--space-6);
   background: var(--panel);
   border: 1px solid var(--edge);
   border-radius: var(--radius);
@@ -715,7 +847,7 @@
 .signin h2 {
   margin: 0 0 0.65rem;
   font-family: var(--font-display);
-  font-size: 1.05rem;
+  font-size: var(--text-lg);
   font-weight: 650;
   letter-spacing: -0.02em;
 }
@@ -723,27 +855,27 @@
 .signin-detail {
   margin: 0 0 0.9rem;
   color: var(--graphite);
-  font-size: 0.82rem;
+  font-size: var(--text-sm);
   line-height: 1.55;
 }
 
 .signin form {
   display: grid;
-  gap: 0.4rem;
+  gap: var(--space-2);
 }
 
 .signin label {
   font-family: var(--font-mono);
-  font-size: 0.7rem;
+  font-size: var(--text-2xs);
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: var(--graphite-dim);
 }
 
 .signin input {
-  padding: 0.55rem 0.65rem;
+  padding: var(--space-2) var(--space-3);
   font-family: var(--font-mono);
-  font-size: 0.8rem;
+  font-size: var(--text-sm);
   color: var(--chalk);
   background: var(--panel-sunken);
   border: 1px solid var(--edge);
@@ -753,8 +885,8 @@
 .signin button {
   justify-self: start;
   margin-top: 0.35rem;
-  padding: 0.5rem 1.1rem;
-  font-size: 0.82rem;
+  padding: var(--space-2) var(--space-4);
+  font-size: var(--text-sm);
   font-weight: 600;
   color: var(--ink);
   background: var(--chalk);
@@ -769,7 +901,7 @@
 
 .signin-help {
   margin-top: 1.1rem;
-  font-size: 0.8rem;
+  font-size: var(--text-sm);
   color: var(--graphite);
 }
 
@@ -780,10 +912,10 @@
 
 .signin-help pre {
   margin: 0.6rem 0;
-  padding: 0.55rem 0.65rem;
+  padding: var(--space-2) var(--space-3);
   overflow-x: auto;
   font-family: var(--font-mono);
-  font-size: 0.76rem;
+  font-size: var(--text-xs);
   background: var(--panel-sunken);
   border-radius: var(--radius-sm);
 }
@@ -798,7 +930,7 @@
 @media (max-width: 1100px) {
   .verdict {
     grid-template-columns: 1fr;
-    gap: 1rem;
+    gap: var(--space-4);
   }
   .verdict-breakdown {
     flex-wrap: wrap;
@@ -820,7 +952,7 @@
   .verdict,
   .scrub,
   .statusbar {
-    padding-inline: 1rem;
+    padding-inline: var(--space-4);
   }
   .scrub-label {
     display: none;
@@ -835,7 +967,7 @@
   z-index: 20;
   display: grid;
   place-items: center;
-  padding: 1.5rem;
+  padding: var(--space-6);
   background: rgba(0, 0, 0, 0.6);
   animation: fade-in var(--step-fast) linear;
 }
@@ -848,7 +980,7 @@
 
 .sheet {
   width: min(30rem, 100%);
-  padding: 1.5rem;
+  padding: var(--space-6);
   background: var(--panel);
   border: 1px solid var(--edge);
   border-radius: var(--radius);
@@ -857,7 +989,7 @@
 .sheet-title {
   margin: 0 0 0.6rem;
   font-family: var(--font-display);
-  font-size: 1.15rem;
+  font-size: var(--text-xl);
   font-weight: 700;
   letter-spacing: -0.03em;
 }
@@ -865,7 +997,7 @@
 .sheet-detail {
   margin: 0 0 0.9rem;
   color: var(--graphite);
-  font-size: 0.83rem;
+  font-size: var(--text-sm);
   line-height: 1.55;
 }
 
@@ -876,9 +1008,9 @@
 .sheet-list {
   max-height: 9rem;
   margin: 0 0 1.1rem;
-  padding: 0.5rem 0.7rem;
+  padding: var(--space-2) var(--space-3);
   overflow-y: auto;
-  font-size: 0.76rem;
+  font-size: var(--text-xs);
   color: var(--graphite);
   list-style: none;
   background: var(--panel-sunken);
@@ -887,14 +1019,14 @@
 
 .sheet-actions {
   display: flex;
-  gap: 0.5rem;
+  gap: var(--space-2);
   justify-content: flex-end;
 }
 
 /* ------------------------------------------------------------ run trail */
 
 .trail {
-  padding: 0.7rem 1.75rem 0.85rem;
+  padding: var(--space-3) var(--space-6) var(--space-3);
   background: var(--panel-raised);
   border-bottom: 1px solid var(--edge);
 }
@@ -914,23 +1046,23 @@
 
 .trail-head {
   display: flex;
-  gap: 0.7rem;
+  gap: var(--space-3);
   align-items: baseline;
 }
 
 .trail-status {
   font-weight: 600;
-  font-size: 0.85rem;
+  font-size: var(--text-md);
 }
 
 .trail-meta {
-  font-size: 0.7rem;
+  font-size: var(--text-2xs);
   color: var(--graphite-dim);
 }
 
 .trail-close {
   margin-left: auto;
-  padding: 0 0.3rem;
+  padding: 0 var(--space-1);
   color: var(--graphite);
   background: transparent;
   border: 0;
@@ -947,9 +1079,9 @@
 .trail-row {
   display: grid;
   grid-template-columns: 5rem 12rem minmax(0, 1fr) auto;
-  gap: 0.6rem;
-  padding: 0.12rem 0;
-  font-size: 0.72rem;
+  gap: var(--space-3);
+  padding: var(--space-1) 0;
+  font-size: var(--text-xs);
   color: var(--graphite);
 }
 
@@ -972,31 +1104,31 @@
 }
 
 .trail-rule {
-  font-size: 0.68rem;
-  padding: 0 0.3rem;
+  font-size: var(--text-2xs);
+  padding: 0 var(--space-1);
   border: 1px solid currentColor;
   border-radius: var(--radius-sm);
 }
 
 .trail-summary {
   margin: 0.5rem 0 0;
-  font-size: 0.78rem;
+  font-size: var(--text-sm);
   color: var(--chalk);
 }
 
 .trail-note {
   margin: 0.35rem 0 0;
   max-width: 70ch;
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
   color: var(--graphite);
 }
 
 .trail-grant {
   margin: 0.5rem 0 0;
-  padding: 0.45rem 0.6rem;
+  padding: var(--space-2) var(--space-3);
   overflow-x: auto;
   font-family: var(--font-mono);
-  font-size: 0.72rem;
+  font-size: var(--text-xs);
   background: var(--panel-sunken);
   border-radius: var(--radius-sm);
 }
@@ -1011,7 +1143,7 @@
 }
 
 .tray-hint {
-  font-size: 0.7rem;
+  font-size: var(--text-2xs);
   color: var(--graphite-dim);
 }
 
@@ -1039,7 +1171,7 @@
 .ledger-picked {
   margin-left: auto;
   margin-right: 0.5rem;
-  font-size: 0.66rem;
+  font-size: var(--text-2xs);
   color: var(--chalk);
 }
 
@@ -1050,7 +1182,7 @@
 
 .verdict-clear {
   padding: 0;
-  font-size: 0.68rem;
+  font-size: var(--text-2xs);
   color: var(--graphite);
   text-decoration: underline;
   background: transparent;
@@ -1064,7 +1196,7 @@
   align-self: center;
   justify-self: center;
   width: min(44rem, calc(100vw - 3rem));
-  padding: 1.75rem;
+  padding: var(--space-6);
   background: var(--panel);
   border: 1px solid var(--risk-red);
   border-radius: var(--radius);
@@ -1073,7 +1205,7 @@
 .crash h2 {
   margin: 0 0 0.5rem;
   font-family: var(--font-display);
-  font-size: 1.1rem;
+  font-size: var(--text-lg);
   font-weight: 700;
   letter-spacing: -0.02em;
   color: var(--risk-red);
@@ -1082,17 +1214,17 @@
 .crash-detail {
   margin: 0 0 1rem;
   color: var(--graphite);
-  font-size: 0.83rem;
+  font-size: var(--text-sm);
   line-height: 1.55;
 }
 
 .crash-message,
 .crash-more pre {
   margin: 0;
-  padding: 0.6rem 0.7rem;
+  padding: var(--space-3) var(--space-3);
   overflow-x: auto;
   font-family: var(--font-mono);
-  font-size: 0.76rem;
+  font-size: var(--text-xs);
   white-space: pre-wrap;
   background: var(--panel-sunken);
   border-radius: var(--radius-sm);
@@ -1100,7 +1232,7 @@
 
 .crash-more {
   margin-top: 0.8rem;
-  font-size: 0.78rem;
+  font-size: var(--text-sm);
   color: var(--graphite);
 }
 
@@ -1113,12 +1245,12 @@
 .crash-more pre {
   max-height: 14rem;
   overflow-y: auto;
-  font-size: 0.72rem;
+  font-size: var(--text-xs);
 }
 
 .crash-actions {
   display: flex;
-  gap: 0.5rem;
+  gap: var(--space-2);
   margin-top: 1.1rem;
 }
 
@@ -1126,10 +1258,10 @@
 
 .supersede {
   display: flex;
-  gap: 1rem;
+  gap: var(--space-4);
   align-items: center;
-  padding: 0.55rem 1.75rem;
-  font-size: 0.78rem;
+  padding: var(--space-2) var(--space-6);
+  font-size: var(--text-sm);
   color: var(--graphite);
   background: var(--panel-raised);
   border-bottom: 1px solid var(--edge);
@@ -1139,16 +1271,16 @@
 
 .supersede button {
   margin-left: auto;
-  padding: 0.3rem 0.7rem;
-  font-size: 0.76rem;
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--text-xs);
   white-space: nowrap;
 }
 
 .signin-sso {
   width: 100%;
-  padding: 0.6rem 1rem;
+  padding: var(--space-3) var(--space-4);
   font-family: var(--font-body);
-  font-size: 0.85rem;
+  font-size: var(--text-md);
   font-weight: 600;
   color: var(--ink);
   background: var(--chalk);
@@ -1164,17 +1296,17 @@
 .signin-issuer {
   margin: 0.4rem 0 0;
   overflow-wrap: anywhere;
-  font-size: 0.7rem;
+  font-size: var(--text-2xs);
   color: var(--graphite-dim);
   text-align: center;
 }
 
 .signin-or {
   display: flex;
-  gap: 0.6rem;
+  gap: var(--space-3);
   align-items: center;
   margin: 1.1rem 0 0.7rem;
-  font-size: 0.72rem;
+  font-size: var(--text-xs);
   color: var(--graphite-dim);
 }
 
@@ -1188,8 +1320,8 @@
 
 .signin-failure {
   margin: 0 0 0.9rem;
-  padding: 0.5rem 0.65rem;
-  font-size: 0.78rem;
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--text-sm);
   color: var(--risk-red);
   background: var(--panel-sunken);
   border-left: 2px solid var(--risk-red);
@@ -1215,14 +1347,14 @@
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-  gap: 0.5rem;
-  padding: 0.85rem 1rem 0.5rem;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-4) var(--space-2);
 }
 
 .inspector-title {
   margin: 0;
   font-family: var(--font-mono);
-  font-size: 0.68rem;
+  font-size: var(--text-2xs);
   font-weight: 500;
   letter-spacing: 0.16em;
   text-transform: uppercase;
@@ -1230,7 +1362,7 @@
 }
 
 .inspector-close {
-  padding: 0 0.3rem;
+  padding: 0 var(--space-1);
   color: var(--graphite-dim);
   background: transparent;
   border: 0;
@@ -1245,8 +1377,8 @@
 .inspector-body {
   min-height: 0;
   overflow-y: auto;
-  padding: 0 1rem 1rem;
-  font-size: 0.78rem;
+  padding: 0 var(--space-4) var(--space-4);
+  font-size: var(--text-sm);
 }
 
 .inspector-subhead {
@@ -1254,7 +1386,7 @@
   align-items: baseline;
   justify-content: space-between;
   margin: 0.9rem 0 0.4rem;
-  font-size: 0.7rem;
+  font-size: var(--text-2xs);
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--graphite-dim);
@@ -1269,9 +1401,9 @@
 .facts {
   display: grid;
   grid-template-columns: auto minmax(0, 1fr);
-  gap: 0.2rem 0.75rem;
+  gap: var(--space-1) var(--space-3);
   margin: 0;
-  font-size: 0.76rem;
+  font-size: var(--text-xs);
 }
 
 .facts dt {
@@ -1293,26 +1425,26 @@
 }
 
 .constraint-list > li {
-  padding: 0.45rem 0;
+  padding: var(--space-2) 0;
   border-top: 1px solid var(--edge);
 }
 
 .constraint-head {
   display: flex;
-  gap: 0.4rem;
+  gap: var(--space-2);
   align-items: baseline;
 }
 
 .constraint-kind {
   font-family: var(--font-mono);
-  font-size: 0.72rem;
+  font-size: var(--text-xs);
   color: var(--chalk);
 }
 
 .constraint-subject {
   overflow: hidden;
   font-family: var(--font-mono);
-  font-size: 0.7rem;
+  font-size: var(--text-2xs);
   color: var(--graphite-dim);
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -1327,9 +1459,9 @@
 }
 
 .flag-blocked {
-  padding: 0 0.3rem;
+  padding: 0 var(--space-1);
   font-family: var(--font-mono);
-  font-size: 0.66rem;
+  font-size: var(--text-2xs);
   color: var(--risk-red);
   border: 1px solid var(--risk-red);
   border-radius: var(--radius-sm);
@@ -1337,21 +1469,21 @@
 
 .inspector-callout {
   margin-top: 0.8rem;
-  padding: 0.55rem 0.65rem;
+  padding: var(--space-2) var(--space-3);
   background: var(--panel-sunken);
   border-radius: var(--radius-sm);
 }
 
 .callout-head {
   margin: 0 0 0.25rem;
-  font-size: 0.72rem;
+  font-size: var(--text-xs);
   font-weight: 600;
   color: var(--chalk);
 }
 
 .linkish {
   padding: 0;
-  font-size: 0.74rem;
+  font-size: var(--text-xs);
   color: var(--graphite);
   text-decoration: underline;
   background: transparent;
@@ -1365,13 +1497,13 @@
 .muted {
   margin: 0;
   color: var(--graphite-dim);
-  font-size: 0.78rem;
+  font-size: var(--text-sm);
 }
 
 .error-text {
   margin: 0;
   color: var(--risk-red);
-  font-size: 0.78rem;
+  font-size: var(--text-sm);
 }
 
 /* --------------------------------------------- next move and plan age */
@@ -1419,8 +1551,8 @@
 .ledger-more {
   display: block;
   width: 100%;
-  padding: 0.5rem 1rem 0.9rem;
-  font-size: 0.74rem;
+  padding: var(--space-2) var(--space-4) var(--space-4);
+  font-size: var(--text-xs);
   color: var(--graphite);
   text-align: left;
   background: transparent;
@@ -1444,20 +1576,20 @@
 .box-density {
   display: flex;
   align-items: baseline;
-  gap: 0.28rem;
-  padding: 0.35rem 0.5rem 0;
+  gap: var(--space-1);
+  padding: var(--space-2) var(--space-2) 0;
   flex-wrap: wrap;
 }
 
 .box-density-count {
-  font-size: 1.35rem;
+  font-size: var(--text-xl);
   line-height: 1;
   color: var(--chalk);
   font-variant-numeric: tabular-nums;
 }
 
 .box-density-unit {
-  font-size: 0.62rem;
+  font-size: var(--text-2xs);
   letter-spacing: 0.04em;
   color: var(--muted);
 }
@@ -1466,7 +1598,7 @@
    mark means the same thing here as everywhere else. Never colour alone. */
 .box-density-blocked {
   margin-left: auto;
-  font-size: 0.62rem;
+  font-size: var(--text-2xs);
   color: var(--risk-yellow);
   white-space: nowrap;
 }
@@ -1487,9 +1619,9 @@
 .tray-awaiting {
   display: inline-flex;
   align-items: baseline;
-  gap: 0.2rem;
+  gap: var(--space-1);
   margin-left: 0.75rem;
-  font-size: 0.68rem;
+  font-size: var(--text-2xs);
   color: var(--muted);
 }
 
@@ -1507,4 +1639,134 @@
 
 .tray-awaiting-count {
   font-variant-numeric: tabular-nums;
+}
+
+/* ------------------------------------------------------- drill-down
+
+   A node used to be a dead end: it reported "4 pods" and gave you no way to
+   ask about any of them. The list below is the missing step between the field
+   and the constraint analyser. */
+
+/* Panel content is keyed on the selection, so this plays on every drill —
+   short, and downward, because the gesture is going deeper. */
+.inspector-swap {
+  animation: drill-in var(--step-base) var(--ease-out) both;
+}
+
+@keyframes drill-in {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+}
+
+.inspector-up {
+  align-self: flex-start;
+  margin: 0 var(--space-4);
+  padding: var(--space-1) var(--space-2);
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--graphite);
+  font-size: var(--text-xs);
+  transition: color var(--step-fast) var(--ease-out);
+}
+
+.inspector-up:hover {
+  color: var(--chalk);
+}
+
+.podlist {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin-top: var(--space-4);
+}
+
+.podlist-head {
+  margin: 0;
+}
+
+.podlist-items {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.podlist-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  grid-template-areas:
+    "name flag"
+    "ns   flag";
+  align-items: center;
+  gap: 0 var(--space-2);
+  width: 100%;
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid transparent;
+  border-radius: var(--radius);
+  background: var(--surface-2);
+  text-align: left;
+  transition: border-color var(--step-fast) var(--ease-out),
+    background var(--step-fast) var(--ease-out);
+  /* Assembles rather than appears: each row is a consequence of the click
+     before it, and the stagger is what makes the list read that way. */
+  animation: row-in var(--step-base) var(--ease-out) both;
+  animation-delay: calc(var(--i, 0) * 22ms);
+}
+
+@keyframes row-in {
+  from {
+    opacity: 0;
+    transform: translateX(-4px);
+  }
+}
+
+.podlist-row:hover {
+  background: var(--surface-3);
+  border-color: var(--border-strong);
+}
+
+.podlist-name {
+  grid-area: name;
+  font-size: var(--text-sm);
+  color: var(--chalk);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.podlist-ns {
+  grid-area: ns;
+  font-size: var(--text-2xs);
+  color: var(--graphite-dim);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Glyph plus word on the blocked flag, never colour alone — the same rule the
+   ratings follow, for the same reason. */
+.podlist-flag {
+  grid-area: flag;
+  font-size: var(--text-2xs);
+  color: var(--graphite-dim);
+  white-space: nowrap;
+}
+
+.podlist-flag-blocked {
+  color: var(--risk-red);
+}
+
+.podlist-flag-ok {
+  color: var(--graphite);
+}
+
+.podlist-elided {
+  margin: var(--space-4) 0 0;
+  color: var(--graphite-dim);
+  font-size: var(--text-xs);
 }

--- a/ui/src/theme.css
+++ b/ui/src/theme.css
@@ -13,23 +13,52 @@
  * Fullness is carried by BRIGHTNESS on a neutral ramp instead. That is not a
  * consolation prize: it means the picture literally gets brighter and smaller
  * as a plan executes, which is the story this product exists to tell.
+ *
+ * Everything below is a token. Nothing in index.css should contain a raw hex,
+ * a bare pixel size or an arbitrary padding: the surface had 21 distinct font
+ * sizes and 32 distinct padding values before this file grew a scale, each of
+ * them sensible alone and improvised together, which is what made a carefully
+ * built instrument read as homemade.
  */
 
 :root {
   color-scheme: dark;
 
-  /* Ground and material. Neutral rather than blue-black, so the fixed green
-     and red below sit on it without a cast. */
-  --ink: #0b0d10;
-  --panel: #14171b;
-  --panel-raised: #1b1f25;
-  --panel-sunken: #08090b;
-  --edge: #262b33;
-  --edge-soft: rgba(233, 236, 239, 0.08);
+  /* ---------------------------------------------------------- surfaces
+     An elevation ladder rather than a set of named slabs. Steps are small —
+     three or four percent of lightness — and most of the separation between
+     panels is carried by a hairline and by space. Heavy contrasting fills are
+     what make a dense tool look like a wireframe of itself.
+
+     True black at the base. On an OLED panel the ground switches off entirely,
+     which makes a single saturated rating the only lit thing in that region of
+     the screen — the strongest possible reading of "colour means risk".
+
+     The raised steps are near-neutral rather than blue-tinted: against pure
+     black a cool cast reads as a colour, and this palette cannot afford a
+     fourth hue. test/palette allows 0.15 chroma on any non-risk token; the
+     highest of these spends 0.02. */
+  --surface-0: #000000;
+  --surface-1: #0b0c0e;
+  --surface-2: #121316;
+  --surface-3: #1a1c20;
+  --surface-sunken: #000000;
+
+  --border: rgba(233, 236, 239, 0.09);
+  --border-strong: rgba(233, 236, 239, 0.16);
+
+  /* Kept as aliases: index.css refers to these in a hundred places and
+     renaming them all buys nothing. New work should use the ladder. */
+  --ink: var(--surface-0);
+  --panel: var(--surface-1);
+  --panel-raised: var(--surface-2);
+  --panel-sunken: var(--surface-sunken);
+  --edge: var(--border);
+  --edge-soft: var(--border);
 
   --chalk: #e9ecef;
-  --graphite: #7a828e;
-  --graphite-dim: #4d545e;
+  --graphite: #8b939f;
+  --graphite-dim: #5d6672;
 
   /* Occupancy ramp — neutral, low to high. The only "scale" on the page that
      is not about risk, and it is deliberately achromatic so it cannot be
@@ -58,8 +87,35 @@
      here: operators compare utilisation down a column. */
   --font-mono: "IBM Plex Mono", ui-monospace, monospace;
 
-  --radius: 3px;
-  --radius-sm: 2px;
+  /* ------------------------------------------------------------- type
+     Seven steps. Anything that does not land on one of these is a mistake
+     rather than a nuance — the previous 21 sizes were the mechanical reason
+     the hierarchy read as approximate. */
+  --text-2xs: 0.6875rem; /* 11px — uppercase eyebrows */
+  --text-xs: 0.75rem; /* 12px — labels, chips */
+  --text-sm: 0.8125rem; /* 13px — dense table rows */
+  --text-md: 0.875rem; /* 14px — body, the base */
+  --text-lg: 1rem; /* 16px — panel titles */
+  --text-xl: 1.25rem; /* 20px — section headings */
+  --text-2xl: 1.75rem; /* 28px — the verdict line, and nothing else */
+
+  --tracking-label: 0.14em;
+  --tracking-display: -0.03em;
+
+  /* ---------------------------------------------------------- spacing
+     An 8px grid with two half-steps. Six values replacing thirty-two. */
+  --space-1: 0.25rem; /* 4 */
+  --space-2: 0.5rem; /* 8 */
+  --space-3: 0.75rem; /* 12 */
+  --space-4: 1rem; /* 16 */
+  --space-6: 1.5rem; /* 24 */
+  --space-8: 2rem; /* 32 */
+
+  /* 3px read as a rounding error rather than a decision. 6 is the smallest
+     radius that reads as intentional at this density. */
+  --radius: 6px;
+  --radius-sm: 4px;
+  --radius-lg: 8px;
 
   --step-fast: 120ms;
   --step-base: 260ms;
@@ -70,45 +126,56 @@
   --ease-out: cubic-bezier(0.22, 1, 0.36, 1);
 }
 
+/*
+ * Light theme.
+ *
+ * Designed rather than inverted. On a light face the occupancy ramp has to run
+ * the other way — fuller means darker — or a nearly full node would render as
+ * a pale, empty-looking box and the whole picture would read backwards.
+ *
+ * The safety scale is deliberately absent from both blocks below. It is fixed
+ * across themes, and test/palette fails the build if a theme redefines it.
+ */
 @media (prefers-color-scheme: light) {
   :root:not([data-theme="dark"]) {
     color-scheme: light;
-    --ink: #dfe3e8;
-    --panel: #f4f6f8;
-    --panel-raised: #ffffff;
-    --panel-sunken: #cfd5dd;
-    --edge: #c2c9d2;
-    --edge-soft: rgba(11, 13, 16, 0.1);
-    --chalk: #10141a;
+    --surface-0: #fbfcfd;
+    --surface-1: #f4f6f8;
+    --surface-2: #ffffff;
+    --surface-3: #eef1f4;
+    --surface-sunken: #e6eaee;
+    --border: rgba(13, 17, 23, 0.1);
+    --border-strong: rgba(13, 17, 23, 0.18);
+    --chalk: #0d1117;
     --graphite: #5b636e;
-    --graphite-dim: #8d949e;
-    /* Ramp inverts: on a light face, fuller means darker. */
-    --fill-05: #e7eaee;
-    --fill-25: #c3cad3;
-    --fill-50: #909aa7;
-    --fill-75: #5c6673;
+    --graphite-dim: #838b96;
+    --fill-05: #eaedf1;
+    --fill-25: #c7ced7;
+    --fill-50: #939dab;
+    --fill-75: #5e6875;
     --fill-95: #232a33;
-    --focus: #10141a;
+    --focus: #0d1117;
   }
 }
 
 :root[data-theme="light"] {
   color-scheme: light;
-  --ink: #dfe3e8;
-  --panel: #f4f6f8;
-  --panel-raised: #ffffff;
-  --panel-sunken: #cfd5dd;
-  --edge: #c2c9d2;
-  --edge-soft: rgba(11, 13, 16, 0.1);
-  --chalk: #10141a;
+  --surface-0: #fbfcfd;
+  --surface-1: #f4f6f8;
+  --surface-2: #ffffff;
+  --surface-3: #eef1f4;
+  --surface-sunken: #e6eaee;
+  --border: rgba(13, 17, 23, 0.1);
+  --border-strong: rgba(13, 17, 23, 0.18);
+  --chalk: #0d1117;
   --graphite: #5b636e;
-  --graphite-dim: #8d949e;
-  --fill-05: #e7eaee;
-  --fill-25: #c3cad3;
-  --fill-50: #909aa7;
-  --fill-75: #5c6673;
+  --graphite-dim: #838b96;
+  --fill-05: #eaedf1;
+  --fill-25: #c7ced7;
+  --fill-50: #939dab;
+  --fill-75: #5e6875;
   --fill-95: #232a33;
-  --focus: #10141a;
+  --focus: #0d1117;
 }
 
 * {
@@ -123,12 +190,13 @@ body,
 
 body {
   margin: 0;
-  background: var(--ink);
+  background: var(--surface-0);
   color: var(--chalk);
   font-family: var(--font-body);
-  font-size: 13px;
-  line-height: 1.5;
+  font-size: var(--text-md);
+  line-height: 1.55;
   -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
 }
 
 /* Every figure on the page is tabular. Comparing 38.6% against 94.1% down a
@@ -137,6 +205,15 @@ body {
   font-family: var(--font-mono);
   font-variant-numeric: tabular-nums;
   letter-spacing: -0.01em;
+}
+
+/* Uppercase micro-labels appear in every panel header. Tracking is not
+   decorative at this size — set solid, 11px caps are close to unreadable. */
+.eyebrow {
+  font-size: var(--text-2xs);
+  letter-spacing: var(--tracking-label);
+  text-transform: uppercase;
+  color: var(--graphite-dim);
 }
 
 button {
@@ -148,6 +225,7 @@ button {
 :where(a, button, input, [tabindex]):focus-visible {
   outline: 2px solid var(--focus);
   outline-offset: 2px;
+  border-radius: var(--radius-sm);
 }
 
 /*


### PR DESCRIPTION
Four things, one of which was a bug that made the other three invisible.

## The operator and the cluster were both missing

The UI showed **neither who you were signed in as nor which cluster you were looking at.** For a tool whose pitch is that a human approves before pods are evicted, the human was absent from the screen — and so was the answer to *"am I about to drain production?"*

```
k8s-dencer   ● orbstack-local        system:serviceaccount:…:dencer-operator   Sign out
```

Identity is what **TokenReview verified**, not a claim decoded from a token the page happens to hold. It rides on the existing `/api/v1/version` response rather than a new route — already authenticated, already fetched, and a new endpoint would be more surface to guard for data every page needs anyway.

Cluster label is operator-set (`uiBackend.clusterLabel`) and **empty by default**: nothing in a cluster reliably names itself, and a guessed environment is worse than none, because the whole value of that field is being believed when it says `prod`.

## There was no scale

**21 font sizes and 32 padding values** — each sensible alone, improvised together, and the mechanical reason a carefully built instrument read as homemade. Now seven type steps and a six-step 8px grid; base 13→14px, radius 3→6px.

## A node was a dead end

It reported "4 pods" and offered no way to ask about any of them — precisely the question the count provokes. Clicking one now **lists its pods**, each opening its own constraints, with a way back up. A drill-down without one is a trapdoor.

Those boxes have carried `role="button"` and a tabindex **since M11 with neither a pointer nor a hover state**, so nothing on screen ever said a node could be opened. The drill-down is worthless if nobody discovers it.

## Two bugs found on the way

**`index.html` had no `Cache-Control` at all**, so browsers cached it heuristically. Since that document names the hashed asset files, a stale copy pins the browser to the *previous release* — the pod serves new bundles and the operator keeps seeing the old app with no sign a deploy happened. The nginx comment already said the entry HTML is not immutable; only the assets half was implemented. Fixed in the image and in the chart ConfigMap that actually applies in-cluster.

**The node panel counted pod elements**, which above the graph endpoint's detail limit is always zero. Every node on a large cluster would have reported no pods — and a node holding forty rendering as empty reads as a successful drain. Uses the server's tallies now, and says why the list is elided at that size.

## Black

Ground is `#000000`. On OLED it switches off entirely, leaving a saturated rating as the only lit thing in that region — the strongest reading of *colour means risk*.

**The safety scale is untouched.** `test/palette` passes: three hexes byte-identical across both themes, glyph + word on every rating, and the highest chroma among the new neutrals is **0.024 against a budget of 0.15**.

Also adds [docs/gcp-setup.md](docs/gcp-setup.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)