### PR TITLE
The planning cycle moves to a tested package; window reads obey the run

### DIFF
--- a/cmd/planner/main.go
+++ b/cmd/planner/main.go
@@ -7,15 +7,12 @@ package main
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
 	"strconv"
 	"strings"
-	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -23,13 +20,10 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/atedgimo/k8s-dencer/internal/cluster"
-	"github.com/atedgimo/k8s-dencer/internal/constraints"
 	"github.com/atedgimo/k8s-dencer/internal/httpserver"
 	"github.com/atedgimo/k8s-dencer/internal/impact"
-	"github.com/atedgimo/k8s-dencer/internal/model"
 	"github.com/atedgimo/k8s-dencer/internal/planner"
-	"github.com/atedgimo/k8s-dencer/internal/reclaim"
-	"github.com/atedgimo/k8s-dencer/internal/store"
+	"github.com/atedgimo/k8s-dencer/internal/publish"
 	sqlitestore "github.com/atedgimo/k8s-dencer/internal/store/sqlite"
 	"github.com/atedgimo/k8s-dencer/internal/telemetry"
 )
@@ -83,43 +77,48 @@ func run(ctx context.Context, log *slog.Logger) error {
 	if err := db.Migrate(ctx); err != nil {
 		return err
 	}
-	retain := intEnv(log, "RETAIN_PLANS", 200)
-
-	var latest atomic.Pointer[model.ClusterSnapshot]
-	var latestAnalysis atomic.Pointer[constraints.Analysis]
-	var latestPlan atomic.Pointer[model.Plan]
-
-	strategy := planner.Greedy{}
 	planOpts := planner.DefaultOptions()
 	planOpts.MinNodeAge = duration(log, "MIN_NODE_AGE", planOpts.MinNodeAge)
 	planOpts.MaxSteps = intEnv(log, "MAX_STEPS", 0)
 	planOpts.ExcludeNamespaces = splitList(os.Getenv("EXCLUDE_NAMESPACES"))
 
-	classifier := impact.New(impact.Thresholds{
-		YellowPodsMoved:  intEnv(log, "YELLOW_PODS_MOVED", 0),
-		RedPodsMoved:     intEnv(log, "RED_PODS_MOVED", 0),
-		TightPDBHeadroom: int32(intEnv(log, "TIGHT_PDB_HEADROOM", 0)),
-	})
+	metrics := telemetry.NewMetrics(telemetry.ComponentPlanner)
+
+	// The cycle itself lives in internal/publish, where its semantics are
+	// tested. This file is only wiring: env, informers, HTTP, the ticker.
+	pub := &publish.Publisher{
+		Log:      log,
+		Source:   collector,
+		Strategy: planner.Greedy{},
+		Options:  planOpts,
+		Classifier: impact.New(impact.Thresholds{
+			YellowPodsMoved:  intEnv(log, "YELLOW_PODS_MOVED", 0),
+			RedPodsMoved:     intEnv(log, "RED_PODS_MOVED", 0),
+			TightPDBHeadroom: int32(intEnv(log, "TIGHT_PDB_HEADROOM", 0)),
+		}),
+		DB:      db,
+		Retain:  intEnv(log, "RETAIN_PLANS", 200),
+		Metrics: metrics,
+	}
 
 	health := &httpserver.Health{}
-	metrics := telemetry.NewMetrics(telemetry.ComponentPlanner)
 	mux := http.NewServeMux()
 	health.Register(mux)
 	metrics.Register(mux)
 	mux.HandleFunc("GET /debug/snapshot", yamlHandler(func() any {
-		if v := latest.Load(); v != nil {
+		if v := pub.LatestSnapshot(); v != nil {
 			return v
 		}
 		return nil
 	}))
 	mux.HandleFunc("GET /debug/constraints", yamlHandler(func() any {
-		if v := latestAnalysis.Load(); v != nil {
+		if v := pub.LatestAnalysis(); v != nil {
 			return v
 		}
 		return nil
 	}))
 	mux.HandleFunc("GET /debug/plan", yamlHandler(func() any {
-		if v := latestPlan.Load(); v != nil {
+		if v := pub.LatestPlan(); v != nil {
 			return v
 		}
 		return nil
@@ -147,7 +146,7 @@ func run(ctx context.Context, log *slog.Logger) error {
 	ticker := time.NewTicker(resync)
 	defer ticker.Stop()
 
-	collect(ctx, log, collector, &latest, &latestAnalysis, &latestPlan, strategy, planOpts, classifier, db, retain, metrics)
+	pub.Cycle(ctx)
 
 	for {
 		select {
@@ -158,150 +157,8 @@ func run(ctx context.Context, log *slog.Logger) error {
 		case err := <-serveErr:
 			return err
 		case <-ticker.C:
-			collect(ctx, log, collector, &latest, &latestAnalysis, &latestPlan, strategy, planOpts, classifier, db, retain, metrics)
+			pub.Cycle(ctx)
 		}
-	}
-}
-
-func collect(
-	ctx context.Context,
-	log *slog.Logger,
-	c *cluster.Collector,
-	latest *atomic.Pointer[model.ClusterSnapshot],
-	latestAnalysis *atomic.Pointer[constraints.Analysis],
-	latestPlan *atomic.Pointer[model.Plan],
-	strategy planner.Strategy,
-	planOpts planner.Options,
-	classifier impact.Classifier,
-	db store.Store,
-	retain int,
-	m *telemetry.Metrics,
-) {
-	cycleStart := time.Now()
-
-	snap, err := c.Snapshot(ctx)
-	if err != nil {
-		log.Error("snapshot failed", "error", err)
-		m.SnapshotFailure.Inc()
-		return
-	}
-	latest.Store(snap)
-
-	allocatable, requested := snap.Totals()
-	cpu, mem, pods := requested.Ratio(allocatable)
-
-	occupied := 0
-	for _, n := range snap.Nodes {
-		if !snap.RequestedOnNode(n.Name).IsZero() {
-			occupied++
-		}
-	}
-
-	blocking := 0
-	for _, p := range snap.PDBs {
-		if p.Blocks() {
-			blocking++
-		}
-	}
-
-	log.Info("snapshot",
-		"nodes", len(snap.Nodes),
-		"nodesOccupied", occupied,
-		"pods", len(snap.Pods),
-		"pdbs", len(snap.PDBs),
-		"pdbsBlocking", blocking,
-		"cpuRequestedPct", pct(cpu),
-		"memRequestedPct", pct(mem),
-		"podSlotsUsedPct", pct(pods),
-		"usageData", snap.HasUsageData,
-	)
-	m.SnapshotNodes.Set(float64(len(snap.Nodes)))
-	m.SnapshotPods.Set(float64(len(snap.Pods)))
-
-	analysis := constraints.Analyze(snap)
-	latestAnalysis.Store(analysis)
-
-	cs := analysis.Summarize()
-	undrainable := 0
-	for _, n := range snap.Nodes {
-		if drainable, _ := analysis.NodeDrainable(n.Name); !drainable {
-			undrainable++
-		}
-	}
-
-	log.Info("constraints",
-		"movable", cs.Movable,
-		"blocked", cs.Blocked,
-		"stuck", cs.Stuck,
-		"pdbBlocked", cs.PDBBlocked,
-		"antiAffinity", cs.AntiAffinity,
-		"spreadBound", cs.SpreadBound,
-		"controllerPinned", cs.ControllerPin,
-		"nodesUndrainable", undrainable,
-	)
-
-	plan, err := strategy.Plan(snap, analysis, planOpts)
-	if err != nil {
-		log.Error("planning failed", "error", err)
-		return
-	}
-	// Rating happens after planning, never during it: the plan is the ideal
-	// end state, and risk is a separate judgement laid over it.
-	classifier.ClassifyPlan(plan, snap, analysis)
-	latestPlan.Store(plan)
-
-	byRating := plan.CountByRating()
-	log.Info("plan",
-		"id", plan.ID,
-		"strategy", strategy.Name(),
-		"steps", len(plan.Steps),
-		"nodesBefore", plan.NodesBefore,
-		"nodesAfter", plan.NodesAfter,
-		"reclaims", plan.ReclaimedNodes(),
-		"green", byRating[model.ImpactGreen],
-		"yellow", byRating[model.ImpactYellow],
-		"red", byRating[model.ImpactRed],
-	)
-
-	// Set every rating explicitly, including the zeroes. Leaving a label unset
-	// makes the series vanish from the scrape, and a missing series reads as a
-	// gap in a graph rather than as "no Red steps" — the opposite of the
-	// reassurance it should give.
-	for _, r := range []model.ImpactRating{model.ImpactGreen, model.ImpactYellow, model.ImpactRed} {
-		m.PlanSteps.WithLabelValues(string(r)).Set(float64(byRating[r]))
-	}
-	m.NodesReclaimed.Set(float64(plan.ReclaimedNodes()))
-	m.PlanProduced(time.Now())
-	m.PlanCycleTime.Observe(time.Since(cycleStart).Seconds())
-
-	// The planner is the only component watching nodes continuously, so it is
-	// the one that can tell whether a node the executor drained was actually
-	// removed. Done against the snapshot just taken, so it costs no API calls.
-	observeReclamations(ctx, log, db, snap, m)
-
-	stored, err := db.Save(ctx, store.Record{
-		Plan:     plan,
-		Snapshot: snap,
-		Analysis: analysis,
-		Strategy: strategy.Name(),
-	})
-	if err != nil {
-		// A store failure must not stop planning: the in-memory plan is still
-		// correct and the next cycle will retry the write.
-		log.Error("storing plan failed", "error", err)
-		return
-	}
-	if !stored {
-		// Same content hash as the previous write, so the cluster has not
-		// changed in any way that alters the plan.
-		return
-	}
-	log.Info("plan stored", "id", plan.ID)
-
-	if pruned, err := db.Prune(ctx, retain); err != nil {
-		log.Warn("pruning plan history failed", "error", err)
-	} else if pruned > 0 {
-		log.Info("pruned plan history", "removed", pruned, "retained", retain)
 	}
 }
 
@@ -340,10 +197,6 @@ func yamlHandler(load func() any) http.HandlerFunc {
 	}
 }
 
-func pct(f float64) string {
-	return fmt.Sprintf("%.1f%%", f*100)
-}
-
 func splitList(s string) []string {
 	if strings.TrimSpace(s) == "" {
 		return nil
@@ -376,60 +229,4 @@ func duration(log *slog.Logger, key string, fallback time.Duration) time.Duratio
 		return fallback
 	}
 	return d
-}
-
-// observeReclamations closes out drained nodes that have since been removed or
-// put back into service.
-//
-// Runs every cycle against the snapshot already in hand. The whole rule lives
-// in internal/reclaim as a pure function so it is testable without a cluster;
-// this is only the plumbing around it.
-//
-// Failures are logged and dropped. Reclamation tracking is a measurement laid
-// over the product, and a database hiccup must not stop the planner planning.
-func observeReclamations(ctx context.Context, log *slog.Logger, db store.Store,
-	snap *model.ClusterSnapshot, m *telemetry.Metrics) {
-	tracker, ok := db.(store.ReclamationStore)
-	if !ok {
-		return
-	}
-
-	pending, err := tracker.PendingReclamations(ctx)
-	if err != nil {
-		log.Error("could not read pending reclamations", "error", err)
-		return
-	}
-	m.NodesAwaitingReclamation.Set(float64(len(pending)))
-	if len(pending) == 0 {
-		return
-	}
-
-	now := time.Now().UTC()
-	for _, t := range reclaim.Resolve(pending, snap, now) {
-		if err := tracker.ResolveReclamation(ctx, t.Reclamation.Node, t.Reclamation.DrainedAt, t.Outcome, t.At); err != nil {
-			if !errors.Is(err, store.ErrNotFound) {
-				log.Error("could not resolve reclamation", "node", t.Reclamation.Node, "error", err)
-			}
-			continue
-		}
-		switch t.Outcome {
-		case store.ReclaimedGone:
-			// The moment the product exists to produce, and the first time it
-			// has ever been recorded rather than assumed.
-			log.Info("node reclaimed", "node", t.Reclamation.Node,
-				"after", t.Took.Round(time.Second), "run", t.Reclamation.RunID)
-			m.ReclamationSeconds.Observe(t.Took.Seconds())
-		case store.ReclaimedReturned:
-			log.Info("drained node returned to service", "node", t.Reclamation.Node,
-				"run", t.Reclamation.RunID)
-			m.NodesReturnedTotal.Inc()
-		}
-	}
-
-	// Recount rather than subtract: a drain recorded by the executor between
-	// the read above and now would make arithmetic wrong, and this gauge is
-	// the one an operator alerts on.
-	if remaining, err := tracker.PendingReclamations(ctx); err == nil {
-		m.NodesAwaitingReclamation.Set(float64(len(remaining)))
-	}
 }

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -225,7 +225,7 @@ func (e *Executor) performStep(ctx context.Context, run store.Run, step model.Pl
 	}
 
 	// Gate first, against state read moments ago rather than the plan's.
-	if err := e.guard.CheckStep(step, live, *state); err != nil {
+	if err := e.guard.CheckStep(ctx, step, live, *state); err != nil {
 		e.blocked(ctx, run, step, err)
 		return err
 	}

--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -1,0 +1,263 @@
+// Package publish owns one planning cycle: snapshot, analyze, plan, classify,
+// publish, persist, observe reclamations.
+//
+// Extracted from cmd/planner precisely because it was the least-tested code
+// with the most consequential semantics. Two of this repo's worst bugs were
+// not in any algorithm — they were in this wiring: what gets published when
+// the plan does not change, and what still has to happen after the store's
+// dedup says "nothing new". Those properties are now pinned by tests in this
+// package instead of living as unstated behaviour in a main().
+//
+// The invariants, stated once:
+//
+//   - Save is called every cycle, changed plan or not. The store touches
+//     stored_at on the dedup path, and that touch is the "still confirmed"
+//     signal the whole freshness display rests on. Skipping Save on an
+//     unchanged plan would silently resurrect the backwards staleness warning.
+//   - Reclamations are observed before the dedup early-return, because a node
+//     disappearing is exactly the kind of change that does not alter the plan.
+//   - A store failure never stops planning. The in-memory plan is still
+//     correct, and the next cycle retries the write.
+//   - A snapshot failure leaves the previously published state in place.
+//     Publishing nothing is recoverable; publishing an empty cluster would
+//     invite a plan to drain everything.
+package publish
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync/atomic"
+	"time"
+
+	"github.com/atedgimo/k8s-dencer/internal/constraints"
+	"github.com/atedgimo/k8s-dencer/internal/impact"
+	"github.com/atedgimo/k8s-dencer/internal/model"
+	"github.com/atedgimo/k8s-dencer/internal/planner"
+	"github.com/atedgimo/k8s-dencer/internal/reclaim"
+	"github.com/atedgimo/k8s-dencer/internal/store"
+	"github.com/atedgimo/k8s-dencer/internal/telemetry"
+)
+
+// Source produces cluster snapshots. Satisfied by *cluster.Collector; a stub
+// in tests, which is the point of the indirection.
+type Source interface {
+	Snapshot(ctx context.Context) (*model.ClusterSnapshot, error)
+}
+
+// Publisher runs planning cycles and holds the latest published state.
+type Publisher struct {
+	Log        *slog.Logger
+	Source     Source
+	Strategy   planner.Strategy
+	Options    planner.Options
+	Classifier impact.Classifier
+	DB         store.Store
+	// Retain bounds plan history; passed through to Prune after each stored
+	// plan.
+	Retain  int
+	Metrics *telemetry.Metrics
+
+	latest         atomic.Pointer[model.ClusterSnapshot]
+	latestAnalysis atomic.Pointer[constraints.Analysis]
+	latestPlan     atomic.Pointer[model.Plan]
+}
+
+// LatestSnapshot returns the last successfully collected snapshot, or nil.
+func (p *Publisher) LatestSnapshot() *model.ClusterSnapshot { return p.latest.Load() }
+
+// LatestAnalysis returns the last constraint analysis, or nil.
+func (p *Publisher) LatestAnalysis() *constraints.Analysis { return p.latestAnalysis.Load() }
+
+// LatestPlan returns the last computed plan, or nil.
+func (p *Publisher) LatestPlan() *model.Plan { return p.latestPlan.Load() }
+
+// Cycle performs one complete planning cycle. It never returns an error:
+// every failure mode has a defined degraded behaviour, logged and counted,
+// because the planning loop must survive anything short of process death.
+func (p *Publisher) Cycle(ctx context.Context) {
+	cycleStart := time.Now()
+
+	snap, err := p.Source.Snapshot(ctx)
+	if err != nil {
+		p.Log.Error("snapshot failed", "error", err)
+		p.Metrics.SnapshotFailure.Inc()
+		return
+	}
+	p.latest.Store(snap)
+
+	allocatable, requested := snap.Totals()
+	cpu, mem, pods := requested.Ratio(allocatable)
+
+	occupied := 0
+	for _, n := range snap.Nodes {
+		if !snap.RequestedOnNode(n.Name).IsZero() {
+			occupied++
+		}
+	}
+
+	blocking := 0
+	for _, pdb := range snap.PDBs {
+		if pdb.Blocks() {
+			blocking++
+		}
+	}
+
+	p.Log.Info("snapshot",
+		"nodes", len(snap.Nodes),
+		"nodesOccupied", occupied,
+		"pods", len(snap.Pods),
+		"pdbs", len(snap.PDBs),
+		"pdbsBlocking", blocking,
+		"cpuRequestedPct", pct(cpu),
+		"memRequestedPct", pct(mem),
+		"podSlotsUsedPct", pct(pods),
+		"usageData", snap.HasUsageData,
+	)
+	p.Metrics.SnapshotNodes.Set(float64(len(snap.Nodes)))
+	p.Metrics.SnapshotPods.Set(float64(len(snap.Pods)))
+
+	analysis := constraints.Analyze(snap)
+	p.latestAnalysis.Store(analysis)
+
+	cs := analysis.Summarize()
+	undrainable := 0
+	for _, n := range snap.Nodes {
+		if drainable, _ := analysis.NodeDrainable(n.Name); !drainable {
+			undrainable++
+		}
+	}
+
+	p.Log.Info("constraints",
+		"movable", cs.Movable,
+		"blocked", cs.Blocked,
+		"stuck", cs.Stuck,
+		"pdbBlocked", cs.PDBBlocked,
+		"antiAffinity", cs.AntiAffinity,
+		"spreadBound", cs.SpreadBound,
+		"controllerPinned", cs.ControllerPin,
+		"nodesUndrainable", undrainable,
+	)
+
+	plan, err := p.Strategy.Plan(snap, analysis, p.Options)
+	if err != nil {
+		p.Log.Error("planning failed", "error", err)
+		return
+	}
+	// Rating happens after planning, never during it: the plan is the ideal
+	// end state, and risk is a separate judgement laid over it.
+	p.Classifier.ClassifyPlan(plan, snap, analysis)
+	p.latestPlan.Store(plan)
+
+	byRating := plan.CountByRating()
+	p.Log.Info("plan",
+		"id", plan.ID,
+		"strategy", p.Strategy.Name(),
+		"steps", len(plan.Steps),
+		"nodesBefore", plan.NodesBefore,
+		"nodesAfter", plan.NodesAfter,
+		"reclaims", plan.ReclaimedNodes(),
+		"green", byRating[model.ImpactGreen],
+		"yellow", byRating[model.ImpactYellow],
+		"red", byRating[model.ImpactRed],
+	)
+
+	// Set every rating explicitly, including the zeroes. Leaving a label unset
+	// makes the series vanish from the scrape, and a missing series reads as a
+	// gap in a graph rather than as "no Red steps" — the opposite of the
+	// reassurance it should give.
+	for _, r := range []model.ImpactRating{model.ImpactGreen, model.ImpactYellow, model.ImpactRed} {
+		p.Metrics.PlanSteps.WithLabelValues(string(r)).Set(float64(byRating[r]))
+	}
+	p.Metrics.NodesReclaimed.Set(float64(plan.ReclaimedNodes()))
+	p.Metrics.PlanProduced(time.Now())
+	p.Metrics.PlanCycleTime.Observe(time.Since(cycleStart).Seconds())
+
+	// The planner is the only component watching nodes continuously, so it is
+	// the one that can tell whether a node the executor drained was actually
+	// removed. Done against the snapshot just taken, so it costs no API calls
+	// — and done BEFORE Save's dedup early-return, because a node
+	// disappearing is exactly the kind of change that does not alter the plan.
+	p.observeReclamations(ctx, snap)
+
+	stored, err := p.DB.Save(ctx, store.Record{
+		Plan:     plan,
+		Snapshot: snap,
+		Analysis: analysis,
+		Strategy: p.Strategy.Name(),
+	})
+	if err != nil {
+		// A store failure must not stop planning: the in-memory plan is still
+		// correct and the next cycle will retry the write.
+		p.Log.Error("storing plan failed", "error", err)
+		return
+	}
+	if !stored {
+		// Same content hash as the previous write, so the cluster has not
+		// changed in any way that alters the plan. Save has still touched
+		// stored_at — that touch is the freshness signal, and it is why Save
+		// is called unconditionally rather than guarded by a comparison here.
+		return
+	}
+	p.Log.Info("plan stored", "id", plan.ID)
+
+	if pruned, err := p.DB.Prune(ctx, p.Retain); err != nil {
+		p.Log.Warn("pruning plan history failed", "error", err)
+	} else if pruned > 0 {
+		p.Log.Info("pruned plan history", "removed", pruned, "retained", p.Retain)
+	}
+}
+
+// observeReclamations resolves drained nodes against the snapshot just taken:
+// still present and cordoned means still awaiting, gone means reclaimed,
+// present and schedulable again means returned.
+func (p *Publisher) observeReclamations(ctx context.Context, snap *model.ClusterSnapshot) {
+	tracker, ok := p.DB.(store.ReclamationStore)
+	if !ok {
+		return
+	}
+
+	pending, err := tracker.PendingReclamations(ctx)
+	if err != nil {
+		p.Log.Error("could not read pending reclamations", "error", err)
+		return
+	}
+	p.Metrics.NodesAwaitingReclamation.Set(float64(len(pending)))
+	if len(pending) == 0 {
+		return
+	}
+
+	now := time.Now().UTC()
+	for _, t := range reclaim.Resolve(pending, snap, now) {
+		if err := tracker.ResolveReclamation(ctx, t.Reclamation.Node, t.Reclamation.DrainedAt, t.Outcome, t.At); err != nil {
+			if !errors.Is(err, store.ErrNotFound) {
+				p.Log.Error("could not resolve reclamation", "node", t.Reclamation.Node, "error", err)
+			}
+			continue
+		}
+		switch t.Outcome {
+		case store.ReclaimedGone:
+			// The moment the product exists to produce, and the first time it
+			// has ever been recorded rather than assumed.
+			p.Log.Info("node reclaimed", "node", t.Reclamation.Node,
+				"after", t.Took.Round(time.Second), "run", t.Reclamation.RunID)
+			p.Metrics.ReclamationSeconds.Observe(t.Took.Seconds())
+		case store.ReclaimedReturned:
+			p.Log.Info("drained node returned to service", "node", t.Reclamation.Node,
+				"run", t.Reclamation.RunID)
+			p.Metrics.NodesReturnedTotal.Inc()
+		}
+	}
+
+	// Recount rather than subtract: a drain recorded by the executor between
+	// the read above and now would make arithmetic wrong, and this gauge is
+	// the one an operator alerts on.
+	if remaining, err := tracker.PendingReclamations(ctx); err == nil {
+		p.Metrics.NodesAwaitingReclamation.Set(float64(len(remaining)))
+	}
+}
+
+func pct(f float64) string {
+	return fmt.Sprintf("%.1f%%", f*100)
+}

--- a/internal/publish/publish_test.go
+++ b/internal/publish/publish_test.go
@@ -1,0 +1,214 @@
+package publish_test
+
+// These tests exist because both of this repo's worst bugs lived in the code
+// this package was extracted from — not in any algorithm, but in the wiring:
+// what still has to happen on a cycle whose plan did not change. Each test
+// pins one of those properties. They run against the real SQLite store, not a
+// mock of it, because the dedup behaviour under test is the store's own.
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/atedgimo/k8s-dencer/internal/impact"
+	"github.com/atedgimo/k8s-dencer/internal/model"
+	"github.com/atedgimo/k8s-dencer/internal/planner"
+	"github.com/atedgimo/k8s-dencer/internal/publish"
+	"github.com/atedgimo/k8s-dencer/internal/store"
+	sqlitestore "github.com/atedgimo/k8s-dencer/internal/store/sqlite"
+	"github.com/atedgimo/k8s-dencer/internal/telemetry"
+)
+
+// steadySource returns the same snapshot every cycle: a stable cluster, which
+// is the healthiest possible state and historically the buggiest code path.
+type steadySource struct{ snap *model.ClusterSnapshot }
+
+func (s steadySource) Snapshot(context.Context) (*model.ClusterSnapshot, error) {
+	return s.snap, nil
+}
+
+type failingSource struct{}
+
+func (failingSource) Snapshot(context.Context) (*model.ClusterSnapshot, error) {
+	return nil, errors.New("apiserver went away")
+}
+
+// failingSaves wraps the real store and fails only Save, because "a store
+// failure must not stop planning" is a claim about what happens around Save,
+// not instead of it.
+type failingSaves struct {
+	store.Store
+}
+
+func (f failingSaves) Save(context.Context, store.Record) (bool, error) {
+	return false, errors.New("disk full")
+}
+
+func newPublisher(t *testing.T, src publish.Source, db store.Store) *publish.Publisher {
+	t.Helper()
+	return &publish.Publisher{
+		Log:        slog.New(slog.DiscardHandler),
+		Source:     src,
+		Strategy:   planner.Greedy{},
+		Options:    planner.DefaultOptions(),
+		Classifier: impact.New(impact.Thresholds{}),
+		DB:         db,
+		Retain:     10,
+		Metrics:    telemetry.NewMetrics(telemetry.ComponentPlanner),
+	}
+}
+
+func openStore(t *testing.T) store.Store {
+	t.Helper()
+	db, err := sqlitestore.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := db.Migrate(t.Context()); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return db
+}
+
+func snapshot(t *testing.T) *model.ClusterSnapshot {
+	t.Helper()
+	opts := model.DefaultSynthetic(8)
+	// Old enough that minNodeAge does not empty the plan.
+	snap := model.Synthesize(opts)
+	return snap
+}
+
+// The property whose absence shipped as "confirmed 72 minutes ago" on a
+// cluster that had not moved: an unchanged plan must still reach Save every
+// cycle, because the store's stored_at touch on the dedup path is the
+// "still confirmed" signal the freshness display rests on.
+func TestUnchangedPlanStillRefreshesItsConfirmation(t *testing.T) {
+	db := openStore(t)
+	pub := newPublisher(t, steadySource{snapshot(t)}, db)
+
+	pub.Cycle(t.Context())
+	first, err := db.Latest(t.Context())
+	if err != nil {
+		t.Fatalf("latest after first cycle: %v", err)
+	}
+
+	// Same cluster, later. The plan's content hash will be identical.
+	time.Sleep(20 * time.Millisecond)
+	pub.Cycle(t.Context())
+	second, err := db.Latest(t.Context())
+	if err != nil {
+		t.Fatalf("latest after second cycle: %v", err)
+	}
+
+	if first.Plan.ID != second.Plan.ID {
+		t.Fatalf("plan changed on a steady cluster: %s -> %s — the fixture no longer tests the dedup path",
+			first.Plan.ID, second.Plan.ID)
+	}
+	if !second.StoredAt.After(first.StoredAt) {
+		t.Errorf("stored_at did not advance across an unchanged cycle (%v -> %v); "+
+			"the UI's \"confirmed just now\" is frozen and the staleness warning fires backwards again",
+			first.StoredAt, second.StoredAt)
+	}
+}
+
+// A store failure must not stop planning: the in-memory plan is still correct,
+// still published to the debug endpoints, and the next cycle retries.
+func TestStoreFailureDoesNotStopPublishing(t *testing.T) {
+	db := openStore(t)
+	pub := newPublisher(t, steadySource{snapshot(t)}, failingSaves{db})
+
+	pub.Cycle(t.Context())
+
+	if pub.LatestPlan() == nil {
+		t.Error("no plan published after a Save failure; a full disk has taken the planner's output with it")
+	}
+	if pub.LatestSnapshot() == nil || pub.LatestAnalysis() == nil {
+		t.Error("snapshot or analysis withheld after a Save failure")
+	}
+}
+
+// A snapshot failure leaves the previously published state in place.
+// Publishing nothing is recoverable; overwriting good state with nothing is
+// how an empty cluster gets planned against.
+func TestSnapshotFailureKeepsLastGoodState(t *testing.T) {
+	db := openStore(t)
+	good := newPublisher(t, steadySource{snapshot(t)}, db)
+	good.Cycle(t.Context())
+	planBefore := good.LatestPlan()
+	if planBefore == nil {
+		t.Fatal("fixture produced no plan")
+	}
+
+	good.Source = failingSource{}
+	good.Cycle(t.Context())
+
+	if got := good.LatestPlan(); got != planBefore {
+		t.Error("a failed snapshot replaced the last good plan")
+	}
+	if good.LatestSnapshot() == nil {
+		t.Error("a failed snapshot cleared the last good snapshot")
+	}
+}
+
+// Reclamations are observed on every cycle, including one whose plan did not
+// change. A node disappearing is exactly the kind of change that does not
+// alter the plan — the drained node was already excluded from it — so putting
+// the observation after the dedup early-return would blind the tracker on
+// stable clusters, which is where it spends its life.
+func TestReclamationsResolveOnAnUnchangedCycle(t *testing.T) {
+	db := openStore(t)
+	tracker, ok := db.(store.ReclamationStore)
+	if !ok {
+		t.Fatal("sqlite store no longer implements ReclamationStore")
+	}
+
+	snap := snapshot(t)
+	pub := newPublisher(t, steadySource{snap}, db)
+
+	// Warm the dedup: first cycle stores the plan.
+	pub.Cycle(t.Context())
+
+	// A node was drained earlier and its machine has since disappeared — it is
+	// in the tracker but absent from the snapshot.
+	drainedAt := time.Now().UTC().Add(-10 * time.Minute)
+	if err := tracker.RecordDrain(t.Context(), store.Reclamation{
+		Node:      "node-that-is-gone",
+		DrainedAt: drainedAt,
+	}); err != nil {
+		t.Fatalf("record drain: %v", err)
+	}
+
+	// Second cycle: same snapshot, same plan ID, dedup path. The observation
+	// must still happen.
+	pub.Cycle(t.Context())
+
+	pending, err := tracker.PendingReclamations(t.Context())
+	if err != nil {
+		t.Fatalf("pending: %v", err)
+	}
+	for _, p := range pending {
+		if p.Node == "node-that-is-gone" {
+			t.Error("a reclamation stayed pending across a cycle that saw the node gone; " +
+				"observation has moved after the dedup early-return")
+		}
+	}
+
+	recent, err := tracker.Reclamations(t.Context(), 10)
+	if err != nil {
+		t.Fatalf("reclamations: %v", err)
+	}
+	found := false
+	for _, r := range recent {
+		if r.Node == "node-that-is-gone" && r.Outcome == store.ReclaimedGone {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("the gone node was not recorded as reclaimed")
+	}
+}

--- a/internal/safety/safety.go
+++ b/internal/safety/safety.go
@@ -15,6 +15,7 @@
 package safety
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/atedgimo/k8s-dencer/internal/constraints"
@@ -75,7 +76,9 @@ type Limits struct {
 // so "no windows at all" is representable as nil — which is what Phase 2 was,
 // and what an install that never creates one stays.
 type Windows interface {
-	AllowsRedOn(node model.Node) (bool, string)
+	// The context is the run's own: an operator aborting a run must also
+	// abort a window read in flight, not wait out its timeout.
+	AllowsRedOn(ctx context.Context, node model.Node) (bool, string)
 }
 
 // DefaultLimits are deliberately conservative. An operator who wants to drain
@@ -130,7 +133,7 @@ type RunState struct {
 // live must be a freshly-collected snapshot, not the one the plan was computed
 // from. Checking a step against the state that produced it would confirm only
 // that the planner was self-consistent.
-func (g *Guard) CheckStep(step model.PlanStep, live *model.ClusterSnapshot, run RunState) error {
+func (g *Guard) CheckStep(ctx context.Context, step model.PlanStep, live *model.ClusterSnapshot, run RunState) error {
 	if g.limits.MaxNodesPerRun > 0 && run.NodesDrainedSoFar >= g.limits.MaxNodesPerRun {
 		return block(RuleMaxNodesPerRun,
 			"this run has already drained %d node(s), the configured maximum. "+
@@ -151,7 +154,7 @@ func (g *Guard) CheckStep(step model.PlanStep, live *model.ClusterSnapshot, run 
 	// Red is checked against the windows covering THIS node, which is why it
 	// comes after the node is resolved rather than first. A window scoped to a
 	// batch pool must not authorise a step elsewhere.
-	if err := g.checkRed(step, node); err != nil {
+	if err := g.checkRed(ctx, step, node); err != nil {
 		return err
 	}
 
@@ -169,7 +172,7 @@ func (g *Guard) CheckStep(step model.PlanStep, live *model.ClusterSnapshot, run 
 // Doc §9: "Red-rated steps can only execute inside an active, approved
 // maintenance window — enforced by the Safety Guard itself, not left to UI/API
 // input validation, so it cannot be bypassed by a crafted request."
-func (g *Guard) checkRed(step model.PlanStep, node model.Node) error {
+func (g *Guard) checkRed(ctx context.Context, step model.PlanStep, node model.Node) error {
 	if !step.Impact.RequiresMaintenanceWindow() {
 		return nil
 	}
@@ -182,7 +185,7 @@ func (g *Guard) checkRed(step model.PlanStep, node model.Node) error {
 				"none is configured. Rated Red because: %s",
 			step.SequenceNumber, step.Rationale)
 	}
-	allowed, why := g.windows.AllowsRedOn(node)
+	allowed, why := g.windows.AllowsRedOn(ctx, node)
 	if !allowed {
 		return block(RuleRedRequiresWindow,
 			"step %d is rated Red and may only run inside an approved maintenance window: %s. "+

--- a/internal/safety/safety_test.go
+++ b/internal/safety/safety_test.go
@@ -1,6 +1,7 @@
 package safety_test
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"testing"
@@ -70,7 +71,7 @@ func TestRedStepsAreRefused(t *testing.T) {
 	live := &model.ClusterSnapshot{Nodes: []model.Node{node("a", 4000), node("b", 4000)}}
 	g := safety.New(permissive())
 
-	err := g.CheckStep(step(7, "a", model.ImpactRed), live, safety.RunState{})
+	err := g.CheckStep(t.Context(), step(7, "a", model.ImpactRed), live, safety.RunState{})
 	b := blockedBy(t, err, safety.RuleRedRequiresWindow)
 
 	// The refusal must quote the classifier's own rationale, so the operator
@@ -88,7 +89,7 @@ func TestGreenAndYellowStepsPass(t *testing.T) {
 	g := safety.New(permissive())
 
 	for _, impact := range []model.ImpactRating{model.ImpactGreen, model.ImpactYellow} {
-		if err := g.CheckStep(step(1, "a", impact), live, safety.RunState{}); err != nil {
+		if err := g.CheckStep(t.Context(), step(1, "a", impact), live, safety.RunState{}); err != nil {
 			t.Errorf("%s step refused: %v", impact, err)
 		}
 	}
@@ -98,10 +99,10 @@ func TestMaxNodesPerRunCapsTheWholeRequest(t *testing.T) {
 	live := &model.ClusterSnapshot{Nodes: []model.Node{node("a", 4000), node("b", 4000)}}
 	g := safety.New(safety.Limits{MaxNodesPerRun: 3})
 
-	if err := g.CheckStep(step(1, "a", model.ImpactGreen), live, safety.RunState{NodesDrainedSoFar: 2}); err != nil {
+	if err := g.CheckStep(t.Context(), step(1, "a", model.ImpactGreen), live, safety.RunState{NodesDrainedSoFar: 2}); err != nil {
 		t.Fatalf("third node refused early: %v", err)
 	}
-	err := g.CheckStep(step(1, "a", model.ImpactGreen), live, safety.RunState{NodesDrainedSoFar: 3})
+	err := g.CheckStep(t.Context(), step(1, "a", model.ImpactGreen), live, safety.RunState{NodesDrainedSoFar: 3})
 	blockedBy(t, err, safety.RuleMaxNodesPerRun)
 }
 
@@ -114,7 +115,7 @@ func TestMinReadyNodesCountsOnlySchedulableCapacity(t *testing.T) {
 		live := &model.ClusterSnapshot{Nodes: []model.Node{
 			node("a", 4000), node("b", 4000), node("c", 4000),
 		}}
-		if err := g.CheckStep(step(1, "a", model.ImpactGreen), live, safety.RunState{}); err != nil {
+		if err := g.CheckStep(t.Context(), step(1, "a", model.ImpactGreen), live, safety.RunState{}); err != nil {
 			t.Errorf("refused with 2 nodes left: %v", err)
 		}
 	})
@@ -127,7 +128,7 @@ func TestMinReadyNodesCountsOnlySchedulableCapacity(t *testing.T) {
 			node("d", 4000),
 		}}
 		// Only a and d are schedulable; draining a leaves 1, below the floor.
-		err := g.CheckStep(step(1, "a", model.ImpactGreen), live, safety.RunState{})
+		err := g.CheckStep(t.Context(), step(1, "a", model.ImpactGreen), live, safety.RunState{})
 		b := blockedBy(t, err, safety.RuleMinReadyNodes)
 		if !strings.Contains(b.Reason, "floor of 2") {
 			t.Errorf("refusal should state the floor: %s", b.Reason)
@@ -137,7 +138,7 @@ func TestMinReadyNodesCountsOnlySchedulableCapacity(t *testing.T) {
 
 func TestVanishedNodeIsRefused(t *testing.T) {
 	live := &model.ClusterSnapshot{Nodes: []model.Node{node("b", 4000)}}
-	err := safety.New(permissive()).CheckStep(step(1, "gone", model.ImpactGreen), live, safety.RunState{})
+	err := safety.New(permissive()).CheckStep(t.Context(), step(1, "gone", model.ImpactGreen), live, safety.RunState{})
 	blockedBy(t, err, safety.RuleNodeNotFound)
 }
 
@@ -151,7 +152,7 @@ func TestStepIsRefusedWhenPodsHaveNowhereToGo(t *testing.T) {
 			Nodes: []model.Node{node("a", 4000), node("b", 4000)},
 			Pods:  []model.Pod{pod("app", "x", "a", 1000)},
 		}
-		if err := g.CheckStep(step(1, "a", model.ImpactGreen), live, safety.RunState{}); err != nil {
+		if err := g.CheckStep(t.Context(), step(1, "a", model.ImpactGreen), live, safety.RunState{}); err != nil {
 			t.Errorf("refused a feasible step: %v", err)
 		}
 	})
@@ -164,7 +165,7 @@ func TestStepIsRefusedWhenPodsHaveNowhereToGo(t *testing.T) {
 				pod("app", "filler", "b", 3800), // b has only 200m left
 			},
 		}
-		err := g.CheckStep(step(1, "a", model.ImpactGreen), live, safety.RunState{})
+		err := g.CheckStep(t.Context(), step(1, "a", model.ImpactGreen), live, safety.RunState{})
 		b := blockedBy(t, err, safety.RuleStepFreshness)
 		if !strings.Contains(b.Reason, "app/big") {
 			t.Errorf("refusal should name the homeless pod: %s", b.Reason)
@@ -181,7 +182,7 @@ func TestStepIsRefusedWhenPodsHaveNowhereToGo(t *testing.T) {
 				pod("app", "p2", "a", 2500),
 			},
 		}
-		err := g.CheckStep(step(1, "a", model.ImpactGreen), live, safety.RunState{})
+		err := g.CheckStep(t.Context(), step(1, "a", model.ImpactGreen), live, safety.RunState{})
 		blockedBy(t, err, safety.RuleStepFreshness)
 	})
 }
@@ -196,7 +197,7 @@ func TestDaemonSetPodsDoNotBlockADrain(t *testing.T) {
 			pod("kube-system", "agent-b", "b", 900, daemonSet),
 		},
 	}
-	if err := safety.New(permissive()).CheckStep(step(1, "a", model.ImpactGreen), live, safety.RunState{}); err != nil {
+	if err := safety.New(permissive()).CheckStep(t.Context(), step(1, "a", model.ImpactGreen), live, safety.RunState{}); err != nil {
 		t.Errorf("a node holding only DaemonSet pods should be drainable: %v", err)
 	}
 }
@@ -269,7 +270,7 @@ type stubWindows struct {
 	why   string
 }
 
-func (s stubWindows) AllowsRedOn(model.Node) (bool, string) { return s.allow, s.why }
+func (s stubWindows) AllowsRedOn(context.Context, model.Node) (bool, string) { return s.allow, s.why }
 
 // The whole point of Phase 3: an open window that permits Red unlocks a step
 // that was previously refused outright.
@@ -278,7 +279,7 @@ func TestRedIsPermittedByAnOpenWindow(t *testing.T) {
 	red := step(7, "a", model.ImpactRed)
 
 	t.Run("no windows configured", func(t *testing.T) {
-		err := safety.New(permissive()).CheckStep(red, live, safety.RunState{})
+		err := safety.New(permissive()).CheckStep(t.Context(), red, live, safety.RunState{})
 		b := blockedBy(t, err, safety.RuleRedRequiresWindow)
 		if !strings.Contains(b.Reason, "none is configured") {
 			t.Errorf("refusal should say no window exists: %s", b.Reason)
@@ -289,7 +290,7 @@ func TestRedIsPermittedByAnOpenWindow(t *testing.T) {
 		g := safety.New(permissive()).WithWindows(stubWindows{
 			allow: false, why: "maintenance window nightly is open but does not permit Red steps",
 		})
-		b := blockedBy(t, g.CheckStep(red, live, safety.RunState{}), safety.RuleRedRequiresWindow)
+		b := blockedBy(t, g.CheckStep(t.Context(), red, live, safety.RunState{}), safety.RuleRedRequiresWindow)
 		// The refusal must carry the window's own explanation, so an operator
 		// can tell "nothing is open" from "open, but not for this".
 		if !strings.Contains(b.Reason, "does not permit Red steps") {
@@ -303,7 +304,7 @@ func TestRedIsPermittedByAnOpenWindow(t *testing.T) {
 
 	t.Run("window open and permits Red", func(t *testing.T) {
 		g := safety.New(permissive()).WithWindows(stubWindows{allow: true, why: "open until 06:00"})
-		if err := g.CheckStep(red, live, safety.RunState{}); err != nil {
+		if err := g.CheckStep(t.Context(), red, live, safety.RunState{}); err != nil {
 			t.Errorf("an open permissive window should admit a Red step: %v", err)
 		}
 	})
@@ -318,14 +319,14 @@ func TestAnOpenWindowDoesNotSuspendTheOtherRails(t *testing.T) {
 	live := &model.ClusterSnapshot{Nodes: []model.Node{node("a", 4000), node("b", 4000)}}
 
 	// Node floor still applies.
-	blockedBy(t, g.CheckStep(step(1, "a", model.ImpactRed), live, safety.RunState{}),
+	blockedBy(t, g.CheckStep(t.Context(), step(1, "a", model.ImpactRed), live, safety.RunState{}),
 		safety.RuleMinReadyNodes)
 
 	// Run cap still applies.
 	big := &model.ClusterSnapshot{Nodes: []model.Node{
 		node("a", 4000), node("b", 4000), node("c", 4000), node("d", 4000),
 	}}
-	blockedBy(t, g.CheckStep(step(1, "a", model.ImpactRed), big, safety.RunState{NodesDrainedSoFar: 2}),
+	blockedBy(t, g.CheckStep(t.Context(), step(1, "a", model.ImpactRed), big, safety.RunState{NodesDrainedSoFar: 2}),
 		safety.RuleMaxNodesPerRun)
 }
 
@@ -343,16 +344,16 @@ func TestRedIsCheckedAgainstTheStepsOwnNode(t *testing.T) {
 	scoped := scopedWindows{pool: "batch"}
 	g := safety.New(permissive()).WithWindows(scoped)
 
-	if err := g.CheckStep(step(1, "batch-1", model.ImpactRed), live, safety.RunState{}); err != nil {
+	if err := g.CheckStep(t.Context(), step(1, "batch-1", model.ImpactRed), live, safety.RunState{}); err != nil {
 		t.Errorf("a node inside the window's scope should be permitted: %v", err)
 	}
-	blockedBy(t, g.CheckStep(step(2, "web-1", model.ImpactRed), live, safety.RunState{}),
+	blockedBy(t, g.CheckStep(t.Context(), step(2, "web-1", model.ImpactRed), live, safety.RunState{}),
 		safety.RuleRedRequiresWindow)
 }
 
 type scopedWindows struct{ pool string }
 
-func (s scopedWindows) AllowsRedOn(n model.Node) (bool, string) {
+func (s scopedWindows) AllowsRedOn(_ context.Context, n model.Node) (bool, string) {
 	if n.Labels["pool"] == s.pool {
 		return true, "covered"
 	}

--- a/internal/window/reader.go
+++ b/internal/window/reader.go
@@ -62,8 +62,11 @@ func (r *Reader) Current(ctx context.Context) (*Set, error) {
 //
 // Errors resolve to "refused", with the error in the reason. A window is an
 // authorisation, and being unable to read one is not the same as having one.
-func (r *Reader) AllowsRedOn(node model.Node) (bool, string) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+func (r *Reader) AllowsRedOn(ctx context.Context, node model.Node) (bool, string) {
+	// The caller's context, capped: a wedged API server must not stall a step
+	// for longer than this, but an operator aborting the run must not have to
+	// wait even that long — cancellation propagates from the run itself.
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
 	set, err := r.Current(ctx)


### PR DESCRIPTION
Code-review items #1 and #2, one theme: **the wiring nobody tests.**

## #1 — `collect()` → `internal/publish` (0% → tested)

The coverage map was inverted: `internal/safety` 93.8%, `internal/planner` 90.8% — and the 200 lines deciding *what gets published when the plan doesn't change* sat in a `main()` at **zero**. Both of this repo's worst bugs lived in exactly that code.

Now `publish.Publisher`, moved verbatim where possible (log fields byte-identical), with the invariants pinned against the **real SQLite store**, not a mock — the dedup behaviour under test is the store's own:

| Invariant | Why it's the one that matters |
|---|---|
| unchanged plan still reaches `Save` every cycle | `stored_at`'s touch is the "still confirmed" signal — skipping it resurrects the backwards staleness warning |
| reclamations resolve on an unchanged cycle | a node disappearing is exactly the change that *doesn't* alter the plan |
| `Save` failure doesn't stop publishing | a full disk must not take the planner's output with it |
| snapshot failure keeps last good state | publishing nothing is recoverable; planning against an empty cluster is not |

Each **mutation-tested** by re-creating the original bug shape. One mutation was a no-op on the first try and was rewritten until it genuinely re-created the bug — a mutation that doesn't fire proves nothing.

## #2 — `safety.Windows` gains the run's context

`AllowsRedOn` built `context.Background()` + 10s because the interface offered nothing better — so an operator aborting a run could wait out a wedged API-server read they had already cancelled. The timeout survives as a cap; cancellation now propagates run → `CheckStep` → wire.

`cmd/planner/main.go` is now ~230 lines of what a main should be: env, informers, HTTP, a ticker.

All 19 packages green, chart contract green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)