### PR TITLE
Stop Dependabot proposing majors it cannot land

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -67,6 +67,18 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
     groups:
+      # react and react-dom are version-locked to each other and to their
+      # @types, exactly as the Kubernetes libraries are. Ungrouped, Dependabot
+      # split them across two PRs and each failed with ERESOLVE before any code
+      # was compiled — @types/react@19 meeting @types/react-dom@18. The failure
+      # looked like a breaking upgrade and was really a broken split.
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+
       # The bundled typefaces are a deliberate, pinned choice — Archivo and IBM
       # Plex, latin subsets only, vendored so an air-gapped cluster still gets
       # designed type. Grouped so a font bump is visibly a font bump rather
@@ -75,7 +87,12 @@ updates:
         patterns: ["@fontsource*"]
       npm-minor-and-patch:
         patterns: ["*"]
-        exclude-patterns: ["@fontsource*"]
+        exclude-patterns:
+          - "@fontsource*"
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
         update-types: [minor, patch]
 
   # -------------------------------------------------------- GitHub Actions

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,13 @@ updates:
       timezone: Etc/UTC
     open-pull-requests-limit: 5
     labels: [dependencies, go]
+    # Majors are not proposed at all, rather than merely kept out of the groups.
+    # Excluding them from a group only changes how they arrive: they still open,
+    # one PR each, and sit red. A Go major is an import path change; it wants a
+    # person choosing to do it, on a branch where the compiler can argue back.
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     groups:
       # The Kubernetes libraries are version-locked to each other: client-go
       # v0.36 expects apimachinery v0.36, and controller-runtime pins its own
@@ -51,6 +58,14 @@ updates:
       timezone: Etc/UTC
     open-pull-requests-limit: 5
     labels: [dependencies, ui]
+    # Same rule, and here it is not theoretical. The first Dependabot run
+    # opened five npm majors — typescript 5.9 to 7.0, vite 6 to 8, react,
+    # react-dom, plugin-react — and every one failed the typecheck and build,
+    # while all three grouped minor/patch PRs passed. Five red PRs nobody
+    # asked for is how a team learns to stop reading Dependabot.
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     groups:
       # The bundled typefaces are a deliberate, pinned choice — Archivo and IBM
       # Plex, latin subsets only, vendored so an air-gapped cluster still gets


### PR DESCRIPTION
The config *said* a major deserves a person deciding to do it — and then didn't arrange for that. **Excluding majors from a group only changes how they arrive**; they still open, one PR each.

The first run proved it immediately:

| | |
|---|---|
| #42 base-images, #43 go minor/patch, #47 actions — **grouped** | ✅ all pass |
| #44 react, #45 typescript 5.9→**7.0**, #46 vite 6→**8**, #48 plugin-react, #49 react-dom — **majors** | ❌ all fail typecheck + build |

Five failing PRs nobody asked for is how a team learns to stop reading Dependabot, which costs more than any of those upgrades were worth.

Majors now ignored outright on `gomod` and `npm`. **Actions and Docker still take them** — an action major is a workflow change CI proves in the same run, and a base-image major is precisely what image updates are for.

One trap worth noting: `update-types` needed quoting. Unquoted, `version-update:semver-major` parses as a *mapping* rather than a string and the whole file becomes invalid. Caught by validating the YAML rather than by watching Dependabot silently ignore a broken config.

Once this merges, #44–#46 and #48–#49 should be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)