### PR TITLE
Three renderings of the field, chosen by cluster size

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -54,6 +54,7 @@ estimated — every milestone here starts from a number in
 | **M22** | Reclamation loop — observe whether a drained node was actually removed | **done** |
 | **M23** | Cloud test on GKE — GKE's autoscaler reclaimed a drained node in **11m9s**, observed | **done** |
 | **M24** | The field shows what *is*, not only what *would be* — live cluster state beside the plan | in progress |
+| **M25** | Closed-loop consolidation — re-plan from observed state after every step, instead of executing a forecast | planned |
 
 High availability and a Postgres store were **dropped, not deferred**: a
 consolidation planner is not a serving path. The run queue is already crash-safe
@@ -80,7 +81,8 @@ loop existed to remove, surviving one layer up in the view.
 | **Node conditions** | a node going `NotReady` mid-drain is invisible |
 | **Where pods actually are** | the field draws the plan's placement; during a run the two diverge |
 | **Reclamation per node** | only a tray tally; the node that is awaiting is not marked |
-| **Freshness** | the snapshot is as old as the last plan, and nothing says so |
+| **Freshness** | the snapshot is as old as the last plan, and the warning fires backwards — see below |
+| **One dimension of three** | the headline fullness figure is CPU alone, while the planner packs on the worst of CPU, memory and pod slots |
 
 The shape, not yet the design: the field's step 0 should be *live state* rather
 than the plan's snapshot of it, with the plan drawn over it as an overlay that
@@ -90,7 +92,106 @@ means risk and nothing else.
 
 First slice shipped: cordoned nodes render as cordoned, hatched and labelled.
 
+#### The staleness warning fires backwards
+
+Past five minutes the verdict line reads *"confirmed 5 minutes ago — the cluster
+may have moved on."* It is not a cosmetic complaint that this looks unfinished:
+**the warning appears precisely when the cluster has not moved on.**
+
+`collect()` returns early when `db.Save` reports the same content hash as the
+previous cycle — the correct thing to do for storage, but it also skips the
+publish, so SSE subscribers hear nothing. On a stable cluster the planner keeps
+snapshotting every 30 seconds and confirming the plan still holds, and says so
+to no one. The UI ticks a clock against `generatedAt`, watches it climb, and
+eventually apologises. Stability is rendered as doubt.
+
+The fix is to stop conflating two different facts:
+
+| Fact | Ages when |
+|---|---|
+| `generatedAt` — when this plan was computed | a new plan is produced |
+| `confirmedAt` — when the cluster was last observed to still match it | **every successful cycle**, published whether or not the plan changed |
+
+The age line reads `confirmedAt`. On a stable cluster it says *confirmed just
+now*, indefinitely, which is true. It only warns when confirmations actually
+stop — the planner wedged, snapshots failing, SSE dropped — which is the one
+case where the operator genuinely should not trust the screen, and the one case
+that is invisible today.
+
+#### Fullness is three dimensions, and the field shows one
+
+`Resources.Fits` checks CPU, memory **and** pod slots; the planner ranks nodes
+by `DominantRatio`, the worst of the three, because that is the dimension that
+actually limits packing. The agent tool reports that number. The planner logs
+`cpuRequestedPct` and `memRequestedPct` side by side. The Inspector shows both
+when a node is opened.
+
+The field's headline figure — the box gauge, the well level, the panel bar, the
+number an operator actually scans — is CPU alone. A memory-bound node reads as
+half empty on a screen whose own planner will refuse to pack it. The two
+surfaces of the same product disagree about how full a node is.
+
+The data is already on the wire (`memAllocatable`, `memRequested`) and already
+in the client model. What changes is which number is drawn: the dominant ratio,
+with the binding dimension named.
+
 Deferred: scheduled automatic execution and multi-agent orchestration.
+
+### M25 — closed-loop consolidation
+
+Today a plan is computed once against one snapshot, and steps 2..N assume steps
+1..N-1 landed exactly as predicted. They may not have, because **the plan does
+not tell the scheduler anything.**
+
+That is worth stating precisely, because the code is already more honest than
+the interface. Every consumer of `step.Moves` was checked: the planner writes
+it, the CLI, graph API and impact classifier read it, and the **executor never
+reads it at all.** It cordons `step.TargetNode` and evicts whatever movable pods
+are genuinely there; where they land is kube-scheduler's decision. Destinations
+are advisory in the engine and drawn as fact in the UI.
+
+The sequence is the real gap. The executor is careful — it re-runs the safety
+guard against freshly-read state before every step, waits for evicted pods to
+recover, and verifies they landed — but its answer to divergence is **abort,
+not re-plan**. So a run that a fresh plan would happily continue is thrown away,
+and a better target appearing mid-run is never noticed.
+
+The loop this replaces the forecast with:
+
+```
+observe → plan one step → gate → execute → settle → observe → …
+```
+
+Two things decide whether this is sound, and both are design, not plumbing:
+
+**Termination.** Re-planning after every step can oscillate: drain A, the
+scheduler fills B, now B looks drainable. Three rails together — each round must
+*strictly reduce the node count* or the loop stops; a node returned to service
+during a run is never re-targeted by that run; and a hard round cap above both,
+so a bug costs a bounded number of evictions rather than a walk across the
+estate.
+
+**What the operator approved.** Today they approve a concrete list of nodes.
+Under continuous re-planning they would be approving a *policy* — "keep going
+until optimum" — and for a product whose entire pitch is *a human approves
+before pods are evicted*, that cannot change silently. The consent becomes an
+explicit envelope: up to N nodes, inside this window, at or below a stated
+impact rating. Re-plan freely within it; anything outside needs a new approval.
+
+The UI follows from that. Step 1 is a commitment and the rest is a projection
+with a shrinking horizon, and the two must not be drawn the same way — which is
+the same rule M24 is already establishing for observed versus predicted.
+
+Verification, in the order that matters:
+
+- an oscillation fixture — draining A makes B drainable and vice versa — that
+  asserts the loop **terminates**, because a plausible-looking implementation
+  that never halts is the failure mode here
+- monotonic decrease asserted per round, and the envelope asserted never
+  exceeded, including when a re-plan wants to
+- KWOK end-to-end: run to fixpoint and compare the result against what the
+  one-shot plan predicted, which finally measures the gap this milestone exists
+  to close
 
 ## What actually runs today
 

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -8,6 +8,7 @@ import { SignIn } from "./components/SignIn";
 import StepLedger from "./components/StepLedger";
 import Verdict from "./components/Verdict";
 import AppBar from "./components/AppBar";
+import { FieldView, defaultView, rememberView, storedView } from "./view";
 import { authInfo, token as tokenStore } from "./auth";
 import { onRenewed } from "./oidc";
 import { runtimeConfig } from "./runtime-config";
@@ -34,6 +35,9 @@ export default function App() {
   // Identity and cluster, for the header. Fetched once — neither changes
   // within a session, and re-polling them would be noise.
   const [server, setServer] = useState<VersionResponse | null>(null);
+
+  // null means "follow cluster size", which is right until someone disagrees.
+  const [viewPref, setViewPref] = useState<FieldView | null>(storedView);
   useEffect(() => {
     let cancelled = false;
     api
@@ -191,12 +195,22 @@ export default function App() {
     setSelection(key ? { kind: "pod", key } : null);
   }, []);
 
+  // Node count drives the default: individual pods stop being worth drawing
+  // long before a vessel per node does.
+  const nodeCount = state.status === "ready" ? (state.graph.elements.filter((e) => e.data.kind === "node").length) : 0;
+  const view: FieldView = viewPref ?? defaultView(nodeCount);
+
   const selectedNode = selection?.kind === "node" ? selection.name : null;
   const selectedPod = selection?.kind === "pod" ? selection.key : null;
 
   return (
     <div className="shell">
       <AppBar
+        view={view}
+        onView={(v) => {
+          setViewPref(v);
+          rememberView(v);
+        }}
         clusterLabel={server?.clusterLabel}
         identity={server?.identity}
         onSignOut={handleSignOut}
@@ -258,6 +272,7 @@ export default function App() {
 
           <main className="workspace">
             <PackingField
+              view={view}
               awaiting={reclaimed.awaiting}
               reclaimedForReal={reclaimed.reclaimed}
               graph={state.graph}

--- a/ui/src/components/AppBar.tsx
+++ b/ui/src/components/AppBar.tsx
@@ -17,6 +17,7 @@
 
 import { useState } from "react";
 import { Theme, applyTheme, storedTheme } from "../theme";
+import { FieldView, VIEW_LABELS } from "../view";
 
 interface Props {
   /** Operator-set. Empty renders nothing rather than a guess. */
@@ -24,9 +25,11 @@ interface Props {
   /** The identity the API server verified, not one the browser asserted. */
   identity?: string;
   onSignOut?: () => void;
+  view?: FieldView;
+  onView?: (v: FieldView) => void;
 }
 
-export default function AppBar({ clusterLabel, identity, onSignOut }: Props) {
+export default function AppBar({ clusterLabel, identity, onSignOut, view, onView }: Props) {
   return (
     <header className="appbar">
       <div className="appbar-brand">
@@ -46,6 +49,24 @@ export default function AppBar({ clusterLabel, identity, onSignOut }: Props) {
       </div>
 
       <div className="appbar-actions">
+        {view && onView && (
+          /* Three renderings of the same data, not three themes. Which one
+             suits depends mostly on cluster size, so the default follows it —
+             this is the override for when it guesses wrong. */
+          <div className="viewswitch" role="group" aria-label="Field view">
+            {(Object.keys(VIEW_LABELS) as FieldView[]).map((v) => (
+              <button
+                key={v}
+                type="button"
+                className={"viewswitch-btn" + (v === view ? " is-on" : "")}
+                aria-pressed={v === view}
+                onClick={() => onView(v)}
+              >
+                {VIEW_LABELS[v]}
+              </button>
+            ))}
+          </div>
+        )}
         <ThemeToggle />
         {identity && (
           /* The full RBAC principal, which for a ServiceAccount is long and

--- a/ui/src/components/FieldViews.tsx
+++ b/ui/src/components/FieldViews.tsx
@@ -10,10 +10,41 @@
 
 import { Model } from "../layout";
 
+/**
+ * What the fullness number actually is, said once and reused in all three views.
+ *
+ * It is *requested* CPU over allocatable — the scheduler's arithmetic, not the
+ * kernel's. That distinction is the whole product: Kubernetes packs by requests,
+ * so a node at 50% requested is half unschedulable no matter how idle its cores
+ * are, and consolidating it is a real gain. An operator reading a bare "cpu"
+ * column will assume utilisation and conclude the opposite.
+ */
+export const FILL_TITLE =
+  "Requested as a percent of allocatable, on whichever of CPU or memory is " +
+  "fuller — what the scheduler packs by, not live usage.";
+
+/** Turns the layout's per-dimension fullness into the fields a view draws. */
+export function spreadFill(f?: { cpu: number; mem: number; dominant: number; bound: "cpu" | "mem" }) {
+  return {
+    fill: f?.dominant ?? 0,
+    cpu: f?.cpu ?? 0,
+    mem: f?.mem ?? 0,
+    bound: f?.bound ?? ("cpu" as const),
+  };
+}
+
 export interface NodeDrawState {
   name: string;
-  /** 0..1, requested over allocatable, at the scrubber's current step. */
+  /**
+   * 0..1 on the dimension that limits packing — the larger of CPU and memory,
+   * matching what the planner ranks on. This is what gets drawn.
+   */
   fill: number;
+  /** The two dimensions behind `fill`, so a view can show the working. */
+  cpu: number;
+  mem: number;
+  /** Which of them `fill` came from. */
+  bound: "cpu" | "mem";
   pods: number;
   /** Cordoned in the cluster right now — observed, not predicted. */
   cordoned: boolean;
@@ -63,7 +94,9 @@ export function FieldWells({ nodes, onSelectNode }: Props) {
         >
           <span className="well-cap">
             <span className="well-name mono">{shortName(n.name)}</span>
-            <span className="well-pct num">{Math.round(n.fill * 100)}</span>
+            <span className="well-pct num" title={FILL_TITLE}>
+              {Math.round(n.fill * 100)}
+            </span>
           </span>
           <span className="well-foot mono">
             {n.cordoned ? "cordoned" : n.pods === 0 ? "empty" : `${n.pods} pods`}
@@ -95,7 +128,12 @@ export function FieldPanel({ nodes, onSelectNode }: Props) {
       <div className="panel-head">
         <span className="eyebrow">node</span>
         <span className="eyebrow">load</span>
-        <span className="eyebrow panel-r">cpu</span>
+        <span className="eyebrow panel-r" title={FILL_TITLE}>
+          cpu %
+        </span>
+        <span className="eyebrow panel-r" title={FILL_TITLE}>
+          mem %
+        </span>
         <span className="eyebrow panel-r">pods</span>
         <span className="eyebrow panel-r">state</span>
       </div>
@@ -118,7 +156,16 @@ export function FieldPanel({ nodes, onSelectNode }: Props) {
           <span className="panel-trace" aria-hidden="true">
             <span className="panel-trace-bar" style={{ width: `${Math.min(100, n.fill * 100)}%` }} />
           </span>
-          <span className="panel-pct num">{Math.round(n.fill * 100)}</span>
+          {/* Both dimensions, with the binding one lifted. Emphasis is weight
+              and brightness, never hue: on this surface a colour would read as
+              a risk rating, and "memory is the constraint here" is a fact
+              about packing, not a warning. */}
+          <span className={n.bound === "cpu" ? "panel-pct num panel-bound" : "panel-pct num"}>
+            {Math.round(n.cpu * 100)}
+          </span>
+          <span className={n.bound === "mem" ? "panel-pct num panel-bound" : "panel-pct num"}>
+            {Math.round(n.mem * 100)}
+          </span>
           <span className="panel-pods num">{n.pods}</span>
           <span className="panel-state mono">{stateWord(n)}</span>
         </button>

--- a/ui/src/components/FieldViews.tsx
+++ b/ui/src/components/FieldViews.tsx
@@ -1,0 +1,141 @@
+/**
+ * The wells and panel renderings of the field.
+ *
+ * They share everything that matters with the rack view — the same model, the
+ * same placement at the current step, the same fill, the same idea of what is
+ * cordoned and what the plan drains. Only the drawing differs. Keeping the
+ * shared parts in PackingField and passing them down is what stops three views
+ * becoming three subtly different products.
+ */
+
+import { Model } from "../layout";
+
+export interface NodeDrawState {
+  name: string;
+  /** 0..1, requested over allocatable, at the scrubber's current step. */
+  fill: number;
+  pods: number;
+  /** Cordoned in the cluster right now — observed, not predicted. */
+  cordoned: boolean;
+  /** The plan drains this node at or before the current step — predicted. */
+  drained: boolean;
+  /** This step is the one being hovered in the ledger. */
+  targeted: boolean;
+  selected: boolean;
+}
+
+interface Props {
+  nodes: NodeDrawState[];
+  model: Model;
+  onSelectNode: (name: string) => void;
+}
+
+/* ------------------------------------------------------------------ wells */
+
+/**
+ * A node as a vessel, load as a level in it.
+ *
+ * Fullness is carried by height and luminance together, which is what makes a
+ * wall of these readable without reading a single number — and why this is the
+ * view that scales. Colour stays out of it entirely; on this surface colour
+ * means risk, and how full a node is is not a risk.
+ */
+export function FieldWells({ nodes, onSelectNode }: Props) {
+  return (
+    <div className="wells">
+      {nodes.map((n) => (
+        <button
+          key={n.name}
+          type="button"
+          className={[
+            "well",
+            n.cordoned ? "well-cordoned" : "",
+            n.drained ? "well-drained" : "",
+            n.targeted ? "well-targeted" : "",
+            n.selected ? "well-selected" : "",
+          ]
+            .filter(Boolean)
+            .join(" ")}
+          onClick={() => onSelectNode(n.name)}
+          aria-label={`${n.name}, ${Math.round(n.fill * 100)} percent requested, ${n.pods} pods${
+            n.cordoned ? ", cordoned" : ""
+          }`}
+        >
+          <span className="well-cap">
+            <span className="well-name mono">{shortName(n.name)}</span>
+            <span className="well-pct num">{Math.round(n.fill * 100)}</span>
+          </span>
+          <span className="well-foot mono">
+            {n.cordoned ? "cordoned" : n.pods === 0 ? "empty" : `${n.pods} pods`}
+          </span>
+          {/* Inline height because it is data, not styling: this is the
+              measurement the view exists to show. */}
+          <span className="well-level" style={{ height: `${Math.min(100, n.fill * 100)}%` }} />
+        </button>
+      ))}
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ panel */
+
+/**
+ * One row per node, fullest first.
+ *
+ * The ordering is the argument: a long tail of barely-used nodes at the bottom
+ * of the list *is* the case for consolidating, and nobody has to be told. That
+ * is worth more here than the spatial picture, which is what this view trades
+ * away.
+ */
+export function FieldPanel({ nodes, onSelectNode }: Props) {
+  const ordered = [...nodes].sort((a, b) => b.fill - a.fill);
+
+  return (
+    <div className="panel-view">
+      <div className="panel-head">
+        <span className="eyebrow">node</span>
+        <span className="eyebrow">load</span>
+        <span className="eyebrow panel-r">cpu</span>
+        <span className="eyebrow panel-r">pods</span>
+        <span className="eyebrow panel-r">state</span>
+      </div>
+      {ordered.map((n) => (
+        <button
+          key={n.name}
+          type="button"
+          className={[
+            "panel-row",
+            n.cordoned ? "panel-row-cordoned" : "",
+            n.targeted ? "panel-row-targeted" : "",
+            n.selected ? "panel-row-selected" : "",
+          ]
+            .filter(Boolean)
+            .join(" ")}
+          onClick={() => onSelectNode(n.name)}
+          aria-label={`${n.name}, ${Math.round(n.fill * 100)} percent requested, ${n.pods} pods`}
+        >
+          <span className="panel-id mono">{shortName(n.name)}</span>
+          <span className="panel-trace" aria-hidden="true">
+            <span className="panel-trace-bar" style={{ width: `${Math.min(100, n.fill * 100)}%` }} />
+          </span>
+          <span className="panel-pct num">{Math.round(n.fill * 100)}</span>
+          <span className="panel-pods num">{n.pods}</span>
+          <span className="panel-state mono">{stateWord(n)}</span>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+/** Observed states win over predicted ones: what is beats what would be. */
+function stateWord(n: NodeDrawState): string {
+  if (n.cordoned) return "cordoned";
+  if (n.drained) return "drained";
+  if (n.pods === 0) return "empty";
+  return "";
+}
+
+/** Node names are long and share a prefix; the tail is the distinguishing part. */
+function shortName(name: string): string {
+  return name.length > 18 ? "…" + name.slice(-17) : name;
+}

--- a/ui/src/components/PackingField.tsx
+++ b/ui/src/components/PackingField.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
+import { FieldPanel, FieldWells, NodeDrawState } from "./FieldViews";
+import { FieldView } from "../view";
 import { GraphPayload, PlanStep } from "../api";
 import {
   NODE_GAP_X,
@@ -53,6 +55,8 @@ interface Props {
   onSelectPod: (key: string | null) => void;
   selectedNode: string | null;
   selectedPod: string | null;
+  /** Which rendering of the field to draw. */
+  view?: FieldView;
   /** Nodes drained earlier whose machine is still present. Observed, not planned. */
   awaiting?: number;
   /** Nodes whose Node object actually disappeared. Observed, not planned. */
@@ -68,6 +72,7 @@ export default function PackingField({
   onSelectPod,
   selectedNode,
   selectedPod,
+  view = "rack",
   awaiting = 0,
   reclaimedForReal = 0,
 }: Props) {
@@ -196,6 +201,37 @@ export default function PackingField({
     }
     return out;
   }, [model, placement, steps, step]);
+
+  const drawStates: NodeDrawState[] = useMemo(
+    () =>
+      model.nodes.map((n) => ({
+        name: n.name,
+        fill: layout.nodeFill.get(n.name) ?? 0,
+        pods: podsByNode.get(n.name) ?? 0,
+        cordoned: n.cordoned,
+        drained: reclaimed.has(n.name),
+        targeted: stepTarget === n.name,
+        selected: selectedNode === n.name,
+      })),
+    [model, layout, podsByNode, reclaimed, stepTarget, selectedNode],
+  );
+
+  if (view !== "rack") {
+    const Renderer = view === "wells" ? FieldWells : FieldPanel;
+    return (
+      <div className="field-wrap">
+        <div className="field-scroll" ref={scrollRef}>
+          <Renderer nodes={drawStates} model={model} onSelectNode={onSelectNode} />
+        </div>
+        <ReclaimedTray
+          count={reclaimed.size}
+          total={plannedDrains}
+          awaiting={awaiting}
+          reclaimedForReal={reclaimedForReal}
+        />
+      </div>
+    );
+  }
 
   return (
     <div className="field-wrap">

--- a/ui/src/components/PackingField.tsx
+++ b/ui/src/components/PackingField.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { FieldPanel, FieldWells, NodeDrawState } from "./FieldViews";
+import { FieldPanel, FieldWells, FILL_TITLE, NodeDrawState, spreadFill } from "./FieldViews";
 import { FieldView } from "../view";
 import { GraphPayload, PlanStep } from "../api";
 import {
@@ -155,8 +155,8 @@ export default function PackingField({
     [...model.nodes]
       .sort(
         (a, b) =>
-          (layout.nodeFill.get(b.name) ?? 0) -
-          (layout.nodeFill.get(a.name) ?? 0),
+          (layout.nodeFill.get(b.name)?.dominant ?? 0) -
+          (layout.nodeFill.get(a.name)?.dominant ?? 0),
       )
       .forEach((n, i) => order.set(n.name, i));
     return order;
@@ -206,7 +206,7 @@ export default function PackingField({
     () =>
       model.nodes.map((n) => ({
         name: n.name,
-        fill: layout.nodeFill.get(n.name) ?? 0,
+        ...spreadFill(layout.nodeFill.get(n.name)),
         pods: podsByNode.get(n.name) ?? 0,
         cordoned: n.cordoned,
         drained: reclaimed.has(n.name),
@@ -248,7 +248,7 @@ export default function PackingField({
             const pos = layout.nodes.get(node.id);
             if (!pos) return null;
             if (!inView(index)) return null;
-            const fill = layout.nodeFill.get(node.name) ?? 0;
+            const fill = layout.nodeFill.get(node.name)?.dominant ?? 0;
             const gone = reclaimed.has(node.name);
             const count = podsByNode.get(node.name) ?? 0;
 
@@ -304,7 +304,7 @@ export default function PackingField({
                       cordoned
                     </span>
                   )}
-                  <span className="box-pct num">
+                  <span className="box-pct num" title={FILL_TITLE}>
                     {gone ? "—" : `${Math.round(fill * 100)}`}
                   </span>
                 </div>

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1972,7 +1972,7 @@
 .panel-head,
 .panel-row {
   display: grid;
-  grid-template-columns: minmax(0, 140px) 1fr 52px 44px 84px;
+  grid-template-columns: minmax(0, 140px) 1fr 52px 52px 44px 84px;
   align-items: center;
   gap: var(--space-4);
   padding: var(--space-2) var(--space-4);
@@ -2077,10 +2077,18 @@
   background: var(--surface-3);
 }
 
+/* The dimension that actually limits packing on this node. Weight and
+   brightness only — hue on this surface means risk, and being memory-bound is
+   not a risk, it is the reason the number next door is the wrong one to read. */
+.panel-bound {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
 @media (max-width: 640px) {
   .panel-head,
   .panel-row {
-    grid-template-columns: minmax(0, 1fr) 2fr 44px;
+    grid-template-columns: minmax(0, 1fr) 2fr 44px 44px;
     gap: var(--space-2);
   }
   .panel-pods,

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1826,3 +1826,268 @@
     display: none;
   }
 }
+
+/* ===================================================== field views
+
+   Three renderings of one model. Everything they share — what is cordoned,
+   how full a node is, what the plan drains — is computed once in PackingField
+   and passed down, so they cannot drift into disagreeing. */
+
+.viewswitch {
+  display: inline-flex;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+
+.viewswitch-btn {
+  padding: var(--space-1) var(--space-3);
+  border: 0;
+  background: transparent;
+  color: var(--graphite);
+  font-size: var(--text-xs);
+  transition: background var(--step-fast) var(--ease-out),
+    color var(--step-fast) var(--ease-out);
+}
+
+.viewswitch-btn + .viewswitch-btn {
+  border-left: 1px solid var(--border);
+}
+
+.viewswitch-btn:hover {
+  color: var(--chalk);
+}
+
+.viewswitch-btn.is-on {
+  background: var(--surface-3);
+  color: var(--chalk);
+}
+
+/* ------------------------------------------------------------- wells */
+
+.wells {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(124px, 1fr));
+  gap: var(--space-3);
+  padding: var(--space-4);
+}
+
+.well {
+  position: relative;
+  height: 110px;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface-sunken);
+  overflow: hidden;
+  text-align: left;
+  transition: border-color var(--step-fast) var(--ease-out);
+}
+
+.well:hover {
+  border-color: var(--border-strong);
+}
+
+/* Height and luminance together carry fullness. Two channels rather than one
+   is what makes a wall of these readable without reading a number — and both
+   are achromatic, because colour here means risk. */
+.well-level {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: linear-gradient(
+    180deg,
+    rgba(204, 210, 218, 0.3),
+    rgba(146, 156, 170, 0.12)
+  );
+  border-top: 1px solid rgba(233, 236, 239, 0.42);
+  box-shadow: 0 -8px 22px rgba(180, 190, 205, 0.12);
+  transition: height var(--step-slow) var(--ease-out);
+}
+
+:root[data-theme="light"] .well-level,
+:root:not([data-theme="dark"]) .well-level {
+  background: linear-gradient(180deg, rgba(35, 42, 51, 0.22), rgba(35, 42, 51, 0.08));
+  border-top-color: rgba(13, 17, 23, 0.42);
+  box-shadow: 0 -8px 22px rgba(13, 17, 23, 0.08);
+}
+
+.well-cap {
+  position: absolute;
+  inset: var(--space-2) var(--space-3) auto;
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  z-index: 1;
+}
+
+.well-name {
+  font-size: var(--text-2xs);
+  color: var(--graphite);
+}
+
+.well-pct {
+  font-size: var(--text-xl);
+  line-height: 1;
+  color: var(--chalk);
+}
+
+.well-foot {
+  position: absolute;
+  left: var(--space-3);
+  bottom: var(--space-2);
+  z-index: 1;
+  font-size: var(--text-2xs);
+  color: var(--graphite-dim);
+}
+
+.well-cordoned {
+  border-style: dashed;
+  border-color: var(--border-strong);
+  background-image: repeating-linear-gradient(
+    135deg,
+    transparent 0 6px,
+    var(--edge-soft) 6px 12px
+  );
+}
+
+.well-drained .well-pct,
+.well-drained .well-foot {
+  color: var(--graphite-dim);
+}
+
+.well-targeted,
+.well-selected {
+  border-color: var(--chalk);
+}
+
+/* ------------------------------------------------------------- panel */
+
+.panel-view {
+  display: flex;
+  flex-direction: column;
+}
+
+.panel-head,
+.panel-row {
+  display: grid;
+  grid-template-columns: minmax(0, 140px) 1fr 52px 44px 84px;
+  align-items: center;
+  gap: var(--space-4);
+  padding: var(--space-2) var(--space-4);
+  text-align: left;
+}
+
+.panel-head {
+  border-bottom: 1px solid var(--border-strong);
+  background: var(--surface-2);
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.panel-r {
+  text-align: right;
+}
+
+.panel-row {
+  border: 0;
+  border-bottom: 1px solid var(--edge-soft);
+  background: transparent;
+  color: inherit;
+  font-size: var(--text-sm);
+  transition: background var(--step-fast) var(--ease-out);
+}
+
+.panel-row:hover {
+  background: var(--surface-2);
+}
+
+.panel-id {
+  color: var(--chalk);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* A faint ruled ground behind the bar, so a length can be judged rather than
+   only compared — the same reason a chart has gridlines. */
+.panel-trace {
+  position: relative;
+  height: 18px;
+  border-left: 1px solid var(--border);
+  background: linear-gradient(90deg, var(--edge-soft) 1px, transparent 1px) 0 0 / 24px 100%;
+}
+
+.panel-trace-bar {
+  position: absolute;
+  left: 0;
+  top: 50%;
+  height: 7px;
+  transform: translateY(-50%);
+  border-radius: 1px;
+  background: linear-gradient(90deg, var(--fill-25), var(--fill-75));
+  transition: width var(--step-slow) var(--ease-out);
+}
+
+.panel-trace-bar::after {
+  content: "";
+  position: absolute;
+  right: 0;
+  top: -3px;
+  bottom: -3px;
+  width: 2px;
+  background: var(--chalk);
+}
+
+.panel-pct {
+  text-align: right;
+  color: var(--chalk);
+}
+
+.panel-pods {
+  text-align: right;
+  color: var(--graphite-dim);
+  font-size: var(--text-xs);
+}
+
+.panel-state {
+  text-align: right;
+  font-size: var(--text-2xs);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--graphite-dim);
+}
+
+.panel-row-cordoned {
+  background-image: repeating-linear-gradient(
+    135deg,
+    transparent 0 6px,
+    var(--edge-soft) 6px 12px
+  );
+}
+
+.panel-row-cordoned .panel-state {
+  color: var(--graphite);
+}
+
+.panel-row-targeted,
+.panel-row-selected {
+  background: var(--surface-3);
+}
+
+@media (max-width: 640px) {
+  .panel-head,
+  .panel-row {
+    grid-template-columns: minmax(0, 1fr) 2fr 44px;
+    gap: var(--space-2);
+  }
+  .panel-pods,
+  .panel-state {
+    display: none;
+  }
+  .viewswitch {
+    display: none;
+  }
+}

--- a/ui/src/layout.ts
+++ b/ui/src/layout.ts
@@ -69,6 +69,7 @@ export interface NodeInfo {
   cpuAllocatable: number;
   cpuRequestedMilli: number;
   memAllocatable: number;
+  memRequestedBytes: number;
   cordoned: boolean;
   ready: boolean;
   drainStep: number;
@@ -86,6 +87,35 @@ export interface NodeInfo {
   pinnedCount: number;
 }
 
+/**
+ * How full a node is, per dimension.
+ *
+ * Kubernetes packs on requests in three dimensions and a pod fits only if it
+ * fits in all of them, so the one that limits consolidation is the *worst* of
+ * them — which is exactly what the planner ranks nodes by (`DominantRatio` in
+ * internal/model/resources.go). Drawing CPU alone made the field disagree with
+ * the planner it is drawing: a memory-bound node looked half empty on a screen
+ * whose own engine would refuse to pack it.
+ *
+ * Pod slots are the third dimension and are deliberately left out here. The
+ * server sends no per-node slot capacity, and inventing the usual 110 would be
+ * a guess rendered as a measurement.
+ */
+export interface Fullness {
+  cpu: number;
+  mem: number;
+  /** The larger of the two: what actually limits packing on this node. */
+  dominant: number;
+  /** Which dimension that is, so the view can name it rather than imply it. */
+  bound: "cpu" | "mem";
+}
+
+function fullness(cpuUsed: number, cpuCap: number, memUsed: number, memCap: number): Fullness {
+  const cpu = cpuCap > 0 ? Math.max(0, cpuUsed) / cpuCap : 0;
+  const mem = memCap > 0 ? Math.max(0, memUsed) / memCap : 0;
+  return { cpu, mem, dominant: Math.max(cpu, mem), bound: mem > cpu ? "mem" : "cpu" };
+}
+
 export interface Positioned {
   nodes: Map<string, { x: number; y: number }>;
   pods: Map<string, { x: number; y: number }>;
@@ -94,13 +124,13 @@ export interface Positioned {
   /** Requested milliCPU per node at this step, for the utilisation fill. */
   nodeLoad: Map<string, number>;
   /**
-   * Requested / allocatable per node, 0..1.
+   * How full each node is, 0..1, on every dimension that limits packing.
    *
    * Drives the brightness ramp, which is how fullness is encoded now that
    * colour is reserved for risk. A node at 0.94 is nearly white; one at 0.12
    * barely lifts off the ground.
    */
-  nodeFill: Map<string, number>;
+  nodeFill: Map<string, Fullness>;
   /** Nodes that are empty of movable pods at this step. */
   emptied: Set<string>;
 }
@@ -134,6 +164,7 @@ export function toModel(graph: GraphPayload): Model {
         cpuAllocatable: d.cpuAllocatable ?? 0,
         cpuRequestedMilli: d.cpuRequested ?? 0,
         memAllocatable: d.memAllocatable ?? 0,
+        memRequestedBytes: d.memRequested ?? 0,
         cordoned: d.cordoned ?? false,
         ready: d.ready ?? false,
         drainStep: d.drainStep ?? 0,
@@ -211,7 +242,7 @@ export function computeLayout(
   const nodes = new Map<string, { x: number; y: number }>();
   const pods = new Map<string, { x: number; y: number }>();
   const nodeLoad = new Map<string, number>();
-  const nodeFill = new Map<string, number>();
+  const nodeFill = new Map<string, Fullness>();
   const emptied = new Set<string>();
 
   const occupants = new Map<string, PodInfo[]>();
@@ -231,9 +262,11 @@ export function computeLayout(
 
     const here = occupants.get(node.name) ?? [];
     let load = 0;
+    let mem = 0;
     let movable = 0;
     here.forEach((pod, j) => {
       load += pod.cpuRequest;
+      mem += pod.memRequest;
       if (pod.movable) movable++;
       const pc = j % cols;
       const pr = Math.floor(j / cols);
@@ -246,7 +279,7 @@ export function computeLayout(
       });
     });
     nodeLoad.set(node.name, load);
-    nodeFill.set(node.name, node.cpuAllocatable > 0 ? load / node.cpuAllocatable : 0);
+    nodeFill.set(node.name, fullness(load, node.cpuAllocatable, mem, node.memAllocatable));
     if (movable === 0) emptied.add(node.name);
   });
 
@@ -298,15 +331,17 @@ function densityLayout(
 
   const nodes = new Map<string, { x: number; y: number }>();
   const nodeLoad = new Map<string, number>();
-  const nodeFill = new Map<string, number>();
+  const nodeFill = new Map<string, Fullness>();
   const emptied = new Set<string>();
 
   // Start from what the server counted, then apply the moves up to this step.
   const count = new Map<string, number>();
   const load = new Map<string, number>();
+  const mem = new Map<string, number>();
   for (const n of model.nodes) {
     count.set(n.name, n.podCount);
     load.set(n.name, n.cpuRequestedMilli);
+    mem.set(n.name, n.memRequestedBytes);
   }
   for (const s of steps) {
     if (s.sequenceNumber > step) break;
@@ -315,6 +350,8 @@ function densityLayout(
       count.set(m.toNode, (count.get(m.toNode) ?? 0) + 1);
       load.set(m.fromNode, (load.get(m.fromNode) ?? 0) - (m.cpuMilli ?? 0));
       load.set(m.toNode, (load.get(m.toNode) ?? 0) + (m.cpuMilli ?? 0));
+      mem.set(m.fromNode, (mem.get(m.fromNode) ?? 0) - (m.memoryBytes ?? 0));
+      mem.set(m.toNode, (mem.get(m.toNode) ?? 0) + (m.memoryBytes ?? 0));
     }
   }
 
@@ -330,7 +367,7 @@ function densityLayout(
     nodeLoad.set(node.name, cpu);
     nodeFill.set(
       node.name,
-      node.cpuAllocatable > 0 ? cpu / node.cpuAllocatable : 0,
+      fullness(cpu, node.cpuAllocatable, mem.get(node.name) ?? 0, node.memAllocatable),
     );
     // Pinned pods never move, so a node holding only pinned pods is never
     // emptied however far the scrubber runs.

--- a/ui/src/view.ts
+++ b/ui/src/view.ts
@@ -1,0 +1,64 @@
+/**
+ * How the field draws a node.
+ *
+ * Three renderings, and they are zoom levels rather than skins. Each answers a
+ * different question, and which question an operator has depends mostly on how
+ * big their cluster is:
+ *
+ *   rack   — a node as a rack unit with a bay per pod. The only view where an
+ *            individual pod is an object you can point at, and the only one
+ *            where the drain animation is pods moving. Falls apart past a few
+ *            hundred nodes, which is exactly when nobody is looking at
+ *            individual pods anyway.
+ *   wells  — a node as a vessel with a level. Legible at a thousand nodes with
+ *            no numbers read, and the drain animation becomes the thing
+ *            draining. This is what M19's density mode was reaching for.
+ *   panel  — one row per node, fullest-first, with a load trace. Densest, and
+ *            the ordering makes the argument for consolidating without anyone
+ *            explaining it. Trades the spatial picture away entirely.
+ *
+ * The default follows cluster size, because the right answer usually does. An
+ * explicit choice overrides it and persists — same reasoning as the theme: a
+ * view preference is not a credential, so localStorage is the right home and
+ * sessionStorage would mean re-picking it in every tab.
+ */
+
+export type FieldView = "rack" | "wells" | "panel";
+
+const KEY = "dencer.view";
+
+/** Above this many nodes, individual pods stop being worth drawing. */
+export const RACK_LIMIT = 120;
+/** Above this, even a vessel per node is too much geometry to scan. */
+export const WELLS_LIMIT = 600;
+
+export function defaultView(nodeCount: number): FieldView {
+  if (nodeCount > WELLS_LIMIT) return "panel";
+  if (nodeCount > RACK_LIMIT) return "wells";
+  return "rack";
+}
+
+/** The stored choice, or null when the operator has not expressed one. */
+export function storedView(): FieldView | null {
+  try {
+    const v = localStorage.getItem(KEY);
+    if (v === "rack" || v === "wells" || v === "panel") return v;
+  } catch {
+    // Private browsing. The size-based default still applies.
+  }
+  return null;
+}
+
+export function rememberView(v: FieldView): void {
+  try {
+    localStorage.setItem(KEY, v);
+  } catch {
+    // Applies for this page; simply will not be remembered.
+  }
+}
+
+export const VIEW_LABELS: Record<FieldView, string> = {
+  rack: "Rack",
+  wells: "Wells",
+  panel: "Panel",
+};

--- a/ui/test/density.ts
+++ b/ui/test/density.ts
@@ -17,22 +17,44 @@
 import { toModel, computeLayout, densityCounts, gridColumns } from "../src/layout";
 import type { GraphPayload, PlanStep } from "../src/api";
 
-const node = (name: string, podCount: number, cpuReq: number, pinned = 0, blocked = 0) => ({
+const GIB = 1 << 30;
+
+/**
+ * Memory is a real dimension here, not filler.
+ *
+ * It used to be `memAllocatable: 1, memRequested: 1` — a placeholder from when
+ * the field drew CPU only. The moment fullness started meaning "the dimension
+ * that limits packing", that placeholder said every node was 100% memory-bound
+ * and the fixture stopped describing any cluster that could exist.
+ */
+const node = (
+  name: string, podCount: number, cpuReq: number, memReq: number,
+  pinned = 0, blocked = 0,
+) => ({
   data: { id: `node:${name}`, kind: "node" as const, label: name,
-          cpuAllocatable: 8000, cpuRequested: cpuReq, memAllocatable: 1, memRequested: 1,
+          cpuAllocatable: 8000, cpuRequested: cpuReq,
+          memAllocatable: 32 * GIB, memRequested: memReq,
           podCount, pinnedCount: pinned, blockedCount: blocked, drainStep: 0 },
 });
 
 const graph: GraphPayload = {
   planId: "p", aggregated: true, stats: {} as never,
-  elements: [node("a", 4, 2000), node("b", 3, 1500), node("c", 0, 0)],
+  elements: [
+    node("a", 4, 2000, 4 * GIB),   // cpu 25%, mem 12.5% — CPU binds
+    node("b", 3, 1500, 2 * GIB),   // cpu 18.75%, mem 6.25% — CPU binds
+    node("c", 0, 0, 0),
+    // The case the old fixture could not express: plenty of CPU free, almost
+    // no memory. Drawing CPU alone showed this node as 12% empty and invited a
+    // plan to pack it, which the planner would then refuse.
+    node("m", 2, 1000, 30 * GIB),  // cpu 12.5%, mem 93.75% — MEMORY binds
+  ],
 };
 
 const steps: PlanStep[] = [{
   id: "s1", sequenceNumber: 1, targetNode: "a", impact: "Green", rationale: "",
   moves: [
-    { namespace: "d", pod: "p1", fromNode: "a", toNode: "b", cpuMilli: 500, memoryBytes: 1 },
-    { namespace: "d", pod: "p2", fromNode: "a", toNode: "b", cpuMilli: 500, memoryBytes: 1 },
+    { namespace: "d", pod: "p1", fromNode: "a", toNode: "b", cpuMilli: 500, memoryBytes: GIB },
+    { namespace: "d", pod: "p2", fromNode: "a", toNode: "b", cpuMilli: 500, memoryBytes: GIB },
   ],
 }];
 
@@ -46,7 +68,7 @@ const check = (label: string, got: unknown, want: unknown) => {
 const model = toModel(graph);
 check("aggregated flag survives toModel", model.aggregated, true);
 check("no pod elements", model.pods.length, 0);
-check("podCount read from payload", model.nodes.map(n => n.podCount), [4, 3, 0]);
+check("podCount read from payload", model.nodes.map(n => n.podCount), [4, 3, 0, 2]);
 
 // Step 0 — the cluster as it stands.
 const c0 = densityCounts(model, steps, 0);
@@ -60,13 +82,27 @@ const cols = gridColumns(model.nodes.length);
 const l0 = computeLayout(model, new Map(), 1, cols, steps, 0);
 const l1 = computeLayout(model, new Map(), 1, cols, steps, 1);
 
-check("fill at step 0 (a: 2000/8000)", l0.nodeFill.get("a"), 0.25);
-check("fill at step 0 (b: 1500/8000)", l0.nodeFill.get("b"), 0.1875);
-// The point of putting cpuMilli on Move: the receiving node must visibly fill.
+check("a: cpu 2000/8000 binds over mem 4/32", l0.nodeFill.get("a"),
+      { cpu: 0.25, mem: 0.125, dominant: 0.25, bound: "cpu" });
+check("b: cpu 1500/8000 binds over mem 2/32", l0.nodeFill.get("b"),
+      { cpu: 0.1875, mem: 0.0625, dominant: 0.1875, bound: "cpu" });
+
+// The regression this dimension exists to prevent. Drawn on CPU alone this
+// node reads 13% — nearly empty — while the planner treats it as 94% full and
+// will not pack it. The field and the engine must agree.
+check("m: memory binds, and the field says so", l0.nodeFill.get("m"),
+      { cpu: 0.125, mem: 0.9375, dominant: 0.9375, bound: "mem" });
+check("m is drawn as nearly full, not nearly empty",
+      l0.nodeFill.get("m")!.dominant > 0.9, true);
+
+// The point of putting cpuMilli and memoryBytes on Move: the receiving node
+// must visibly fill on both dimensions.
 check("a drains by 1000 milli", l1.nodeLoad.get("a"), 1000);
 check("b GAINS 1000 milli", l1.nodeLoad.get("b"), 2500);
-check("b fill rises", l1.nodeFill.get("b")! > l0.nodeFill.get("b")!, true);
-check("boxes are positioned", l0.nodes.size, 3);
+check("b cpu fill rises", l1.nodeFill.get("b")!.cpu > l0.nodeFill.get("b")!.cpu, true);
+check("b mem fill rises too", l1.nodeFill.get("b")!.mem > l0.nodeFill.get("b")!.mem, true);
+check("a mem fill falls", l1.nodeFill.get("a")!.mem < l0.nodeFill.get("a")!.mem, true);
+check("boxes are positioned", l0.nodes.size, 4);
 check("density boxes are square-ish", l0.nodeWidth === l0.nodeHeight, true);
 check("empty node counts as emptied", l0.emptied.has("c"), true);
 check("occupied node not emptied at step 0", l0.emptied.has("a"), false);


### PR DESCRIPTION
Mockups: https://claude.ai/code/artifact/0c55bd14-237a-4df9-a025-bbce22d01c3d

**Not three skins — three zoom levels.** Which one suits depends mostly on how many nodes you have, so the default follows node count and an explicit choice overrides it.

| View | A node is | Good for | Gives up |
|---|---|---|---|
| **Rack** (≤120 nodes) | a box with a block per pod | pointing at an individual pod; pods-moving animation | falls apart at scale |
| **Wells** (≤600) | a vessel with a level | reading a wall of nodes without reading numbers | pods as objects |
| **Panel** (>600) | a sorted row with a load trace | scanning, comparing, hierarchy | the spatial picture |

Wells is what M19's density mode was reaching for and never had a shape for. Panel's **ordering is the argument** — a long tail of barely-used nodes at the bottom of a sorted list is the case for consolidating, and nobody has to be told.

## One model, three renderers

Everything the views share — what's cordoned, how full a node is, what the plan drains at this step — is derived **once** in `PackingField` and passed down as `NodeDrawState`. Three components each computing that for themselves is how three views become three subtly different products.

## The palette rule survives intact

Fullness is **height and luminance together**, both achromatic. States are hatching and words. The only saturated pixels on screen are still the risk ratings. `test/palette` green, `test/ui` green, density probe green.

Light theme designed rather than inverted — the well fill inverts, because on a light ground "fuller" has to mean darker or the picture reads backwards.

Deployed to OrbStack and verified served.

🤖 Generated with [Claude Code](https://claude.com/claude-code)