### PR TITLE
M24: an observed overlay on the field, so facts hold still

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,12 @@ same one the planner ranks on. Requests, not usage: Kubernetes schedules on what
 pods ask for, so a node at 50% requested is half unschedulable however idle its
 cores are.
 
+The field also separates **what is observed from what is predicted**. Facts
+about the real cluster — a node cordoned, NotReady, drained and awaiting
+removal, or actually reclaimed — are worded on the node itself and hold still
+while the scrubber animates the plan's forecast over them. During a run the
+executor's own event trail marks cordons and drains as they genuinely happen.
+
 ## Documentation
 
 | | |

--- a/docs/findings.md
+++ b/docs/findings.md
@@ -147,7 +147,7 @@ Worth recording because each cost time before being understood as correct:
 
 | Gap | Where |
 |---|---|
-| **M24 — live state in the field** | node conditions, actual pod placement during a run, per-node reclamation, snapshot freshness |
+| **M24 — per-pod placement during a run** | nodes done (observed overlay: NotReady, awaiting, reclaimed, run-event cordons/drains); pods still drawn where the plan put them |
 | **Karpenter / cluster-autoscaler detection** | deliberately skipped: warn *before* draining that nothing will remove the node |
 | **Never run against a production cluster** | a throwaway GKE cluster is not someone's estate |
 | **Workload Identity / IRSA half-proven** | annotations render and are accepted; k8s-dencer makes no cloud API calls, so no credential path is exercised |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -53,7 +53,7 @@ estimated — every milestone here starts from a number in
 | **M21b** | Real ingress controller and StorageClass, exercised in the e2e | **done** |
 | **M22** | Reclamation loop — observe whether a drained node was actually removed | **done** |
 | **M23** | Cloud test on GKE — GKE's autoscaler reclaimed a drained node in **11m9s**, observed | **done** |
-| **M24** | The field shows what *is*, not only what *would be* — live cluster state beside the plan | in progress |
+| **M24** | The field shows what *is*, not only what *would be* — observed node states overlaid on the plan | **done for nodes**; per-pod placement waits on M25 |
 | **M25** | Closed-loop consolidation — re-plan from observed state after every step, instead of executing a forecast | planned |
 
 High availability and a Postgres store were **dropped, not deferred**: a
@@ -75,22 +75,35 @@ was to scrub forward into a prediction that happened to match reality.
 That is the same confusion between predicted and observed that the reclamation
 loop existed to remove, surviving one layer up in the view.
 
-| Gap | Today |
+| Gap | State |
 |---|---|
-| **Cordoned** | in the model, drawn nowhere |
-| **Node conditions** | a node going `NotReady` mid-drain is invisible |
-| **Where pods actually are** | the field draws the plan's placement; during a run the two diverge |
-| **Reclamation per node** | only a tray tally; the node that is awaiting is not marked |
-| **Freshness** | the snapshot is as old as the last plan, and the warning fires backwards — see below |
-| **One dimension of three** | the headline fullness figure is CPU alone, while the planner packs on the worst of CPU, memory and pod slots |
+| **Cordoned** | **shipped** — hatched and worded, in all three views |
+| **Node conditions** | **shipped** — NotReady renders as a dotted border and the word; it was parsed and drawn nowhere, the cordoned bug again |
+| **Reclamation per node** | **shipped** — the awaiting node itself says *awaiting removal*; an observed-reclaimed node ghosts and says *reclaimed* |
+| **Freshness** | **shipped** — `planConfirmedAt`, polled; the warning now names the real failure (confirmations stopping) instead of firing on stability |
+| **One dimension of three** | **shipped** — fullness is the dominant of CPU and memory, matching the planner |
+| **During a run** | **shipped for nodes** — the run's own event trail marks cordons and drains as they actually happen, with dry runs excluded; **still open for pods**, whose drawn positions follow the plan even while the scheduler decides otherwise |
 
-The shape, not yet the design: the field's step 0 should be *live state* rather
-than the plan's snapshot of it, with the plan drawn over it as an overlay that
-is visibly an overlay. Observed and predicted must be distinguishable at a
-glance without reading a label — and without colour, which on this surface
-means risk and nothing else.
+The mechanism that landed: a per-node **observed overlay** (`ObservedNode`),
+derived once in `PackingField` from three sources — the snapshot, the
+reclamation tracker, and the current run's event trail — and layered over the
+plan so all three views agree on what is real. Observed facts hold still while
+the scrubber runs; that is the visible difference between a fact and a
+forecast. Priority when facts stack: *reclaimed* over *NotReady* over
+*awaiting removal* over *cordoned*, by what an operator must act on first.
 
-First slice shipped: cordoned nodes render as cordoned, hatched and labelled.
+Textures distinguish the kind without colour: cordon hatches, NotReady dots,
+observed-gone ghosts. The words do the naming; colour stays reserved for risk.
+
+Guarded by mutation-tested source assertions, because this bug class —
+**parsed into the model, rendered nowhere** — shipped twice (`cordoned`, then
+`ready`) and the payload-parity guard structurally cannot catch it: reading a
+field into a struct nothing draws satisfies "the UI reads it".
+
+Remaining for M24: per-pod placement during a run. The run events name evicted
+pods but not where they landed; drawing that honestly needs live placement
+data the payload does not carry, and it is the natural first consumer of M25's
+closed loop.
 
 #### The staleness warning fires backwards
 

--- a/test/ui/client_test.go
+++ b/test/ui/client_test.go
@@ -195,3 +195,57 @@ func TestPlanConfirmationIsPolledRatherThanFetchedOnce(t *testing.T) {
 			"planConfirmedAt; nothing else refreshes on a steady cluster")
 	}
 }
+
+// Observed node states must be drawn, not merely parsed.
+//
+// Twice now a fact about the real cluster made it into the client model and
+// stopped there — `cordoned` (found by a user: "one node drained, how I know
+// in UI?") and then `ready`, which sat in NodeInfo unrendered from the day it
+// was parsed. The payload-parity guard cannot catch this class: it checks that
+// a field is *read*, and layout.ts reading a field into a struct nothing draws
+// satisfies it. These assertions pin the last hop, source-to-screen.
+func TestObservedNodeStatesAreDrawnNotJustParsed(t *testing.T) {
+	views := read(t, "components/FieldViews.tsx")
+
+	// The observed vocabulary, complete. Losing a word here silently demotes
+	// that state back to invisible.
+	for _, word := range []string{`"reclaimed"`, `"NotReady"`, `"awaiting removal"`, `"cordoned"`} {
+		if !strings.Contains(views, word) {
+			t.Errorf("FieldViews no longer renders the observed state %s", word)
+		}
+	}
+
+	// Observed beats predicted, structurally: stateWord must consult
+	// observedWord before it considers the scrubber's "drained".
+	if !regexp.MustCompile(`(?s)function stateWord[^}]*observedWord\(n\)[^}]*n\.drained`).MatchString(views) {
+		t.Error("stateWord no longer prefers observed facts over the predicted " +
+			"\"drained\"; a real cordon would vanish the moment the scrubber " +
+			"passes the node's step")
+	}
+
+	// The specific field that was parsed and never drawn. NodeInfo.ready must
+	// reach a draw state, not just a struct.
+	field := read(t, "components/PackingField.tsx")
+	if !strings.Contains(field, "notReady: !n.ready") {
+		t.Error("PackingField no longer derives notReady from the model's " +
+			"ready field; NotReady nodes are invisible again")
+	}
+
+	app := read(t, "App.tsx")
+
+	// A rehearsal must never mark a node as actually drained. Dry runs emit
+	// the same event stream on purpose (the UI renders both with one
+	// component), so the observed overlay has to filter them or a dry run
+	// paints the field with drains that never happened.
+	if !regexp.MustCompile(`(?s)const observed = useMemo.{0,900}?!run\.state\.run\.dryRun`).MatchString(app) {
+		t.Error("the observed overlay does not exclude dry runs; a rehearsal " +
+			"would mark nodes as genuinely drained")
+	}
+
+	// The reclamation lists must reach the overlay as names, not just counts.
+	// The counts-only version shipped and the first question was "which node?".
+	if !strings.Contains(app, `{ reclaim: "awaiting" }`) {
+		t.Error("App no longer maps awaiting reclamations onto named nodes; " +
+			"the field cannot mark which node is dead weight")
+	}
+}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { api, Impact, PlanStep, VersionResponse } from "./api";
+import { api, Impact, PlanStep, Reclamation, VersionResponse } from "./api";
 import Inspector, { Selection } from "./components/Inspector";
 import PackingField from "./components/PackingField";
+import { ObservedNode } from "./components/FieldViews";
 import { ConfirmRun, RunTrail } from "./components/RunPanel";
 import Scrubber from "./components/Scrubber";
 import { SignIn } from "./components/SignIn";
@@ -30,7 +31,17 @@ export default function App() {
   // Observed reclamation, as distinct from what the plan predicts. Polled
   // rather than pushed: it changes on the planner's resync, which is tens of
   // seconds, and it is never the reason someone is watching the screen.
-  const [reclaimed, setReclaimed] = useState({ awaiting: 0, reclaimed: 0 });
+  //
+  // The full lists, not just the tallies. The names in them are the difference
+  // between "2 awaiting" in a tray and the actual node on the field being
+  // marked — the tray version shipped first and a user immediately asked
+  // *which* node. Stats ride along for the tray so its numbers stay the
+  // server's own (the recent list is windowed; recounting it would drift).
+  const [reclamations, setReclamations] = useState<{
+    awaiting: Reclamation[];
+    recent: Reclamation[];
+    stats: { awaiting: number; reclaimed: number };
+  }>({ awaiting: [], recent: [], stats: { awaiting: 0, reclaimed: 0 } });
 
   // Identity and cluster, for the header. Fetched once — neither changes
   // within a session, and re-polling them would be noise.
@@ -95,7 +106,11 @@ export default function App() {
       try {
         const r = await api.reclamations();
         if (!cancelled && r.tracking) {
-          setReclaimed({ awaiting: r.stats.awaiting, reclaimed: r.stats.reclaimed });
+          setReclamations({
+            awaiting: r.awaiting ?? [],
+            recent: r.recent ?? [],
+            stats: { awaiting: r.stats.awaiting, reclaimed: r.stats.reclaimed },
+          });
         }
       } catch {
         // Reclamation tracking is supplementary. A backend that does not have
@@ -129,6 +144,43 @@ export default function App() {
   // Reloading is the honest response — anything else leaves an operator acting
   // on a picture that no longer matches their cluster.
   const run = useRun(state.status === "ready" ? state.reload : undefined);
+
+  // Everything known about nodes from *outside* the plan's snapshot, keyed by
+  // node name. Two sources, layered oldest-first:
+  //
+  //   - the reclamation tracker: nodes drained for real and what became of them
+  //   - the current run's event trail: the executor saying what it just did,
+  //     which matters most at exactly the moment the plan is pinned and its
+  //     snapshot is at its most wrong
+  //
+  // A dry run is excluded outright. Its events say "would", and letting a
+  // rehearsal mark nodes as actually drained would be the predicted/observed
+  // confusion this overlay exists to end, rebuilt one layer up.
+  const observed = useMemo(() => {
+    const m = new Map<string, ObservedNode>();
+    for (const r of reclamations.awaiting) {
+      m.set(r.node, { reclaim: "awaiting" });
+    }
+    for (const r of reclamations.recent) {
+      if (r.outcome === "reclaimed") m.set(r.node, { reclaim: "reclaimed" });
+      // "returned" is deliberately not drawn: the node is back in service and
+      // is, once again, just a node. The tray still counts it.
+    }
+    if (run.state.status === "active" || run.state.status === "done") {
+      if (!run.state.run.dryRun) {
+        for (const e of run.state.events) {
+          if (!e.node) continue;
+          if (e.action === "Cordon") {
+            m.set(e.node, { ...m.get(e.node), cordoned: true });
+          } else if (e.action === "Drained") {
+            const cur = m.get(e.node);
+            m.set(e.node, { ...cur, cordoned: true, reclaim: cur?.reclaim ?? "awaiting" });
+          }
+        }
+      }
+    }
+    return m;
+  }, [reclamations, run.state]);
 
   const greenSteps = useMemo(() => steps.filter((s) => s.impact === "Green"), [steps]);
 
@@ -300,8 +352,9 @@ export default function App() {
           <main className="workspace">
             <PackingField
               view={view}
-              awaiting={reclaimed.awaiting}
-              reclaimedForReal={reclaimed.reclaimed}
+              awaiting={reclamations.stats.awaiting}
+              reclaimedForReal={reclamations.stats.reclaimed}
+              observed={observed}
               graph={state.graph}
               steps={steps}
               step={step}

--- a/ui/src/components/FieldViews.tsx
+++ b/ui/src/components/FieldViews.tsx
@@ -33,6 +33,29 @@ export function spreadFill(f?: { cpu: number; mem: number; dominant: number; bou
   };
 }
 
+/**
+ * What is *known* about a node, as opposed to what the plan projects.
+ *
+ * Every field here is observed: it came from the cluster (via the snapshot),
+ * from the reclamation tracker (the planner watching nodes disappear), or from
+ * a run's own event trail (the executor reporting what it just did). None of
+ * it moves when the scrubber moves — that is the entire point. The scrubber
+ * animates a forecast; these facts sit underneath it and do not budge.
+ */
+export interface ObservedNode {
+  /** `spec.unschedulable` is set right now. */
+  cordoned?: boolean;
+  /** The node's Ready condition is false or unknown — it may not be running pods properly. */
+  notReady?: boolean;
+  /**
+   * Where the node is in its afterlife. `awaiting`: drained for real and still
+   * present — the machine is costing money and nothing has removed it yet.
+   * `reclaimed`: the Node object actually disappeared; the one outcome that
+   * saves anything.
+   */
+  reclaim?: "awaiting" | "reclaimed";
+}
+
 export interface NodeDrawState {
   name: string;
   /**
@@ -48,6 +71,10 @@ export interface NodeDrawState {
   pods: number;
   /** Cordoned in the cluster right now — observed, not predicted. */
   cordoned: boolean;
+  /** The node's Ready condition is false — observed, and never good news. */
+  notReady: boolean;
+  /** Observed reclamation state, when the node has one. */
+  reclaim?: "awaiting" | "reclaimed";
   /** The plan drains this node at or before the current step — predicted. */
   drained: boolean;
   /** This step is the one being hovered in the ledger. */
@@ -81,6 +108,8 @@ export function FieldWells({ nodes, onSelectNode }: Props) {
           className={[
             "well",
             n.cordoned ? "well-cordoned" : "",
+            n.notReady ? "well-notready" : "",
+            n.reclaim === "reclaimed" ? "well-gone" : "",
             n.drained ? "well-drained" : "",
             n.targeted ? "well-targeted" : "",
             n.selected ? "well-selected" : "",
@@ -89,7 +118,7 @@ export function FieldWells({ nodes, onSelectNode }: Props) {
             .join(" ")}
           onClick={() => onSelectNode(n.name)}
           aria-label={`${n.name}, ${Math.round(n.fill * 100)} percent requested, ${n.pods} pods${
-            n.cordoned ? ", cordoned" : ""
+            stateWord(n) ? `, ${stateWord(n)}` : ""
           }`}
         >
           <span className="well-cap">
@@ -99,7 +128,7 @@ export function FieldWells({ nodes, onSelectNode }: Props) {
             </span>
           </span>
           <span className="well-foot mono">
-            {n.cordoned ? "cordoned" : n.pods === 0 ? "empty" : `${n.pods} pods`}
+            {stateWord(n) || (n.pods === 0 ? "empty" : `${n.pods} pods`)}
           </span>
           {/* Inline height because it is data, not styling: this is the
               measurement the view exists to show. */}
@@ -144,6 +173,8 @@ export function FieldPanel({ nodes, onSelectNode }: Props) {
           className={[
             "panel-row",
             n.cordoned ? "panel-row-cordoned" : "",
+            n.notReady ? "panel-row-notready" : "",
+            n.reclaim === "reclaimed" ? "panel-row-gone" : "",
             n.targeted ? "panel-row-targeted" : "",
             n.selected ? "panel-row-selected" : "",
           ]
@@ -167,16 +198,50 @@ export function FieldPanel({ nodes, onSelectNode }: Props) {
             {Math.round(n.mem * 100)}
           </span>
           <span className="panel-pods num">{n.pods}</span>
-          <span className="panel-state mono">{stateWord(n)}</span>
+          <span className="panel-state mono" title={STATE_TITLES[stateWord(n)]}>
+            {stateWord(n)}
+          </span>
         </button>
       ))}
     </div>
   );
 }
 
-/** Observed states win over predicted ones: what is beats what would be. */
-function stateWord(n: NodeDrawState): string {
+/**
+ * The observed facts only, most consequential first.
+ *
+ * The ordering is by what an operator must act on: a node that actually
+ * disappeared outranks one that is misbehaving, which outranks one that was
+ * drained and is now dead weight, which outranks one that is merely fenced
+ * off. Nothing predicted appears here — that is the function's contract, and
+ * why the rack view can use it for the tag it refuses to move during a scrub.
+ */
+export function observedWord(n: NodeDrawState): string {
+  if (n.reclaim === "reclaimed") return "reclaimed";
+  if (n.notReady) return "NotReady";
+  if (n.reclaim === "awaiting") return "awaiting removal";
   if (n.cordoned) return "cordoned";
+  return "";
+}
+
+/** What each observed word means, for the hover an unfamiliar operator needs. */
+export const STATE_TITLES: Record<string, string> = {
+  reclaimed: "Observed: the Node object is gone. The capacity was actually returned.",
+  NotReady: "Observed: the node's Ready condition is false. It may not be running its pods.",
+  "awaiting removal":
+    "Observed: drained for real, but the machine is still present — it is " +
+    "costing money until something removes it.",
+  cordoned: "Observed: unschedulable right now (spec.unschedulable is set).",
+};
+
+/**
+ * One word per node. Observed states win over predicted ones: what is beats
+ * what would be. "drained" is the only predicted word, and it only appears
+ * when the scrubber is ahead of reality.
+ */
+export function stateWord(n: NodeDrawState): string {
+  const seen = observedWord(n);
+  if (seen) return seen;
   if (n.drained) return "drained";
   if (n.pods === 0) return "empty";
   return "";

--- a/ui/src/components/PackingField.tsx
+++ b/ui/src/components/PackingField.tsx
@@ -1,5 +1,14 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { FieldPanel, FieldWells, FILL_TITLE, NodeDrawState, spreadFill } from "./FieldViews";
+import {
+  FieldPanel,
+  FieldWells,
+  FILL_TITLE,
+  NodeDrawState,
+  ObservedNode,
+  STATE_TITLES,
+  observedWord,
+  spreadFill,
+} from "./FieldViews";
 import { FieldView } from "../view";
 import { GraphPayload, PlanStep } from "../api";
 import {
@@ -61,6 +70,12 @@ interface Props {
   awaiting?: number;
   /** Nodes whose Node object actually disappeared. Observed, not planned. */
   reclaimedForReal?: number;
+  /**
+   * Per-node observed facts from outside the plan's snapshot: the reclamation
+   * tracker and a run's own event trail. Merged over the snapshot here, once,
+   * so all three views agree on what is real.
+   */
+  observed?: Map<string, ObservedNode>;
 }
 
 export default function PackingField({
@@ -75,6 +90,7 @@ export default function PackingField({
   view = "rack",
   awaiting = 0,
   reclaimedForReal = 0,
+  observed,
 }: Props) {
   const model: Model = useMemo(() => toModel(graph), [graph]);
   const peak = useMemo(() => peakOccupancy(model, steps), [model, steps]);
@@ -204,16 +220,24 @@ export default function PackingField({
 
   const drawStates: NodeDrawState[] = useMemo(
     () =>
-      model.nodes.map((n) => ({
-        name: n.name,
-        ...spreadFill(layout.nodeFill.get(n.name)),
-        pods: podsByNode.get(n.name) ?? 0,
-        cordoned: n.cordoned,
-        drained: reclaimed.has(n.name),
-        targeted: stepTarget === n.name,
-        selected: selectedNode === n.name,
-      })),
-    [model, layout, podsByNode, reclaimed, stepTarget, selectedNode],
+      model.nodes.map((n) => {
+        // The snapshot's facts, then anything fresher layered over them. The
+        // snapshot ages between plan publishes; a run's event trail and the
+        // reclamation tracker do not, so where they speak, they win.
+        const obs = observed?.get(n.name);
+        return {
+          name: n.name,
+          ...spreadFill(layout.nodeFill.get(n.name)),
+          pods: podsByNode.get(n.name) ?? 0,
+          cordoned: n.cordoned || (obs?.cordoned ?? false),
+          notReady: !n.ready || (obs?.notReady ?? false),
+          reclaim: obs?.reclaim,
+          drained: reclaimed.has(n.name),
+          targeted: stepTarget === n.name,
+          selected: selectedNode === n.name,
+        };
+      }),
+    [model, layout, podsByNode, reclaimed, stepTarget, selectedNode, observed],
   );
 
   if (view !== "rack") {
@@ -248,9 +272,16 @@ export default function PackingField({
             const pos = layout.nodes.get(node.id);
             if (!pos) return null;
             if (!inView(index)) return null;
-            const fill = layout.nodeFill.get(node.name)?.dominant ?? 0;
-            const gone = reclaimed.has(node.name);
+            // drawStates is built from the same model.nodes, so it is
+            // index-aligned by construction. This is the one source of truth
+            // for what is observed; the rack must not re-derive it.
+            const ds = drawStates[index];
+            const fill = ds.fill;
+            // Predicted by the scrubber, or actually observed gone. The first
+            // moves as the scrubber moves; the second never does.
+            const gone = reclaimed.has(node.name) || ds.reclaim === "reclaimed";
             const count = podsByNode.get(node.name) ?? 0;
+            const seen = observedWord(ds);
 
             return (
               <div
@@ -262,7 +293,9 @@ export default function PackingField({
                   // *would* do at the scrubber's current position. The field
                   // showed only the prediction, so a node you had genuinely
                   // just drained looked identical to an untouched one.
-                  node.cordoned ? "box-cordoned" : "",
+                  ds.cordoned ? "box-cordoned" : "",
+                  ds.notReady ? "box-notready" : "",
+                  ds.reclaim === "reclaimed" ? "box-gone" : "",
                   gone ? "box-reclaimed" : "",
                   selectedNode === node.name ? "box-selected" : "",
                   stepTarget === node.name ? "box-targeted" : "",
@@ -290,18 +323,20 @@ export default function PackingField({
                   }
                 }}
                 aria-label={`${node.name}, ${Math.round(fill * 100)} percent requested, ${count} pods${
-                  node.cordoned ? ", cordoned" : ""
-                }${gone ? ", reclaimed" : ""}`}
+                  seen ? `, ${seen}` : gone ? ", drained in this plan" : ""
+                }`}
               >
                 <div className="box-head">
                   <span className="box-name mono">{shortName(node.name)}</span>
-                  {/* The word, not just the hatching. Colour is reserved for
+                  {/* The word, not just the texture. Colour is reserved for
                       risk on this surface, so a state has to be legible
-                      without it — and "cordoned" is a fact an operator needs
-                      to read, not infer from a texture. */}
-                  {node.cordoned && !gone && (
-                    <span className="box-cordoned-tag mono" title="Cordoned: unschedulable">
-                      cordoned
+                      without it — and an observed fact is something an
+                      operator needs to read, not infer from a pattern. The
+                      tag holds still while the scrubber runs, because these
+                      words are facts about the cluster, not about the plan. */}
+                  {seen && (
+                    <span className="box-state-tag mono" title={STATE_TITLES[seen]}>
+                      {seen}
                     </span>
                   )}
                   <span className="box-pct num" title={FILL_TITLE}>

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1789,7 +1789,12 @@
   );
 }
 
-.box-cordoned-tag {
+/* The observed-state word on a rack box — cordoned, NotReady, awaiting
+   removal, reclaimed. One style for all of them, because they differ in
+   *content*, and giving each a look would drift toward colour-coding states,
+   which this surface reserves for risk. Was .box-cordoned-tag when cordoned
+   was the only observed fact the field knew. */
+.box-state-tag {
   margin-left: auto;
   padding: 0 var(--space-1);
   border: 1px solid var(--border-strong);
@@ -1798,6 +1803,49 @@
   letter-spacing: 0.04em;
   color: var(--graphite);
   text-transform: uppercase;
+  white-space: nowrap;
+}
+
+/* NotReady: the border itself misbehaves — dotted, not the cordon's dashes.
+   Texture distinguishes the *kind* of problem; the word names it. */
+.box-notready {
+  border-style: dotted;
+  border-color: var(--border-strong);
+}
+
+/* Observed gone: the Node object no longer exists. The box stays as a record
+   of what was reclaimed, but nothing about it should read as live capacity. */
+.box-gone {
+  opacity: 0.45;
+  border-style: dashed;
+  background-image: none;
+}
+
+.well-notready {
+  border-style: dotted;
+  border-color: var(--border-strong);
+}
+
+.well-gone {
+  opacity: 0.45;
+  border-style: dashed;
+}
+
+.well-gone .well-level {
+  display: none;
+}
+
+.panel-row-notready .panel-id {
+  text-decoration: underline dotted var(--graphite-dim);
+  text-underline-offset: 3px;
+}
+
+.panel-row-gone {
+  opacity: 0.45;
+}
+
+.panel-row-gone .panel-trace-bar {
+  display: none;
 }
 
 .appbar-theme {


### PR DESCRIPTION
The field drew the plan; nothing on it distinguished a fact from a forecast. This kept shipping the same bug at the same seam: `cordoned` was parsed and rendered nowhere until a user asked *"one node drained, how I know in UI?"* — and `ready` has been sitting in `NodeInfo` unrendered since the day it was parsed.

## The mechanism

A per-node **`ObservedNode` overlay**, derived once in `PackingField` and layered over the snapshot so all three views agree on what is real:

| Source | Contributes |
|---|---|
| the snapshot | `cordoned`, `ready` |
| the reclamation tracker | which node is **awaiting removal**, which was **actually reclaimed** — App fetched these names every 30s and reduced them to two integers for a tray |
| the run's event trail | cordons and drains **as the executor reports them** — exactly when the plan is pinned and its snapshot most wrong. Dry runs excluded outright |

**Observed facts hold still while the scrubber runs.** That is the visible difference between a fact and a forecast, and it needs no legend.

One word per node, most consequential first: `reclaimed` › `NotReady` › `awaiting removal` › `cordoned`; predicted `drained` only when nothing observed outranks it. Textures carry the kind without colour — cordon hatches, NotReady dots, observed-gone ghosts. The palette rule survives untouched.

## Guard

Five source assertions, **each mutation-tested** — drop a state word, invert the priority, stop deriving `notReady`, unguard dry runs, or reduce reclamations to counts, and one fails. The payload-parity guard cannot catch this class (reading a field into a struct nothing draws counts as "read"); this pins the last hop, source to screen.

## Verified live

Deployed to OrbStack: `kwok-node-18` and `kwok-node-21` are genuinely awaiting removal on this cluster and now say so on the field itself.

**Remaining for M24:** per-pod placement during a run — needs live placement data the payload doesn't carry; natural first consumer of M25's closed loop. Roadmap updated accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)