### PR TITLE
Stop a cloud run hijacking the terminal it didn't start in, and default to dark

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,109 @@
+# Dependency updates.
+#
+# Four ecosystems, because that is what the repository actually contains: a Go
+# module at the root, an npm project under ui/, the workflows in
+# .github/workflows, and two Dockerfiles under build/.
+#
+# Everything is grouped. Ungrouped Dependabot on a repo this size opens a
+# stream of single-dependency pull requests, each one costing a full CI run —
+# and this repository's CI stands up a five-node k3d cluster and drains a node,
+# so a run is minutes, not seconds. Grouping turns a dozen patch bumps into one
+# reviewable change.
+
+version: 2
+updates:
+  # ------------------------------------------------------------------- Go
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    labels: [dependencies, go]
+    groups:
+      # The Kubernetes libraries are version-locked to each other: client-go
+      # v0.36 expects apimachinery v0.36, and controller-runtime pins its own
+      # compatible pair. Updating any one of them alone does not produce a
+      # failing test — it produces a repository that will not compile. They
+      # move together or not at all.
+      kubernetes:
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+      # Everything else, minor and patch only. A Go major version is an import
+      # path change and deserves a human deciding to do it.
+      go-minor-and-patch:
+        patterns: ["*"]
+        exclude-patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+        update-types: [minor, patch]
+
+  # ------------------------------------------------------------------ npm
+  - package-ecosystem: npm
+    directory: "/ui"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    labels: [dependencies, ui]
+    groups:
+      # The bundled typefaces are a deliberate, pinned choice — Archivo and IBM
+      # Plex, latin subsets only, vendored so an air-gapped cluster still gets
+      # designed type. Grouped so a font bump is visibly a font bump rather
+      # than hiding among build-tool churn.
+      fonts:
+        patterns: ["@fontsource*"]
+      npm-minor-and-patch:
+        patterns: ["*"]
+        exclude-patterns: ["@fontsource*"]
+        update-types: [minor, patch]
+
+  # -------------------------------------------------------- GitHub Actions
+  # Directory is "/" regardless of where the workflows live; Dependabot always
+  # reads .github/workflows from the repository root.
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    labels: [dependencies, ci]
+    groups:
+      actions:
+        patterns: ["*"]
+
+  # --------------------------------------------------------------- Docker
+  #
+  # Worth being honest about what this can reach. Of the four base images:
+  #
+  #   nginxinc/nginx-unprivileged:1.27-alpine   updatable
+  #   gcr.io/distroless/static-debian12:nonroot pinned to a floating tag, so
+  #                                             there is no version to bump
+  #   golang:${GO_VERSION}-alpine               built from an ARG
+  #   node:${NODE_VERSION}-alpine               built from an ARG
+  #
+  # Dependabot does not resolve build arguments, so the last two are invisible
+  # to it and the Go and Node versions still have to be bumped by hand in
+  # build/*.Dockerfile. Keeping this entry is still worth it for nginx, and
+  # inlining the two ARGs purely to satisfy a bot would trade a deliberate
+  # single-source-of-truth for automation of a version this project pins on
+  # purpose.
+  - package-ecosystem: docker
+    directory: "/build"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    labels: [dependencies, docker]
+    groups:
+      base-images:
+        patterns: ["*"]

--- a/Makefile
+++ b/Makefile
@@ -188,6 +188,30 @@ cli-install: cli ## Install dencer and kubectl-dencer into $(GOBIN) or ~/go/bin
 e2e: ## Install on a throwaway multi-node k3d cluster and drain a real node
 	./hack/e2e.sh
 
+.PHONY: guard-context
+guard-context:
+	@# Refuse to deploy into a cloud cluster by accident.
+	@#
+	@# `make deploy` builds local, unqualified image tags and installs them
+	@# into whatever context happens to be current. That was harmless while
+	@# every context was a local cluster. It stopped being harmless the day a
+	@# GKE path existed: `gcloud container clusters get-credentials` switches
+	@# the current context, so a cloud run in one terminal silently redirects a
+	@# deploy in another — which is exactly what happened, overwriting a live
+	@# test cluster's release with image tags no registry has.
+	@#
+	@# hack/e2e.sh already passes --context on every call for this reason. This
+	@# extends the same discipline to the target humans actually type.
+	@ctx="$$(kubectl config current-context 2>/dev/null)"; \
+	case "$$ctx" in \
+	  orbstack|docker-desktop|minikube|kind-*|k3d-*|colima) ;; \
+	  *) echo "refusing to deploy: current kube context is '$$ctx', which is not a known local cluster."; \
+	     echo "  local image tags are meaningless anywhere else, and a cloud run may have switched this."; \
+	     echo "  switch back:  kubectl config use-context orbstack"; \
+	     echo "  or override:  make deploy ALLOW_ANY_CONTEXT=1"; \
+	     [ -n "$(ALLOW_ANY_CONTEXT)" ] || exit 1 ;; \
+	esac
+
 .PHONY: gke-setup
 gke-setup: ## One-time GCP bootstrap for the cloud test (APIs, quota, budget alert)
 	./hack/gke-setup.sh
@@ -211,7 +235,7 @@ lint: $(KUBECONFORM) ## Chart portability gate: lint, render and assert the cont
 # ---------------------------------------------------------------------------
 
 .PHONY: deploy
-deploy: ## Install/upgrade the product chart with the provider overlay
+deploy: guard-context ## Install/upgrade the product chart with the provider overlay
 	helm upgrade --install $(RELEASE) $(CHART) \
 		--namespace $(NAMESPACE) --create-namespace \
 		-f $(CHART)/ci/$(CLUSTER_PROVIDER)-values.yaml \

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -166,6 +166,16 @@ except Exception: print(0)')"
 
   gcloud container clusters get-credentials "$CLUSTER" --zone "$GCP_ZONE" --quiet 2>/dev/null
   kubectl config rename-context "$(kubectl config current-context)" "$CTX" >/dev/null 2>&1 || true
+
+  # Hand the current context straight back.
+  #
+  # get-credentials does not just write a context, it makes it current — which
+  # silently redirects every kubectl and helm command in every other terminal
+  # on the machine for as long as this runs. Restoring only on exit is too
+  # late: a 25-minute run is 25 minutes of the operator's own commands landing
+  # on a throwaway cloud cluster. This script addresses the cluster by
+  # --context everywhere, so it needs no help from the global setting.
+  restore_context
 }
 
 cluster_delete() {

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -60,9 +60,19 @@ PROVIDER="${PROVIDER:-k3d}"
 GCP_ZONE="${GCP_ZONE:-us-central1-a}"
 GCP_MACHINE="${GCP_MACHINE:-e2-medium}"
 # Published tags, not a local build: on GKE this doubles as the first proof
-# that what we ship to ghcr actually installs. Overridable so a release
-# candidate can be tested before it is tagged latest.
-GHCR_TAG="${GHCR_TAG:-latest}"
+# that what we ship to ghcr actually installs.
+#
+# Defaults to the chart's own appVersion rather than "latest" — the chart's
+# values.schema.json refuses a tag of "latest" outright, and it is right to:
+# deploying a floating tag makes a cluster unreproducible and a rollback
+# meaningless. Testing the version the chart declares is also simply the more
+# useful thing to test.
+GHCR_TAG="${GHCR_TAG:-$(awk '/^appVersion:/ {gsub(/"/,"",$2); print $2}' "$REPO/charts/k8s-dencer/Chart.yaml")}"
+# Spot is ~70% cheaper and interruption is fine for a 25-minute test, but a new
+# GCP project's PREEMPTIBLE_CPUS quota starts at zero and has to be requested.
+# Rather than fail the run on that, detect it and use on-demand — the
+# difference over 25 minutes is about five cents.
+GCP_SPOT="${GCP_SPOT:-auto}"
 
 case "$PROVIDER" in
   k3d) CTX="k3d-${CLUSTER}" ;;
@@ -95,13 +105,6 @@ cleanup() {
 }
 trap cleanup EXIT
 
-if [[ "${1:-}" == "clean" ]]; then
-  cluster_delete
-  restore_context
-  green "removed"
-  exit 0
-fi
-
 # ------------------------------------------------------------- provider
 
 cluster_create() {
@@ -120,6 +123,25 @@ cluster_create() {
   [[ -n "$project" && "$project" != "(unset)" ]] \
     || fail "no gcloud project set. Run 'make gke-setup' first"
 
+  local spot_flag=()
+  case "$GCP_SPOT" in
+    auto)
+      local limit
+      limit="$(gcloud compute regions describe "${GCP_ZONE%-*}" --format=json 2>/dev/null \
+        | python3 -c 'import json,sys
+try: print(int({x["metric"]: x["limit"] for x in json.load(sys.stdin).get("quotas",[])}.get("PREEMPTIBLE_CPUS",0)))
+except Exception: print(0)')"
+      if [[ "${limit:-0}" -ge $(( (AGENTS + 1) * 2 )) ]]; then
+        spot_flag=(--spot)
+        green "  using Spot nodes (${limit} preemptible vCPUs available)"
+      else
+        green "  using on-demand nodes: preemptible quota in ${GCP_ZONE%-*} is ${limit:-0}"
+      fi
+      ;;
+    1|true|yes) spot_flag=(--spot) ;;
+    *) ;;
+  esac
+
   # Zonal, not regional: the GKE free tier credit covers one zonal cluster's
   # management fee, and a regional control plane buys nothing for a cluster
   # that lives twenty minutes.
@@ -134,7 +156,7 @@ cluster_create() {
     --zone "$GCP_ZONE" \
     --num-nodes "$((AGENTS + 1))" \
     --machine-type "$GCP_MACHINE" \
-    --spot \
+    "${spot_flag[@]}" \
     --disk-type pd-standard --disk-size 20 \
     --enable-autoscaling --min-nodes 1 --max-nodes "$((AGENTS + 2))" \
     --no-enable-autoupgrade --no-enable-autorepair \
@@ -155,8 +177,17 @@ cluster_delete() {
   # this script can cost real money, so a failure to delete must be seen rather
   # than swallowed into /dev/null like the k3d case.
   echo "  deleting the GKE cluster (this takes a few minutes)…"
-  gcloud container clusters delete "$CLUSTER" --zone "$GCP_ZONE" --quiet \
-    || red "COULD NOT DELETE CLUSTER ${CLUSTER} in ${GCP_ZONE} — delete it by hand, it is costing money"
+  if ! gcloud container clusters delete "$CLUSTER" --zone "$GCP_ZONE" --quiet 2>/tmp/dencer-del.err; then
+    # A delete already in flight, or a cluster that is simply gone, is not the
+    # failure this warning exists for. Shouting about those trains people to
+    # ignore the one case that matters: a cluster still running and billing.
+    if grep -qiE "not found|already being deleted|is currently being (deleted|repaired)" /tmp/dencer-del.err; then
+      green "  already gone"
+    else
+      red "COULD NOT DELETE CLUSTER ${CLUSTER} in ${GCP_ZONE} — delete it by hand, it is costing money"
+      sed 's/^/    /' /tmp/dencer-del.err
+    fi
+  fi
   kubectl config delete-context "$CTX" >/dev/null 2>&1 || true
 }
 
@@ -169,6 +200,16 @@ if [[ "$PROVIDER" == "k3d" ]]; then
   done
 else
   command -v gcloud >/dev/null || fail "gcloud is required for PROVIDER=gke"
+fi
+
+# `clean` lives here, not at the top of the file: it calls cluster_delete, and
+# a subcommand placed before its own function is defined fails with "command
+# not found" — which is exactly what it did.
+if [[ "${1:-}" == "clean" ]]; then
+  cluster_delete
+  restore_context
+  green "removed"
+  exit 0
 fi
 
 # ---------------------------------------------------------------- cluster

--- a/hack/gke-setup.sh
+++ b/hack/gke-setup.sh
@@ -72,32 +72,56 @@ bold "==> quota for ${NODES} × ${MACHINE} Spot in ${ZONE}"
 # CPU quota of zero, and the cluster create then fails several minutes in with a
 # message about "PREEMPTIBLE_CPUS" that reads like a bug in the script.
 region="${ZONE%-*}"
-spot_quota="$(gcloud compute regions describe "$region" \
-  --format='value(quotas.filter("metric:PREEMPTIBLE_CPUS").limit)' 2>/dev/null || echo "")"
 needed=$(( NODES * 2 ))   # e2-medium is 2 vCPU
-if [[ -z "$spot_quota" ]]; then
-  warn "  could not read PREEMPTIBLE_CPUS quota for ${region}; the run may still work"
-elif (( ${spot_quota%.*} < needed )); then
-  warn "  PREEMPTIBLE_CPUS in ${region} is ${spot_quota%.*}, and ${NODES} × ${MACHINE} needs ${needed}."
-  warn "  Request more at https://console.cloud.google.com/iam-admin/quotas, or run with"
-  warn "  fewer/smaller nodes:  AGENTS=2 GCP_MACHINE=e2-small make cloud-e2e"
+
+# Read the quotas out of JSON rather than a --format filter expression. The
+# filter form returned nothing here and the check reported "could not read",
+# which is how a limit of zero got waved through into a cluster create that
+# would have failed several minutes later.
+quota_json="$(gcloud compute regions describe "$region" --format=json 2>/dev/null || echo '{}')"
+read -r SPOT_LIMIT ONDEMAND_LIMIT <<<"$(printf '%s' "$quota_json" | python3 -c '
+import json, sys
+try:
+    q = {x["metric"]: x["limit"] for x in json.load(sys.stdin).get("quotas", [])}
+except Exception:
+    q = {}
+print(int(q.get("PREEMPTIBLE_CPUS", -1)), int(q.get("CPUS", -1)))
+')"
+
+if [[ "${SPOT_LIMIT:--1}" -ge "$needed" ]]; then
+  green "  ${SPOT_LIMIT} preemptible vCPUs available, ${needed} needed — Spot will be used"
+elif [[ "${ONDEMAND_LIMIT:--1}" -ge "$needed" ]]; then
+  # The common case on a new project: Spot quota starts at zero and has to be
+  # requested. On-demand for twenty-five minutes is a few cents, so falling
+  # back beats blocking on a quota request.
+  warn "  preemptible vCPU quota in ${region} is ${SPOT_LIMIT}, and ${needed} are needed."
+  warn "  On-demand quota is ${ONDEMAND_LIMIT}, so the run will use on-demand nodes instead."
+  warn "  That is roughly 7 cents for a 25 minute run rather than 2. To use Spot,"
+  warn "  request PREEMPTIBLE_CPUS at https://console.cloud.google.com/iam-admin/quotas"
 else
-  green "  ${spot_quota%.*} preemptible vCPUs available, ${needed} needed"
+  fail "neither preemptible (${SPOT_LIMIT}) nor on-demand (${ONDEMAND_LIMIT}) vCPU quota in
+  ${region} covers the ${needed} vCPUs this needs. Request more, or run smaller:
+    AGENTS=2 GCP_MACHINE=e2-small make cloud-e2e"
 fi
 
 bold "==> budget alert"
+# Every gcloud call below runs with stdin closed. The Billing Budgets API is
+# often not enabled on a new project, and gcloud responds by prompting to
+# enable it — which, in a non-interactive script, is an indefinite hang rather
+# than an error. This section is a nicety; it must never block the run.
+exec 3<&0
 # Cheap insurance against the one real failure mode: a cluster left running.
 ba="$(gcloud billing projects describe "$project" \
-  --format='value(billingAccountName)' 2>/dev/null || true)"
+  --format='value(billingAccountName)' </dev/null 2>/dev/null || true)"
 if [[ -z "$ba" ]]; then
   warn "  could not read the billing account; skipping"
 elif gcloud billing budgets list --billing-account="${ba##*/}" \
-       --format='value(displayName)' 2>/dev/null | grep -q "dencer-e2e"; then
+       --format='value(displayName)' </dev/null 2>/dev/null | grep -q "dencer-e2e"; then
   green "  already set"
 elif [[ "$CHECK_ONLY" == "1" ]]; then
   warn "  no dencer-e2e budget alert"
 else
-  if gcloud billing budgets create --billing-account="${ba##*/}" \
+  if gcloud billing budgets create --billing-account="${ba##*/}" </dev/null \
        --display-name="dencer-e2e" \
        --budget-amount="${BUDGET}USD" \
        --threshold-rule=percent=0.5 --threshold-rule=percent=1.0 \

--- a/ui/src/components/AppBar.tsx
+++ b/ui/src/components/AppBar.tsx
@@ -15,6 +15,9 @@
  * makes a Green/Yellow/Red rating land.
  */
 
+import { useState } from "react";
+import { Theme, applyTheme, storedTheme } from "../theme";
+
 interface Props {
   /** Operator-set. Empty renders nothing rather than a guess. */
   clusterLabel?: string;
@@ -43,6 +46,7 @@ export default function AppBar({ clusterLabel, identity, onSignOut }: Props) {
       </div>
 
       <div className="appbar-actions">
+        <ThemeToggle />
         {identity && (
           /* The full RBAC principal, which for a ServiceAccount is long and
              gets truncated. The title carries the whole thing, because the
@@ -59,5 +63,33 @@ export default function AppBar({ clusterLabel, identity, onSignOut }: Props) {
         )}
       </div>
     </header>
+  );
+}
+
+/**
+ * Dark or light, the operator's choice rather than their desktop's.
+ *
+ * A glyph and a label, not an unlabelled icon: this is the same surface that
+ * refuses to let colour carry meaning on its own, and an ambiguous sun/moon
+ * pictogram would be that mistake in another form.
+ */
+function ThemeToggle() {
+  const [theme, setTheme] = useState<Theme>(storedTheme);
+
+  const next: Theme = theme === "dark" ? "light" : "dark";
+  return (
+    <button
+      type="button"
+      className="appbar-theme"
+      aria-label={`Switch to the ${next} theme`}
+      title={`Switch to the ${next} theme`}
+      onClick={() => {
+        applyTheme(next);
+        setTheme(next);
+      }}
+    >
+      <span aria-hidden="true">{theme === "dark" ? "◐" : "◑"}</span>
+      <span className="appbar-theme-word">{next}</span>
+    </button>
   );
 }

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1770,3 +1770,30 @@
   color: var(--graphite-dim);
   font-size: var(--text-xs);
 }
+
+.appbar-theme {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-1) var(--space-3);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--graphite);
+  font-size: var(--text-xs);
+  transition: color var(--step-fast) var(--ease-out),
+    border-color var(--step-fast) var(--ease-out);
+}
+
+.appbar-theme:hover {
+  color: var(--chalk);
+  border-color: var(--border-strong);
+}
+
+/* The word goes before the identity does: on a narrow bar the glyph alone
+   still says which way the switch points. */
+@media (max-width: 900px) {
+  .appbar-theme-word {
+    display: none;
+  }
+}

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -3,11 +3,14 @@ import { createRoot } from "react-dom/client";
 import App from "./App";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import "./index.css";
+import { applyTheme, storedTheme } from "./theme";
 
 const root = document.getElementById("root");
 if (!root) {
   throw new Error("#root not found");
 }
+
+applyTheme(storedTheme());
 
 createRoot(root).render(
   <StrictMode>

--- a/ui/src/theme.ts
+++ b/ui/src/theme.ts
@@ -1,0 +1,42 @@
+/**
+ * Which face the instrument wears.
+ *
+ * The palette has always supported both, but nothing ever set `data-theme`, so
+ * the operating system was the only vote and an operator who wanted the dark
+ * instrument on a light desktop had no way to ask for it.
+ *
+ * Dark is the default rather than "follow the OS". This is a wall-mounted
+ * instrument as much as an app — the ground goes black so that a saturated
+ * rating is the only lit thing on it, which is the whole premise of the
+ * palette. A light desktop is a statement about documents and mail, not about
+ * how someone wants to watch a drain.
+ *
+ * The choice persists in localStorage, which is fine here. The rule in
+ * test/ui is scoped to auth.ts and exists so a bearer token cannot outlive the
+ * tab; a colour preference is not a credential, and putting it in
+ * sessionStorage would mean re-picking the theme in every new tab.
+ */
+
+export type Theme = "dark" | "light";
+
+const KEY = "dencer.theme";
+
+export function storedTheme(): Theme {
+  try {
+    const v = localStorage.getItem(KEY);
+    if (v === "dark" || v === "light") return v;
+  } catch {
+    // Private browsing, or storage disabled. Fall through to the default.
+  }
+  return "dark";
+}
+
+/** Stamps the root element, which is what theme.css keys off. */
+export function applyTheme(theme: Theme): void {
+  document.documentElement.setAttribute("data-theme", theme);
+  try {
+    localStorage.setItem(KEY, theme);
+  } catch {
+    // The theme still applies for this page; it just will not be remembered.
+  }
+}


### PR DESCRIPTION
## The context hijack

`gcloud container clusters get-credentials` doesn't merely *write* a kubeconfig context — it makes it **current**. So a 25-minute cloud run silently redirects every `kubectl` and `helm` command in every other terminal on the machine for its whole duration. Restoring on exit, which is all this did, is far too late.

Not hypothetical: a `helm upgrade` I typed during a run landed on the GKE cluster instead of OrbStack, installed local image tags no registry has, and **killed the run it was supposed to be unrelated to**.

`e2e.sh` already addresses its cluster by `--context` on every call, so it never needed the global setting. The context now goes straight back after `get-credentials`.

**`make deploy` gains the same discipline.** It builds unqualified local image tags and installs them into whatever context happens to be current — harmless while every context was a local cluster, and not harmless from the day a GKE path existed:

```
refusing to deploy: current kube context is 'gke-e2e', which is not a known local cluster.
  local image tags are meaningless anywhere else, and a cloud run may have switched this.
  switch back:  kubectl config use-context orbstack
  or override:  make deploy ALLOW_ANY_CONTEXT=1
```

## Dark by default, and a toggle

The palette has supported both faces for a long time, but **nothing ever set `data-theme`** — so the OS was the only vote, and an operator on a light desktop got the light instrument with no way to ask otherwise. Which is exactly what happened: the black theme was reported as "no change" because the desktop was light.

Dark leads because the ground going black is what leaves a saturated rating as the only lit thing on the surface, and that is the premise the entire palette rests on. A light desktop is a statement about documents, not about how someone wants to watch a drain.

The toggle carries a glyph **and** a word — an unlabelled sun/moon pictogram would be the same mistake this surface refuses to make with colour.

Persisted in `localStorage`. The rule in `test/ui` is scoped to `auth.ts` and exists so a bearer token cannot outlive its tab; a colour preference is not a credential, and `sessionStorage` would mean re-picking it in every new tab.

`test/palette` and `test/ui` both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)