### PR TITLE
Document what shipped today but never reached the docs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -158,6 +158,18 @@ The graph payload is shaped for Cytoscape's compound-node model — cluster node
 make ui     # port-forwards and prints the URLs
 ```
 
+**A header carries the context, quietly.** Which cluster (`uiBackend.clusterLabel`,
+empty by default) and the identity the API server verified — plus sign-out and a
+dark/light toggle. Dark is the default rather than following the OS: the ground
+going black is what leaves a saturated rating as the only lit thing on the
+surface, and that is the premise the whole palette rests on.
+
+**Cordoned is drawn, because reality and prediction are different things.** A
+node cordoned in the cluster right now gets dashed hatching and the word; a node
+the *plan* would drain at the scrubber's position gets the reclaimed treatment.
+Conflating them is how the field once showed nothing at all after a real drain
+— see [M24](roadmap.md), which is about closing the rest of that gap.
+
 **The capacity ribbon is the page's argument.** One bar per node, ordered fullest-first, filled to requested CPU — the long tail of barely-used bars *is* the case for consolidating. Dragging the scrubber drains them in place. A big number over a small label was the first draft; it states a conclusion where the evidence should be, so the only display-size figure now sits inside a sentence that gives it meaning.
 
 **One morphing canvas, not two before/after panes.** Scrubbing shows the same comparison plus every intermediate state, and makes the causality visible — this pod leaves, so this node empties. Two half-width panes of 30 nodes would be unreadable, and the ribbon already does the at-a-glance job.

--- a/docs/development.md
+++ b/docs/development.md
@@ -30,6 +30,22 @@ make demo CLUSTER_PROVIDER=k3d
 
 ---
 
+## make deploy refuses a non-local cluster
+
+`make deploy` builds unqualified local image tags, which mean nothing outside a
+local cluster. That was harmless until a GKE path existed — then
+`gcloud container clusters get-credentials` began making its context *current*,
+silently redirecting a deploy typed in another terminal.
+
+It happened: a `helm upgrade` landed on a live GKE test cluster, installed tags
+no registry had, and killed the run it was supposed to be unrelated to. The
+target now refuses anything that is not a recognisable local context, names
+what it found, and prints the way back. `ALLOW_ANY_CONTEXT=1` overrides it.
+
+The cloud run no longer hijacks the context either: it hands it straight back
+after `get-credentials` and addresses its cluster by `--context` throughout, so
+you can keep working locally while it runs.
+
 ## End-to-end
 
 ```bash

--- a/docs/install.md
+++ b/docs/install.md
@@ -67,7 +67,22 @@ Runs `helm lint` and `kubeconform --strict` across every profile, then asserts t
 20. scraping **does not give the executor a Service** — planner and executor stay reachable only as pods
 21. enabling `serviceMonitor` makes the NetworkPolicy **admit the monitoring namespace**, or the scrape is silently dropped
 
-### Known constraints
+### Naming the cluster in the UI
+
+```yaml
+uiBackend:
+  clusterLabel: prod-eu-west-1
+```
+
+Shown in the UI header so an operator can see which cluster they are about to
+act on. **Empty by default, and the header then shows nothing.** Nothing in a
+cluster reliably names itself, and a guessed environment label is worse than
+none — the entire value of this field is being believed when it says `prod`.
+
+Beside it the header shows the identity the API server verified through
+`TokenReview`, not a claim decoded from whatever token the page is holding.
+
+## Known constraints
 
 - **SQLite is single-writer.** `uiBackend.replicaCount` is pinned to 1 and enforced by the schema; the planner is co-scheduled with ui-backend via a `requiredDuringScheduling` podAffinity, because a ReadWriteOnce claim only permits multiple pods on the same node. Both constraints disappear when the Postgres store lands.
 - **PDBs use `maxUnavailable`, never `minAvailable`.** A `minAvailable` PDB on a single-replica Deployment makes its own pod undrainable — the exact pathology this product exists to detect.


### PR DESCRIPTION
An audit for stale claims turned up little — "planned", "never run against a production cluster" are all still accurate. What it *did* turn up is four things live in the product and documented nowhere:

| | Now in |
|---|---|
| `uiBackend.clusterLabel` | `docs/install.md` |
| The verified identity beside it | `docs/install.md` |
| Theme toggle + dark default | `docs/architecture.md` |
| `make deploy`'s context guard | `docs/development.md` |

**The guard earns a section rather than a line.** It exists because a `helm upgrade` typed in one terminal landed on a GKE cluster another was testing — `get-credentials` makes its context current without saying so. Someone will hit the refusal and deserves to find out *why it's there*, not just how to switch it off.

`architecture.md` also now records that cordoned is drawn, and why it's drawn differently from the plan's own idea of a drained node. Reality and prediction being distinct is the whole of M24, and the file explaining the field should say so.

Also checked and clean: no GCP credentials, project IDs, billing accounts or tokens anywhere in the repo or its full git history. The only identifiers are your email in `SECURITY.md` and `Chart.yaml` — both deliberate and required — and AWS's own `123456789012` docs placeholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)