### PR TITLE
A product roadmap, and order in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,8 @@ executor's own event trail marks cordons and drains as they genuinely happen.
 | [Observability](docs/observability.md) | Prometheus metrics per component |
 | [Development](docs/development.md) | Local loop, KWOK fabric, CI gates, releases |
 | [Benchmarks](docs/benchmarks.md) | Measured cost, growth curves, the ceiling |
-| [Roadmap and status](docs/roadmap.md) | Built, planned, and deliberately dropped |
+| [Product roadmap](docs/product-roadmap.md) | Shipped capabilities and what comes next, as features |
+| [Engineering roadmap](docs/roadmap.md) | The milestone history — built, planned, and deliberately dropped |
 | [Design document](docs/k8s-consolidation-agent-architecture.md) | The original architecture and its reasoning |
 
 ## Status

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,8 @@
 | **[Development](development.md)** | The local loop, the KWOK fake-node fabric, the CI gates, and cutting a release |
 | **[Benchmarks](benchmarks.md)** | Measured cost per operation, and where each stage stops being usable |
 | **[Findings](findings.md)** | Bugs and gaps found by running it — what hid, and why |
-| **[Roadmap and status](roadmap.md)** | What is built, what is planned, and what was dropped |
+| **[Product roadmap](product-roadmap.md)** | Shipped capabilities and what comes next, as features rather than milestones |
+| **[Engineering roadmap and status](roadmap.md)** | The milestone history — measurements, design reasoning, what was dropped and why |
 | **[Security policy](../SECURITY.md)** | Reporting a vulnerability, and what is in scope |
 | **[Design document](k8s-consolidation-agent-architecture.md)** | The original architecture and the reasoning behind it |
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -190,3 +190,7 @@ SCALE_LARGE=1 make bench    # adds the 5,000-pod point, several minutes
 Sizes stop at 2,500 on purpose. A benchmark nobody will sit through is a
 benchmark nobody maintains; the larger points are opt-in until the growth curve
 is fixed.
+
+---
+
+[← Documentation index](README.md) · [Project README](../README.md)

--- a/docs/k8s-consolidation-agent-architecture.md
+++ b/docs/k8s-consolidation-agent-architecture.md
@@ -1,5 +1,11 @@
 # k8s-dencer — Architecture & Implementation Plan
 
+> **Historical document.** This is the original design, kept as the record of
+> what was intended and why. Where it disagrees with the code, the code won —
+> see [architecture.md](architecture.md) for what actually runs, and
+> [roadmap.md](roadmap.md) for what changed along the way and the reasons.
+
+
 **Project name**: `k8s-dencer`
 
 | Artifact | Name |
@@ -222,3 +228,7 @@ and no subagents/ADK orchestration yet — that's still Phase 4.
 - Exact thresholds/rules for Green vs. Yellow vs. Red classification (e.g.
   where PDB headroom stops being "Green") — likely needs to be a tunable
   policy rather than hardcoded, since risk tolerance differs per cluster.
+
+---
+
+[← Documentation index](README.md) · [Project README](../README.md)

--- a/docs/product-roadmap.md
+++ b/docs/product-roadmap.md
@@ -1,0 +1,107 @@
+# Product roadmap
+
+What k8s-dencer can do today, and what it will do next — as capabilities, not
+milestones. The engineering history behind each item, with measurements and
+design reasoning, is in **[roadmap.md](roadmap.md)**; this page is the view for
+deciding what to build next and telling users what they get.
+
+*Last updated: 2026-07-31.*
+
+## Shipped
+
+### Analysis and planning
+- **Full constraint analysis** — PDBs, topology spread, pod/node affinity,
+  taints and tolerations, controller ownership, local storage; every immovable
+  pod explained in words, not codes
+- **Consolidation plans as ordered, discrete steps** — one node drained per
+  step, each step independently executable
+- **Risk rating per step** (Green / Yellow / Red) with the reasoning attached;
+  ratings are glyph + word, never colour alone
+- **Fullness measured the way the scheduler packs** — worst of CPU and memory
+  requests over allocatable, identical to the planner's own ranking
+- **Scales to 5,000+ pods** — constraint analysis 298 ms, planning 466 ms at
+  5,026 pods, measured; no cluster required to benchmark
+
+### Execution
+- **Off by default**, and the chart refuses to enable it without
+  authentication and persistence
+- **Runs only the steps a human picked**, through the eviction API — the API
+  server enforces PDBs, not code in this repo
+- **Safety Guard re-checks live state before every action** and refuses on a
+  named rule; refusals are auditable outcomes, not errors
+- **Red steps require an open maintenance window**; window evaluation fails
+  closed
+- **Recovery judged on readiness, not phase** — a replacement pod that fails
+  its probes aborts the run
+- **Dry run** — the full guard chain and the same event trail, touching nothing
+- **Privilege split held by construction** — the network-reachable component
+  cannot evict; the evicting component has no Service; lint fails the build if
+  `pods/eviction` leaks to any other role
+
+### Observing reality (not just predicting it)
+- **Reclamation tracking** — a drained node is watched until something
+  actually removes it (*awaiting → reclaimed | returned*), proven against
+  GKE's own autoscaler (removal observed and timed at 11m9s)
+- **Observed node states on the field** — cordoned, NotReady, awaiting
+  removal, actually reclaimed; facts hold still while the plan's animation
+  runs over them
+- **Live run trail** — cordons, evictions and drains stream into the UI as
+  the executor performs them; dry runs are visibly rehearsals
+- **Plan freshness that means something** — "confirmed just now" is refreshed
+  every planner cycle; the warning fires only when confirmations *stop*
+
+### Interfaces
+- **Web UI** — dark instrument-style design; three field renderings chosen by
+  cluster size (Rack ≤120 nodes, Wells ≤600, Panel above), each switchable and
+  persistent; step scrubber; per-node and per-pod inspector; verified identity
+  and cluster label in the chrome
+- **CLI** — `dencer` and `kubectl dencer` plugin; everything the UI does, with
+  `-o json` for pipelines; finds the backend through kubeconfig, no
+  port-forward
+- **Natural-language agent** (optional, via Kagent) — answers questions by
+  quoting the analyzer rather than re-deriving anything
+- **Prometheus metrics** on every component; Grafana-ready
+- **Auth is your cluster's auth** — TokenReview + SubjectAccessReview
+  delegation, OIDC/SSO; no credential store of its own
+
+### Delivery
+- **Published images and Helm chart** on ghcr.io, installable in two commands
+- **Every release e2e-verified in CI** — five-node cluster, PodSecurity
+  `restricted` enforcing, real ingress, real drains, reclamation observed
+- **Zero-cost demo** — KWOK fake-node fabric, no real workloads needed
+
+## Next
+
+Ordered by intent; items move up when a user need pulls them.
+
+1. **Reclaimed capacity, not just node count** — "reclaim 15 nodes, 340
+   cores, 1.2 TiB" instead of a bare count. Nodes are not fungible; the count
+   alone cannot say whether a plan is worth running.
+2. **Closed-loop consolidation** (M25, designed) — re-plan from observed state
+   after every step instead of executing a forecast; bounded by an explicit
+   operator-approved envelope (max nodes, window, impact ceiling). Ends the
+   gap where a run aborts on divergence a fresh plan would simply absorb.
+3. **Per-pod placement during a run** — draw where pods actually landed, not
+   where the plan predicted; first consumer of the closed loop's live data.
+4. **Cost awareness** — instance type and capacity type (spot/on-demand) in
+   the model, so "better plan" can mean "cheaper estate", not "fewer nodes".
+5. **Reclaimer detection** — warn *before* draining when no autoscaler or
+   Karpenter is present to remove the emptied node (drained-but-not-removed is
+   pure cost).
+6. **Planner lookahead** — evaluate whether draining A forecloses draining B
+   and C; adopt only if measurably better plans result.
+
+## Explicitly not planned
+
+Decisions, not omissions — recorded so they are not re-litigated by accident:
+
+- **High availability / Postgres** — a consolidation planner is not a serving
+  path; the run queue is crash-safe, the planner replans on restart
+- **Fully autonomous operation** — the product's premise is that a human
+  approves eviction; scheduled unattended execution stays out until the
+  closed-loop envelope model proves itself
+- **Multi-cluster orchestration** — one cluster per install
+
+---
+
+[← Documentation index](README.md) · [Engineering roadmap](roadmap.md) · [Project README](../README.md)


### PR DESCRIPTION
Requested: review the docs, bring order, and add a product-management roadmap.

**New: [docs/product-roadmap.md](../blob/docs/product-roadmap/docs/product-roadmap.md)** — shipped capabilities as a feature list (grouped: analysis, execution, observing reality, interfaces, delivery), the next items in intended order, and an explicit **not-planned** section so dropped decisions (HA, Postgres, autonomy) aren't re-litigated by accident. The engineering roadmap keeps the milestone history; the two are cross-linked and named for what they are.

**Order fixes from auditing all 15 markdown files:**
- the original design doc read as current — now carries a historical banner pointing at `architecture.md` for what actually runs
- `benchmarks.md` and the design doc were the only docs missing the nav footer — added
- index and README updated to carry both roadmaps, named for which is which

🤖 Generated with [Claude Code](https://claude.com/claude-code)