### PR TITLE
Find the GKE auth plugin that Homebrew installs but doesn't link

### DIFF
--- a/docs/gcp-setup.md
+++ b/docs/gcp-setup.md
@@ -12,8 +12,12 @@ only thing that has ever removed a drained node is our own test script.
 
 ## What it will cost
 
-**Nothing, on a new account.** The $300 / 90-day free trial covers it many
-thousand times over.
+**Nothing, on the free trial.** The $300 / 90-day credit covers it many
+thousand times over. Check what you have left with:
+
+```bash
+gcloud billing accounts list
+```
 
 | | |
 |---|---|
@@ -71,6 +75,21 @@ brew install --cask google-cloud-sdk     # macOS
 
 Anything else: <https://cloud.google.com/sdk/docs/install>
 
+**Do not skip the Homebrew caveat.** The cask links `gcloud` into `bin` but
+leaves the SDK's other components — including `gke-gcloud-auth-plugin`, which
+kubectl needs to authenticate to GKE at all — in a directory that is not on
+`PATH`. `make gke-setup` checks for it, and `hack/e2e.sh` finds it regardless,
+but for your own `kubectl` against the cluster:
+
+```bash
+export PATH="$(brew --prefix)/share/google-cloud-sdk/bin:$PATH"
+```
+
+Left unfixed this produces a confusing failure rather than a clear one: the
+first few kubectl calls succeed on the token `get-credentials` leaves behind,
+so a run gets several minutes in and only then reports that it cannot reach the
+API server.
+
 ## 5. Log in and select the project
 
 ```bash
@@ -88,9 +107,12 @@ Idempotent, and safe to re-run. It:
 
 - confirms you are logged in and billing is linked
 - enables `container.googleapis.com` and `compute.googleapis.com`
-- **checks your preemptible-CPU quota** — a brand-new project can have zero,
-  and without this check the failure arrives several minutes into cluster
-  creation with a message that reads like a bug in our script
+- **checks your preemptible-CPU quota.** A new project's `PREEMPTIBLE_CPUS`
+  limit is **zero** — this is normal, not a misconfiguration, and it has to be
+  requested. Rather than block on that, the run falls back to on-demand nodes:
+  about 7 cents for 25 minutes instead of 2. Request Spot at
+  [IAM & Admin → Quotas](https://console.cloud.google.com/iam-admin/quotas) if
+  you plan to run this often
 - offers to create a **$1 budget alert**
 - prints what a run costs
 
@@ -138,9 +160,11 @@ make cloud-e2e-clean                # if it is not
 
 ### Failures I would expect first
 
-**`PREEMPTIBLE_CPUS` quota exceeded.** New projects often start at zero. Either
-request an increase at
-<https://console.cloud.google.com/iam-admin/quotas>, or run smaller:
+**Nothing to fix — the run says "using on-demand nodes".** That is the
+preemptible quota being zero, which is the default on a new project. It costs a
+few cents more and is otherwise identical.
+
+**Genuinely out of quota.** If on-demand `CPUS` is also short, run smaller:
 
 ```bash
 AGENTS=2 GCP_MACHINE=e2-small make cloud-e2e

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -60,9 +60,19 @@ PROVIDER="${PROVIDER:-k3d}"
 GCP_ZONE="${GCP_ZONE:-us-central1-a}"
 GCP_MACHINE="${GCP_MACHINE:-e2-medium}"
 # Published tags, not a local build: on GKE this doubles as the first proof
-# that what we ship to ghcr actually installs. Overridable so a release
-# candidate can be tested before it is tagged latest.
-GHCR_TAG="${GHCR_TAG:-latest}"
+# that what we ship to ghcr actually installs.
+#
+# Defaults to the chart's own appVersion rather than "latest" — the chart's
+# values.schema.json refuses a tag of "latest" outright, and it is right to:
+# deploying a floating tag makes a cluster unreproducible and a rollback
+# meaningless. Testing the version the chart declares is also simply the more
+# useful thing to test.
+GHCR_TAG="${GHCR_TAG:-$(awk '/^appVersion:/ {gsub(/"/,"",$2); print $2}' "$REPO/charts/k8s-dencer/Chart.yaml")}"
+# Spot is ~70% cheaper and interruption is fine for a 25-minute test, but a new
+# GCP project's PREEMPTIBLE_CPUS quota starts at zero and has to be requested.
+# Rather than fail the run on that, detect it and use on-demand — the
+# difference over 25 minutes is about five cents.
+GCP_SPOT="${GCP_SPOT:-auto}"
 
 case "$PROVIDER" in
   k3d) CTX="k3d-${CLUSTER}" ;;
@@ -95,14 +105,32 @@ cleanup() {
 }
 trap cleanup EXIT
 
-if [[ "${1:-}" == "clean" ]]; then
-  cluster_delete
-  restore_context
-  green "removed"
-  exit 0
-fi
-
 # ------------------------------------------------------------- provider
+
+# kubectl cannot talk to GKE without gke-gcloud-auth-plugin, and Homebrew
+# installs it into the SDK's own bin directory rather than linking it alongside
+# gcloud — so it is present, installed, and invisible.
+#
+# The failure it produces is genuinely misleading: the first few kubectl calls
+# succeed on the token get-credentials leaves behind, and only later ones fail,
+# so it looks like something broke mid-run rather than a prerequisite never
+# having been met.
+ensure_gke_auth_plugin() {
+  command -v gke-gcloud-auth-plugin >/dev/null && return 0
+  local d
+  for d in \
+    "$(dirname "$(command -v gcloud 2>/dev/null || echo /nonexistent)")" \
+    "$(brew --prefix 2>/dev/null)/share/google-cloud-sdk/bin" \
+    "/opt/homebrew/share/google-cloud-sdk/bin" \
+    "/usr/local/share/google-cloud-sdk/bin" \
+    "$HOME/google-cloud-sdk/bin"; do
+    if [[ -x "$d/gke-gcloud-auth-plugin" ]]; then
+      PATH="$d:$PATH"; export PATH
+      return 0
+    fi
+  done
+  return 1
+}
 
 cluster_create() {
   if [[ "$PROVIDER" == "k3d" ]]; then
@@ -115,10 +143,34 @@ cluster_create() {
     return
   fi
 
+  ensure_gke_auth_plugin \
+    || fail "gke-gcloud-auth-plugin not found. kubectl cannot authenticate to GKE without it.
+  Install:  gcloud components install gke-gcloud-auth-plugin
+  Homebrew: it ships with the SDK at \$(brew --prefix)/share/google-cloud-sdk/bin — add that to PATH"
+
   local project
   project="$(gcloud config get-value project 2>/dev/null)"
   [[ -n "$project" && "$project" != "(unset)" ]] \
     || fail "no gcloud project set. Run 'make gke-setup' first"
+
+  local spot_flag=()
+  case "$GCP_SPOT" in
+    auto)
+      local limit
+      limit="$(gcloud compute regions describe "${GCP_ZONE%-*}" --format=json 2>/dev/null \
+        | python3 -c 'import json,sys
+try: print(int({x["metric"]: x["limit"] for x in json.load(sys.stdin).get("quotas",[])}.get("PREEMPTIBLE_CPUS",0)))
+except Exception: print(0)')"
+      if [[ "${limit:-0}" -ge $(( (AGENTS + 1) * 2 )) ]]; then
+        spot_flag=(--spot)
+        green "  using Spot nodes (${limit} preemptible vCPUs available)"
+      else
+        green "  using on-demand nodes: preemptible quota in ${GCP_ZONE%-*} is ${limit:-0}"
+      fi
+      ;;
+    1|true|yes) spot_flag=(--spot) ;;
+    *) ;;
+  esac
 
   # Zonal, not regional: the GKE free tier credit covers one zonal cluster's
   # management fee, and a regional control plane buys nothing for a cluster
@@ -134,7 +186,7 @@ cluster_create() {
     --zone "$GCP_ZONE" \
     --num-nodes "$((AGENTS + 1))" \
     --machine-type "$GCP_MACHINE" \
-    --spot \
+    "${spot_flag[@]}" \
     --disk-type pd-standard --disk-size 20 \
     --enable-autoscaling --min-nodes 1 --max-nodes "$((AGENTS + 2))" \
     --no-enable-autoupgrade --no-enable-autorepair \
@@ -144,6 +196,16 @@ cluster_create() {
 
   gcloud container clusters get-credentials "$CLUSTER" --zone "$GCP_ZONE" --quiet 2>/dev/null
   kubectl config rename-context "$(kubectl config current-context)" "$CTX" >/dev/null 2>&1 || true
+
+  # Hand the current context straight back.
+  #
+  # get-credentials does not just write a context, it makes it current — which
+  # silently redirects every kubectl and helm command in every other terminal
+  # on the machine for as long as this runs. Restoring only on exit is too
+  # late: a 25-minute run is 25 minutes of the operator's own commands landing
+  # on a throwaway cloud cluster. This script addresses the cluster by
+  # --context everywhere, so it needs no help from the global setting.
+  restore_context
 }
 
 cluster_delete() {
@@ -155,8 +217,17 @@ cluster_delete() {
   # this script can cost real money, so a failure to delete must be seen rather
   # than swallowed into /dev/null like the k3d case.
   echo "  deleting the GKE cluster (this takes a few minutes)…"
-  gcloud container clusters delete "$CLUSTER" --zone "$GCP_ZONE" --quiet \
-    || red "COULD NOT DELETE CLUSTER ${CLUSTER} in ${GCP_ZONE} — delete it by hand, it is costing money"
+  if ! gcloud container clusters delete "$CLUSTER" --zone "$GCP_ZONE" --quiet 2>/tmp/dencer-del.err; then
+    # A delete already in flight, or a cluster that is simply gone, is not the
+    # failure this warning exists for. Shouting about those trains people to
+    # ignore the one case that matters: a cluster still running and billing.
+    if grep -qiE "not found|already being deleted|is currently being (deleted|repaired)" /tmp/dencer-del.err; then
+      green "  already gone"
+    else
+      red "COULD NOT DELETE CLUSTER ${CLUSTER} in ${GCP_ZONE} — delete it by hand, it is costing money"
+      sed 's/^/    /' /tmp/dencer-del.err
+    fi
+  fi
   kubectl config delete-context "$CTX" >/dev/null 2>&1 || true
 }
 
@@ -169,6 +240,16 @@ if [[ "$PROVIDER" == "k3d" ]]; then
   done
 else
   command -v gcloud >/dev/null || fail "gcloud is required for PROVIDER=gke"
+fi
+
+# `clean` lives here, not at the top of the file: it calls cluster_delete, and
+# a subcommand placed before its own function is defined fails with "command
+# not found" — which is exactly what it did.
+if [[ "${1:-}" == "clean" ]]; then
+  cluster_delete
+  restore_context
+  green "removed"
+  exit 0
 fi
 
 # ---------------------------------------------------------------- cluster

--- a/hack/gke-setup.sh
+++ b/hack/gke-setup.sh
@@ -32,6 +32,29 @@ CHECK_ONLY=0
 
 command -v gcloud >/dev/null || fail "gcloud is required: https://cloud.google.com/sdk/docs/install"
 
+bold "==> kubectl can authenticate to GKE"
+# Checked first because it is the prerequisite most likely to be missing and
+# the one whose failure reads least like its cause.
+if command -v gke-gcloud-auth-plugin >/dev/null; then
+  green "  gke-gcloud-auth-plugin on PATH"
+else
+  found=""
+  for d in "$(brew --prefix 2>/dev/null)/share/google-cloud-sdk/bin" \
+           "/opt/homebrew/share/google-cloud-sdk/bin" \
+           "/usr/local/share/google-cloud-sdk/bin" \
+           "$HOME/google-cloud-sdk/bin"; do
+    [[ -x "$d/gke-gcloud-auth-plugin" ]] && found="$d" && break
+  done
+  if [[ -n "$found" ]]; then
+    warn "  gke-gcloud-auth-plugin is installed at ${found} but not on PATH."
+    warn "  hack/e2e.sh finds it anyway. To use kubectl against GKE by hand, add:"
+    warn "    export PATH=\"${found}:\$PATH\""
+  else
+    fail "gke-gcloud-auth-plugin is not installed. kubectl cannot authenticate to GKE.
+  gcloud components install gke-gcloud-auth-plugin"
+  fi
+fi
+
 bold "==> account and project"
 account="$(gcloud config get-value account 2>/dev/null || true)"
 [[ -n "$account" && "$account" != "(unset)" ]] || fail "not logged in. Run: gcloud auth login"
@@ -72,32 +95,56 @@ bold "==> quota for ${NODES} × ${MACHINE} Spot in ${ZONE}"
 # CPU quota of zero, and the cluster create then fails several minutes in with a
 # message about "PREEMPTIBLE_CPUS" that reads like a bug in the script.
 region="${ZONE%-*}"
-spot_quota="$(gcloud compute regions describe "$region" \
-  --format='value(quotas.filter("metric:PREEMPTIBLE_CPUS").limit)' 2>/dev/null || echo "")"
 needed=$(( NODES * 2 ))   # e2-medium is 2 vCPU
-if [[ -z "$spot_quota" ]]; then
-  warn "  could not read PREEMPTIBLE_CPUS quota for ${region}; the run may still work"
-elif (( ${spot_quota%.*} < needed )); then
-  warn "  PREEMPTIBLE_CPUS in ${region} is ${spot_quota%.*}, and ${NODES} × ${MACHINE} needs ${needed}."
-  warn "  Request more at https://console.cloud.google.com/iam-admin/quotas, or run with"
-  warn "  fewer/smaller nodes:  AGENTS=2 GCP_MACHINE=e2-small make cloud-e2e"
+
+# Read the quotas out of JSON rather than a --format filter expression. The
+# filter form returned nothing here and the check reported "could not read",
+# which is how a limit of zero got waved through into a cluster create that
+# would have failed several minutes later.
+quota_json="$(gcloud compute regions describe "$region" --format=json 2>/dev/null || echo '{}')"
+read -r SPOT_LIMIT ONDEMAND_LIMIT <<<"$(printf '%s' "$quota_json" | python3 -c '
+import json, sys
+try:
+    q = {x["metric"]: x["limit"] for x in json.load(sys.stdin).get("quotas", [])}
+except Exception:
+    q = {}
+print(int(q.get("PREEMPTIBLE_CPUS", -1)), int(q.get("CPUS", -1)))
+')"
+
+if [[ "${SPOT_LIMIT:--1}" -ge "$needed" ]]; then
+  green "  ${SPOT_LIMIT} preemptible vCPUs available, ${needed} needed — Spot will be used"
+elif [[ "${ONDEMAND_LIMIT:--1}" -ge "$needed" ]]; then
+  # The common case on a new project: Spot quota starts at zero and has to be
+  # requested. On-demand for twenty-five minutes is a few cents, so falling
+  # back beats blocking on a quota request.
+  warn "  preemptible vCPU quota in ${region} is ${SPOT_LIMIT}, and ${needed} are needed."
+  warn "  On-demand quota is ${ONDEMAND_LIMIT}, so the run will use on-demand nodes instead."
+  warn "  That is roughly 7 cents for a 25 minute run rather than 2. To use Spot,"
+  warn "  request PREEMPTIBLE_CPUS at https://console.cloud.google.com/iam-admin/quotas"
 else
-  green "  ${spot_quota%.*} preemptible vCPUs available, ${needed} needed"
+  fail "neither preemptible (${SPOT_LIMIT}) nor on-demand (${ONDEMAND_LIMIT}) vCPU quota in
+  ${region} covers the ${needed} vCPUs this needs. Request more, or run smaller:
+    AGENTS=2 GCP_MACHINE=e2-small make cloud-e2e"
 fi
 
 bold "==> budget alert"
+# Every gcloud call below runs with stdin closed. The Billing Budgets API is
+# often not enabled on a new project, and gcloud responds by prompting to
+# enable it — which, in a non-interactive script, is an indefinite hang rather
+# than an error. This section is a nicety; it must never block the run.
+exec 3<&0
 # Cheap insurance against the one real failure mode: a cluster left running.
 ba="$(gcloud billing projects describe "$project" \
-  --format='value(billingAccountName)' 2>/dev/null || true)"
+  --format='value(billingAccountName)' </dev/null 2>/dev/null || true)"
 if [[ -z "$ba" ]]; then
   warn "  could not read the billing account; skipping"
 elif gcloud billing budgets list --billing-account="${ba##*/}" \
-       --format='value(displayName)' 2>/dev/null | grep -q "dencer-e2e"; then
+       --format='value(displayName)' </dev/null 2>/dev/null | grep -q "dencer-e2e"; then
   green "  already set"
 elif [[ "$CHECK_ONLY" == "1" ]]; then
   warn "  no dencer-e2e budget alert"
 else
-  if gcloud billing budgets create --billing-account="${ba##*/}" \
+  if gcloud billing budgets create --billing-account="${ba##*/}" </dev/null \
        --display-name="dencer-e2e" \
        --budget-amount="${BUDGET}USD" \
        --threshold-rule=percent=0.5 --threshold-rule=percent=1.0 \


### PR DESCRIPTION
kubectl cannot authenticate to GKE without `gke-gcloud-auth-plugin`. The Homebrew cask installs it *with* the SDK and links `gcloud` into `bin`, but leaves components behind in `share/google-cloud-sdk/bin` — so the plugin is **present, installed, and invisible**.

## Why this one is nastier than a missing binary usually is

The first few kubectl calls **succeed**, on the short-lived token `get-credentials` leaves in the kubeconfig. So the namespace and PodSecurity steps pass, and only a later call fails:

```
==> multi-node cluster (gke)        5 nodes          ✓
==> namespace with PodSecurity      enforced         ✓
==> images                          ghcr :0.2.0      ✓
==> real workloads
    Unable to connect to the server: getting credentials:
    exec: executable gke-gcloud-auth-plugin not found
```

It reads as something breaking *mid-run* rather than a prerequisite never met — and by then the run has spent five minutes and real money building a cluster.

## The fix

- `e2e.sh` locates the plugin across the usual install layouts and puts it on `PATH` for the run
- `gke-setup` checks it **first**, ahead of account and billing, because it's the prerequisite most likely to be missing and the one whose symptom points least clearly at its cause

It warns rather than fails when the plugin exists but is unlinked, since the run works either way and only manual `kubectl` needs the export:

```
==> kubectl can authenticate to GKE
  gke-gcloud-auth-plugin is installed at /opt/homebrew/share/google-cloud-sdk/bin but not on PATH.
  hack/e2e.sh finds it anyway. To use kubectl against GKE by hand, add:
    export PATH="/opt/homebrew/share/google-cloud-sdk/bin:$PATH"
```

Stacks cleanly on #37 and #38; branched from `main` so it can merge in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)