### PR TITLE
M24: show that a node is cordoned, and open the milestone for live state

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -53,11 +53,42 @@ estimated — every milestone here starts from a number in
 | **M21b** | Real ingress controller and StorageClass, exercised in the e2e | **done** |
 | **M22** | Reclamation loop — observe whether a drained node was actually removed | **done** |
 | **M23** | Cloud test on GKE — `make cloud-e2e`, so a real cluster autoscaler reclaims the node | **done** |
+| **M24** | The field shows what *is*, not only what *would be* — live cluster state beside the plan | in progress |
 
 High availability and a Postgres store were **dropped, not deferred**: a
 consolidation planner is not a serving path. The run queue is already crash-safe
 and resumes, the planner replans on restart, and a minute of UI downtime costs
 nothing.
+
+### M24 — live reality in the field
+
+The packing field draws the plan. Everything on it — a node emptying, a box
+going dim — is the scrubber simulating a step, and it is honest about being a
+simulation. What it cannot do is show what is *actually true right now*.
+
+Found the obvious way: a node was drained on a real cluster, `kubectl` reported
+`SchedulingDisabled`, and the UI looked exactly as it had before. `cordoned`
+was parsed into the model and rendered nowhere, so the only way to see a drain
+was to scrub forward into a prediction that happened to match reality.
+
+That is the same confusion between predicted and observed that the reclamation
+loop existed to remove, surviving one layer up in the view.
+
+| Gap | Today |
+|---|---|
+| **Cordoned** | in the model, drawn nowhere |
+| **Node conditions** | a node going `NotReady` mid-drain is invisible |
+| **Where pods actually are** | the field draws the plan's placement; during a run the two diverge |
+| **Reclamation per node** | only a tray tally; the node that is awaiting is not marked |
+| **Freshness** | the snapshot is as old as the last plan, and nothing says so |
+
+The shape, not yet the design: the field's step 0 should be *live state* rather
+than the plan's snapshot of it, with the plan drawn over it as an overlay that
+is visibly an overlay. Observed and predicted must be distinguishable at a
+glance without reading a label — and without colour, which on this surface
+means risk and nothing else.
+
+First slice shipped: cordoned nodes render as cordoned, hatched and labelled.
 
 Deferred: scheduled automatic execution and multi-agent orchestration.
 

--- a/ui/src/components/PackingField.tsx
+++ b/ui/src/components/PackingField.tsx
@@ -221,6 +221,12 @@ export default function PackingField({
                 key={node.id}
                 className={[
                   "box",
+                  // Actually cordoned, right now, according to the cluster —
+                  // as distinct from box-reclaimed, which is what the plan
+                  // *would* do at the scrubber's current position. The field
+                  // showed only the prediction, so a node you had genuinely
+                  // just drained looked identical to an untouched one.
+                  node.cordoned ? "box-cordoned" : "",
                   gone ? "box-reclaimed" : "",
                   selectedNode === node.name ? "box-selected" : "",
                   stepTarget === node.name ? "box-targeted" : "",
@@ -248,11 +254,20 @@ export default function PackingField({
                   }
                 }}
                 aria-label={`${node.name}, ${Math.round(fill * 100)} percent requested, ${count} pods${
-                  gone ? ", reclaimed" : ""
-                }`}
+                  node.cordoned ? ", cordoned" : ""
+                }${gone ? ", reclaimed" : ""}`}
               >
                 <div className="box-head">
                   <span className="box-name mono">{shortName(node.name)}</span>
+                  {/* The word, not just the hatching. Colour is reserved for
+                      risk on this surface, so a state has to be legible
+                      without it — and "cordoned" is a fact an operator needs
+                      to read, not infer from a texture. */}
+                  {node.cordoned && !gone && (
+                    <span className="box-cordoned-tag mono" title="Cordoned: unschedulable">
+                      cordoned
+                    </span>
+                  )}
                   <span className="box-pct num">
                     {gone ? "—" : `${Math.round(fill * 100)}`}
                   </span>

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1770,3 +1770,32 @@
   color: var(--graphite-dim);
   font-size: var(--text-xs);
 }
+
+/* A node that is cordoned in the cluster right now.
+   Distinct from .box-reclaimed, which reflects the plan at the scrubber's
+   position — one is what happened, the other is what would. Conflating them is
+   how the field managed to show nothing after a real drain.
+   Hatching rather than a hue: colour on this surface means risk, and being
+   unschedulable is a state, not a danger. */
+.box-cordoned {
+  border-style: dashed;
+  border-color: var(--border-strong);
+  background-image: repeating-linear-gradient(
+    135deg,
+    transparent,
+    transparent 5px,
+    var(--edge-soft) 5px,
+    var(--edge-soft) 10px
+  );
+}
+
+.box-cordoned-tag {
+  margin-left: auto;
+  padding: 0 var(--space-1);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  font-size: 0.55rem;
+  letter-spacing: 0.04em;
+  color: var(--graphite);
+  text-transform: uppercase;
+}


### PR DESCRIPTION
Found the obvious way, by you: a node was drained on a real GKE cluster, `kubectl` reported `SchedulingDisabled`, and **the UI looked exactly as it had before.**

```
gke-...-3cvs   Ready,SchedulingDisabled   10m
```

`cordoned` was parsed into the model and **rendered nowhere**. The only "drained" appearance a node box had was `box-reclaimed`, which comes from scrubbing the plan — that's what the plan *would* do at the scrubber's position, not what is true. So the only way to see a real drain was to scrub forward into a prediction that happened to match reality.

That's the same confusion between predicted and observed that the reclamation loop existed to remove, surviving one layer up in the view.

## First slice

Cordoned nodes get dashed hatching and the word `cordoned`.

Hatching rather than a hue: colour on this surface means risk, and being unschedulable is a **state, not a danger**. The word is there because a texture is something to infer and this is something to read — the same rule the risk ratings follow. `test/palette` green.

## M24, recorded

| Gap | Today |
|---|---|
| **Cordoned** | fixed here |
| **Node conditions** | a node going `NotReady` mid-drain is invisible |
| **Where pods actually are** | the field draws the plan's placement; during a run the two diverge |
| **Reclamation per node** | only a tray tally; the awaiting node isn't marked |
| **Freshness** | the snapshot is as old as the last plan, and nothing says so |

The shape, not yet the design: step 0 should be **live state** rather than the plan's snapshot of it, with the plan drawn over as a visible overlay. Observed and predicted must be distinguishable at a glance, without a label and without colour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)