### PR TITLE
Re-read the plan's confirmation instead of freezing it at page load

### DIFF
--- a/docs/findings.md
+++ b/docs/findings.md
@@ -40,6 +40,39 @@ The product's central claim was a guess wearing the clothes of a measurement.
   into a prediction that happened to match reality. First slice fixed; the rest
   is [M24](roadmap.md).
 
+### Signals that meant the opposite of what they said
+
+**The staleness warning fired hardest when nothing was wrong.** The verdict line
+read *"confirmed 72 minutes ago — the cluster may have moved on."* Measured on
+the live cluster at that moment:
+
+```
+planGeneratedAt:  4648s old   ← what was displayed
+planConfirmedAt:    12s old   ← the truth
+```
+
+Every part had been built correctly and in isolation. The store deliberately
+touches `stored_at` on an unchanged plan — with a comment explaining that not
+doing so had already made a re-verified plan read as nineteen hours old. The UI
+deliberately ages against `storedAt` rather than `generatedAt`, with a comment
+saying why. **Neither was wrong. Nothing connected them.** A plan only
+re-publishes when its *content* changes, so the client kept the `storedAt` it
+was handed at page load while the column behind it was refreshed every 30
+seconds.
+
+The result inverted the signal: a steady cluster with a healthy planner
+confirming continuously was *the one state guaranteed to trip the warning*,
+because stability is exactly what stops a plan from being republished.
+
+Fixed by polling the version endpoint — the client's only liveness signal — and
+carrying `planConfirmedAt` on it. The wording changed too, because the old text
+described a different failure: silence here never meant the cluster drifted, it
+meant **nothing is watching it any more**. It now says so.
+
+The lesson is not "add a poll". It is that **two correct components with correct
+comments can still compose into a lie**, and no test of either one catches it.
+Guarded now by mutation-tested assertions on both halves.
+
 ### Data shipped that nothing read
 
 - **45% of the graph payload was edges** — move, anti-affinity, PDB — unread

--- a/internal/api/rest/rest.go
+++ b/internal/api/rest/rest.go
@@ -156,6 +156,17 @@ func (s *Server) handleVersion(w http.ResponseWriter, r *http.Request) {
 	if err == nil {
 		resp["latestPlanId"] = latest.Plan.ID
 		resp["planGeneratedAt"] = latest.Plan.GeneratedAt
+		// When the cluster was last observed to still match this plan, as
+		// distinct from when the plan was computed. The store touches it every
+		// resync whether or not the plan changed, so on a steady cluster it is
+		// always seconds old — which is the honest reading, because an
+		// unchanged plan is the strongest evidence there is that it is current.
+		//
+		// Sent here because this is the endpoint the client can cheaply re-poll.
+		// The plan itself only re-publishes when its *content* changes, so a
+		// steady cluster leaves the client holding the storedAt it was given at
+		// load, watching it age, while the planner re-confirms in silence.
+		resp["planConfirmedAt"] = latest.StoredAt
 	}
 
 	// Who is asking, and which cluster they are looking at.

--- a/test/ui/client_test.go
+++ b/test/ui/client_test.go
@@ -149,3 +149,49 @@ func TestOidcUsesTheIdTokenAsTheCredential(t *testing.T) {
 		}
 	}
 }
+
+// The plan's confirmation must be re-read, never taken once.
+//
+// This one shipped and reached a user. The verdict line read "confirmed 72
+// minutes ago — the cluster may have moved on" on a cluster that had not moved
+// at all: the store touches stored_at on every resync precisely so an
+// unchanged plan reads as current, but a plan only re-publishes when its
+// *content* changes. So the healthiest possible state — a steady cluster,
+// planner confirming every 30s — was the one state guaranteed to trip the
+// staleness warning. The signal meant the opposite of what it said.
+//
+// The fix is a poll, and a poll is one deleted line away from being a fetch
+// again, with no compile error and no visible symptom until an hour in.
+func TestPlanConfirmationIsPolledRatherThanFetchedOnce(t *testing.T) {
+	app := read(t, "App.tsx")
+
+	// The version fetch and a setInterval must live in the same effect. A
+	// bare api.version() somewhere plus an unrelated interval elsewhere would
+	// satisfy a naive substring check while leaving the value frozen.
+	poll := regexp.MustCompile(`api\s*\n?\s*\.version\(\)[\s\S]{0,600}?setInterval\(`)
+	if !poll.MatchString(app) {
+		t.Error("App fetches the version once instead of polling it; " +
+			"planConfirmedAt will freeze at page load and the plan will " +
+			"appear to go stale while the planner is still confirming it")
+	}
+
+	// Ageing the displayed plan by another plan's confirmation would be worse
+	// than not polling: while the view is pinned, the server's latest is a
+	// different plan.
+	if !strings.Contains(app, "latestPlanId === state.plan.plan.id") {
+		t.Error("App does not check that the polled confirmation belongs to " +
+			"the plan on screen; a pinned plan would be dated by the clock " +
+			"of whatever superseded it")
+	}
+
+	// The backend half. Sending generatedAt here would restore the original
+	// bug: it is the one timestamp that never moves for an unchanged plan.
+	rest, err := os.ReadFile("../../internal/api/rest/rest.go")
+	if err != nil {
+		t.Fatalf("read rest.go: %v", err)
+	}
+	if !strings.Contains(string(rest), `resp["planConfirmedAt"] = latest.StoredAt`) {
+		t.Error("the version response does not carry latest.StoredAt as " +
+			"planConfirmedAt; nothing else refreshes on a steady cluster")
+	}
+}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -38,19 +38,38 @@ export default function App() {
 
   // null means "follow cluster size", which is right until someone disagrees.
   const [viewPref, setViewPref] = useState<FieldView | null>(storedView);
+  // Polled, not fetched once, because this response carries the only
+  // liveness signal the client gets.
+  //
+  // A plan re-publishes when its *content* changes. On a steady cluster it
+  // never does — which is the healthiest possible state — so the client would
+  // sit on the storedAt it was handed at load and watch it age past the
+  // staleness threshold while the planner went on confirming the plan every
+  // resync. The warning fired precisely when nothing was wrong. Re-reading
+  // planConfirmedAt is what makes "confirmed just now" stay true, and what
+  // makes the warning mean the thing it says.
+  //
+  // Identity and cluster label ride along unchanged; they are cheap and cannot
+  // drift within a session.
   useEffect(() => {
     let cancelled = false;
-    api
-      .version()
-      .then((v) => {
-        if (!cancelled) setServer(v);
-      })
-      .catch(() => {
-        // The header simply shows less. Failing to learn the cluster name is
-        // not a reason to withhold the plan.
-      });
+    const load = () => {
+      api
+        .version()
+        .then((v) => {
+          if (!cancelled) setServer(v);
+        })
+        .catch(() => {
+          // Leave the last good response in place. A dropped poll is not
+          // evidence the plan went stale, and blanking the header over one
+          // failed request would be its own kind of lie.
+        });
+    };
+    load();
+    const t = setInterval(load, 30_000);
     return () => {
       cancelled = true;
+      clearInterval(t);
     };
   }, []);
 
@@ -247,7 +266,15 @@ export default function App() {
           <Verdict
             stats={state.graph.stats}
             steps={steps}
-            generatedAt={state.plan.storedAt}
+            // The polled confirmation, but only when it is about the plan on
+            // screen. While the view is pinned the server's latest is a
+            // *different* plan, and dating this one by that one's confirmation
+            // would age a held plan by someone else's clock.
+            confirmedAt={
+              server?.latestPlanId === state.plan.plan.id && server?.planConfirmedAt
+                ? server.planConfirmedAt
+                : state.plan.storedAt
+            }
             focusedRating={focusedRating}
             onFocusRating={setFocusedRating}
             onRun={requestRun}

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -292,6 +292,15 @@ export interface VersionResponse {
   readOnly: boolean;
   latestPlanId?: string;
   planGeneratedAt?: string;
+  /**
+   * When the cluster was last seen to still match the latest plan.
+   *
+   * Refreshed every planner resync even when the plan does not change, which
+   * is the whole reason it is polled: the plan itself only re-publishes on a
+   * content change, so on a steady cluster this is the only signal that
+   * anything is still watching.
+   */
+  planConfirmedAt?: string;
   identity?: string;
   clusterLabel?: string;
 }

--- a/ui/src/components/Verdict.tsx
+++ b/ui/src/components/Verdict.tsx
@@ -27,8 +27,13 @@ interface Props {
    * An unchanged plan keeps its original generatedAt however many times the
    * planner re-verifies it, so that field reported a perfectly current plan as
    * hours stale. Confirmation is the question a reader is actually asking.
+   *
+   * It must be *re-read*, not taken once. The store touches it every resync,
+   * but a plan only re-publishes when its content changes, so a client that
+   * fetched this at load and never asked again ages a plan the planner is
+   * actively confirming. App polls the version endpoint for it.
    */
-  generatedAt: string;
+  confirmedAt: string;
   onFocusRating: (impact: Impact | null) => void;
   focusedRating: Impact | null;
   onRun: (dryRun: boolean) => void;
@@ -41,7 +46,7 @@ interface Props {
 export default function Verdict({
   stats,
   steps,
-  generatedAt,
+  confirmedAt,
   onFocusRating,
   focusedRating,
   onRun,
@@ -66,7 +71,7 @@ export default function Verdict({
     <header className="verdict">
       <div className="verdict-main">
         <p className="verdict-eyebrow mono">
-          consolidation plan <PlanAge generatedAt={generatedAt} />
+          consolidation plan <PlanAge confirmedAt={confirmedAt} />
         </p>
         <h1 className="verdict-line">
           Reclaim <span className="verdict-figure num">{stats.reclaimable}</span> of{" "}
@@ -168,22 +173,34 @@ export default function Verdict({
  * proxy for that the UI has. Ticks on its own so the number stays true
  * without waiting for a re-fetch.
  */
-function PlanAge({ generatedAt }: { generatedAt: string }) {
+function PlanAge({ confirmedAt }: { confirmedAt: string }) {
   const [, tick] = useState(0);
   useEffect(() => {
     const t = setInterval(() => tick((n) => n + 1), 15_000);
     return () => clearInterval(t);
   }, []);
 
-  const seconds = Math.max(0, (Date.now() - new Date(generatedAt).getTime()) / 1000);
-  const stale = seconds > 300;
+  const seconds = Math.max(0, (Date.now() - new Date(confirmedAt).getTime()) / 1000);
+  const stale = seconds > STALE_AFTER_SECONDS;
   return (
     <span className={stale ? "verdict-age verdict-age-stale" : "verdict-age"}>
       · confirmed {describeAge(seconds)}
-      {stale && " — the cluster may have moved on"}
+      {stale && " — the planner has stopped confirming it"}
     </span>
   );
 }
+
+/**
+ * How long without a confirmation before the screen stops vouching for itself.
+ *
+ * Ten missed resyncs at the 30s default. The old wording — "the cluster may
+ * have moved on" — described the opposite of what this measures. A confirmation
+ * is refreshed whether or not the plan changes, so silence here does not mean
+ * the cluster drifted; it means **nothing is watching it any more**: the
+ * planner wedged, snapshots failing, the poll dead. That is a different
+ * problem, it is worse, and it deserves to be named.
+ */
+const STALE_AFTER_SECONDS = 300;
 
 function describeAge(seconds: number): string {
   if (seconds < 45) return "just now";


### PR DESCRIPTION
The verdict line read **"confirmed 72 minutes ago — the cluster may have moved on"** on a cluster that had not moved at all. Measured on the live deployment at that moment:

```
planGeneratedAt:  4648s old   ← what was displayed
planConfirmedAt:    12s old   ← the truth
```

## Both halves were already correct

The store **deliberately** touches `stored_at` when an unchanged plan is re-verified — with a comment explaining that not doing so had once made a current plan read as nineteen hours old. The UI **deliberately** ages against `storedAt` rather than `generatedAt`, with a comment saying why.

Neither was wrong. **Nothing connected them.** A plan re-publishes only when its *content* changes, so the client kept the `storedAt` it was handed at page load while the column behind it moved every 30 seconds.

That inverts the signal: a steady cluster with a healthy planner confirming continuously is *exactly* what stops a plan from being republished, so the healthiest possible state was the one state guaranteed to trip the warning.

## The fix

- `/api/v1/version` carries `planConfirmedAt` (`latest.StoredAt`)
- `App` **polls** it on the resync cadence — it is the client's only liveness signal and was being fetched exactly once
- applied only when it belongs to the plan on screen: while the view is pinned the server's latest is a *different* plan, and dating a held plan by its successor's clock would be a new way to be wrong
- wording: *"the planner has stopped confirming it"*. Silence here never meant the cluster drifted — it means **nothing is watching it any more**. Worse, and worth naming.

## Guard

Three assertions, **each mutation-tested**: break the poll, break the plan-id check, or send `generatedAt` from the backend, and one fails. This repo has shipped guards that could not fail, so each was broken deliberately and confirmed to scream.

Deployed to OrbStack and verified: `planConfirmedAt` 12s old against `planGeneratedAt` 4648s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)