### PR TITLE
The cloud claim is proven, and the findings are collected

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,11 +229,17 @@ workload came back Ready, then deletes the node and confirms the reclamation
 was observed. That is what
 [`make e2e`](hack/e2e.sh) does, and it runs on every pull request.
 
-**It has still never run against a cloud cluster.** A cloud test now exists —
-`make cloud-e2e` runs the same assertions on a throwaway GKE cluster for about
-two cents, so a real cluster autoscaler is the thing that removes the drained
-node rather than our own test script — but it is one command away, not a green
-tick. When it has been run, this paragraph will say so.
+**It has now run against a real cloud cluster.** `make cloud-e2e` stands up a
+five-node GKE cluster, installs the published images, drains a node, and then
+waits — touching nothing — while **Google's own cluster autoscaler** decides the
+node is unneeded and removes it. Observed and timed at **11m9s** on
+2026-07-31. That is the reclamation loop confirmed against a reclaimer nobody
+here wrote, which is the one thing k3d structurally cannot prove.
+
+Still unproven, and worth saying: this has not run against anyone's
+*production* cluster, only a throwaway one. Workload Identity and IRSA remain
+half-tested — the chart's annotations render and are accepted, but k8s-dencer
+makes no cloud API calls, so there is no credential path to exercise.
 
 Treat the read-only path as ready to try, and the executor as something to
 enable deliberately, on something you can afford to be wrong about.

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@
 | **[Running the cloud test on GCP](gcp-setup.md)** | Account, project, billing, quota — everything to do by hand, once |
 | **[Development](development.md)** | The local loop, the KWOK fake-node fabric, the CI gates, and cutting a release |
 | **[Benchmarks](benchmarks.md)** | Measured cost per operation, and where each stage stops being usable |
+| **[Findings](findings.md)** | Bugs and gaps found by running it — what hid, and why |
 | **[Roadmap and status](roadmap.md)** | What is built, what is planned, and what was dropped |
 | **[Security policy](../SECURITY.md)** | Reporting a vulnerability, and what is in scope |
 | **[Design document](k8s-consolidation-agent-architecture.md)** | The original architecture and the reasoning behind it |

--- a/docs/findings.md
+++ b/docs/findings.md
@@ -1,0 +1,129 @@
+# Findings
+
+Bugs and gaps found by running the thing, kept together because the pattern
+matters more than any single entry.
+
+Almost none of these were found by reading code. They were found by putting the
+product on a cluster it had not met, or by a person looking at a screen and
+saying *"I don't see it."* The ones that stayed hidden longest were the ones
+where **something reported success while doing nothing** — a test that could not
+fail, a check whose own reader was broken, a payload field nothing consumed.
+
+## Fixed
+
+### Things that reported success while doing nothing
+
+| What | Why it hid |
+|---|---|
+| `kubectl auth can-i create pods/eviction` in NOTES.txt | Answers "no" for everyone without `--subresource=eviction`. In the repo since Phase 1 and **could never have failed.** |
+| A readiness lint assertion | The profiles it checked had the executor off, so nothing rendered and nothing was asserted. |
+| A recovery-comparison fixture | Nothing in it was ever Ready, so the comparison was vacuous. |
+| Two of four new chart assertions | One matched a *commented-out* registration; the other matched `health.Register(mux)` instead of the metrics one. Caught by mutating the source and checking each actually failed. |
+| The Spot-quota check | Written specifically to catch a zero quota, it used a `gcloud --format` filter that returns nothing, reported "could not read", and waved the failure through into a five-minute cluster create. |
+
+**The habit that catches these:** after writing a guard, break the thing it
+guards and confirm it screams. Every assertion above passed until it was
+deliberately attacked.
+
+### Predictions presented as outcomes
+
+The product's central claim was a guess wearing the clothes of a measurement.
+
+- **`"15 reclaimable"`** came from counting plan steps. The UI marked a node
+  `box-reclaimed` from `steps[].targetNode <= step`. **Nothing anywhere checked
+  whether a single node ever went away** — and on the KWOK fabric none ever do.
+  Fixed by the reclamation loop: *reclaimable → awaiting → reclaimed | returned*.
+- **`Stats.Reclaimed` → `Reclaimable`**, since it always described what a plan
+  *would* free.
+- **A drained node looked untouched in the UI.** `cordoned` was parsed into the
+  model and rendered nowhere, so the only way to see a real drain was to scrub
+  into a prediction that happened to match reality. First slice fixed; the rest
+  is [M24](roadmap.md).
+
+### Data shipped that nothing read
+
+- **45% of the graph payload was edges** — move, anti-affinity, PDB — unread
+  since M11 replaced the node-link graph. Building the PDB edges also walked
+  every pod for every PDB, so they were a quadratic term as well as dead weight.
+- `utilization`, `drained`, `targetNode`, `moveStep`, then `nodesAfter`,
+  `cpuReclaimedMilli`, `memoryReclaimedBytes`.
+- A guard now parses the payload struct and fails on any field the UI never
+  reads — **and the reverse**, on any `api.ts` field the payload stopped
+  sending, because every field is optional and a stale declaration reads as
+  `undefined` rather than failing to compile. That reverse check caught eight
+  fields immediately, and would have caught the `Reclaimable` rename shipping
+  as a blank headline figure.
+
+### Deployment and delivery
+
+- **`index.html` had no `Cache-Control`.** Browsers cached it heuristically, and
+  since it names the hashed asset files, a stale copy pinned the browser to the
+  *previous release*. Every UI deploy was invisible to a returning tab. The
+  nginx comment already said the entry HTML is not immutable; only the assets
+  half had been implemented.
+- **`make help` hid every target with a digit** — its regex was `[a-zA-Z_-]+`,
+  so `e2e` was invisible from the day it was added.
+- **The chart described a product from Phase 1**: *"read-only: it plans and
+  explains, it never evicts"*, twelve milestones after execution shipped, in the
+  text Artifact Hub renders.
+
+### Cloud, on first contact
+
+Everything here was found within one hour of a real GCP project existing.
+
+- **`gke-gcloud-auth-plugin` present, installed, and invisible.** Homebrew links
+  `gcloud` but leaves components off `PATH`. The failure is worse than a missing
+  binary: the first kubectl calls *succeed* on the token `get-credentials`
+  leaves behind, so a run gets five minutes and a built cluster in before
+  failing in a way that looks like a mid-run break.
+- **A new project's `PREEMPTIBLE_CPUS` quota is zero.** Normal, not a
+  misconfiguration. Now falls back to on-demand rather than blocking.
+- **`gke-setup` hung ten minutes** on a budget alert: gcloud prompts to enable
+  the Billing Budgets API and waits on stdin that never comes.
+- **`e2e.sh clean` never worked** — it called `cluster_delete` seventy lines
+  before the function was defined.
+- **The chart refused `image.tag: latest`**, correctly. The GKE path was
+  defaulting to it.
+
+### Rails that looked like failures
+
+Worth recording because each cost time before being understood as correct:
+
+- **`MinReadyNodes`** refused to drain 1 of 3 nodes. The fix was five nodes, not
+  a lowered floor — a test that weakens a safety rail is testing a
+  configuration nobody runs.
+- **`minNodeAge`** produced no plan at all on a fresh cluster. It will not touch
+  a node younger than ten minutes, which means **a newly built cluster shows
+  nothing for ten minutes and looks broken.**
+- **A `kube-system` pod without a PDB** pins its node and the autoscaler
+  correctly refuses to remove it.
+
+### Mistakes made while working, and what stopped them recurring
+
+- **An unpinned `helm upgrade` hit the GKE cluster** and killed a run in
+  progress. `get-credentials` makes its context *current*, silently redirecting
+  every terminal on the machine. Fixed twice over: the run hands the context
+  straight back, and `make deploy` refuses any non-local context.
+- **A running script was edited.** Bash reads lazily by byte offset, so a mid-run
+  edit can execute garbage — on this script, possibly skipping the teardown that
+  stops a cluster billing. Caught by luck; restored byte-for-byte.
+- **Image tag drift**, repeatedly: `IMAGE_TAG` is content-hashed, so editing a
+  file between `make images` and `make deploy` produces `ImagePullBackOff`.
+
+## Open
+
+| Gap | Where |
+|---|---|
+| **M24 — live state in the field** | node conditions, actual pod placement during a run, per-node reclamation, snapshot freshness |
+| **Karpenter / cluster-autoscaler detection** | deliberately skipped: warn *before* draining that nothing will remove the node |
+| **Never run against a production cluster** | a throwaway GKE cluster is not someone's estate |
+| **Workload Identity / IRSA half-proven** | annotations render and are accepted; k8s-dencer makes no cloud API calls, so no credential path is exercised |
+| **The `returned` branch is k3d-only** | uncordoning races a real autoscaler |
+| **Community files** | `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `GOVERNANCE.md` — `SECURITY.md` and `LICENSE` exist |
+
+Dropped by decision: Postgres and HA. Deferred: scheduled automatic execution,
+multi-agent orchestration.
+
+---
+
+[← Documentation index](README.md) · [Project README](../README.md)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -52,7 +52,7 @@ estimated — every milestone here starts from a number in
 | **M21** | Multi-node k3d e2e in CI, PodSecurity **enforcing**, `readiness: Ready` on real pods | **done** |
 | **M21b** | Real ingress controller and StorageClass, exercised in the e2e | **done** |
 | **M22** | Reclamation loop — observe whether a drained node was actually removed | **done** |
-| **M23** | Cloud test on GKE — `make cloud-e2e`, so a real cluster autoscaler reclaims the node | **done** |
+| **M23** | Cloud test on GKE — GKE's autoscaler reclaimed a drained node in **11m9s**, observed | **done** |
 
 High availability and a Postgres store were **dropped, not deferred**: a
 consolidation planner is not a serving path. The run queue is already crash-safe


### PR DESCRIPTION
## The README can stop hedging

It said this had never run against a cloud cluster. It has:

```
==> GKE's own cluster autoscaler removes it
    Nothing here touches the node. GKE decides, on its own schedule.
    observed as reclaimed after 11m9s — by a reclaimer we did not write
```

That's the reclamation loop confirmed against a reclaimer nobody here wrote — the one thing k3d structurally cannot prove.

What stays unproven is now narrower **and stated as such**: a throwaway cluster is not someone's production estate, and Workload Identity remains half-tested because the product makes no cloud API calls for a credential to authenticate.

## `docs/findings.md`

Everything found by running this, in one place — because the pattern across them matters more than any single entry.

**Almost none were found by reading code.** They were found by putting the product on a cluster it hadn't met, or by a person looking at a screen and saying *"I don't see it."*

The ones that hid longest share a shape: **something reported success while doing nothing.**

| | |
|---|---|
| `kubectl auth can-i create pods/eviction` | answers "no" for everyone without `--subresource` — in the repo since Phase 1, **could never fail** |
| A readiness lint assertion | its profiles had the executor off, so nothing rendered and nothing was asserted |
| The Spot-quota check | its own reader was broken, so it waved through the failure it existed to catch |
| Two of four new chart assertions | one matched a *commented-out* line, one matched the wrong `Register` call |
| 45% of the graph payload | edges nothing had read since M11 |

Plus: predictions presented as outcomes, data shipped that nothing read, the `index.html` caching bug that made every deploy invisible, everything cloud broke on first contact, the safety rails that looked like failures and weren't, and the mistakes I made mid-session with what now prevents them.

Six gaps stay open, listed at the end — M24, autoscaler detection, production, Workload Identity, the k3d-only `returned` branch, and community files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)