### PR TITLE
State what the node count is worth: reclaimable capacity in the verdict

### DIFF
--- a/internal/api/graph/graph.go
+++ b/internal/api/graph/graph.go
@@ -114,11 +114,21 @@ type Stats struct {
 	Ratings     map[string]int `json:"ratings"`
 	PodsMoved   int            `json:"podsMoved"`
 
-	// nodesAfter, cpuReclaimedMilli and memoryReclaimedBytes used to live
-	// here. Nothing read any of them, and the freed-capacity pair were
-	// plan-time predictions dressed in the past tense besides. Removed when a
-	// guard over this struct was finally written; they can come back the day
-	// something reads them.
+	// What the reclaimable nodes are actually worth: the summed allocatable
+	// of every node the plan drains. Nodes are not fungible — "reclaim 15
+	// nodes" may be a rack of 96-core machines or a drawer of 2-core ones,
+	// and the count alone cannot say whether the plan is worth running.
+	//
+	// A near-identical pair lived here once, past-tensed as "reclaimed", and
+	// was removed because nothing read them — the contract test over this
+	// struct enforces that in both directions. They return under the plan's
+	// honest tense and with a reader in the verdict, which is exactly the
+	// bar the removal comment set: "they can come back the day something
+	// reads them."
+	CPUReclaimableMilli int64 `json:"cpuReclaimableMilli"`
+	MemReclaimableBytes int64 `json:"memReclaimableBytes"`
+
+	// nodesAfter also lived here once; still nothing reads it.
 }
 
 // Build renders the payload at default detail.
@@ -197,7 +207,7 @@ func BuildWith(plan *model.Plan, snap *model.ClusterSnapshot, analysis *constrai
 	if p.Aggregated {
 		// The node elements above already carry everything the density view
 		// draws. Skipping the pod loop is the entire saving.
-		p.Stats = buildStats(plan, targets)
+		p.Stats = buildStats(plan, snap, targets)
 		return p
 	}
 
@@ -230,16 +240,20 @@ func BuildWith(plan *model.Plan, snap *model.ClusterSnapshot, analysis *constrai
 		p.Elements = append(p.Elements, Element{Data: data})
 	}
 
-	p.Stats = buildStats(plan, targets)
+	p.Stats = buildStats(plan, snap, targets)
 	return p
 }
 
-func buildStats(plan *model.Plan, targets map[string]model.Move) Stats {
+func buildStats(plan *model.Plan, snap *model.ClusterSnapshot, targets map[string]model.Move) Stats {
 	ratings := plan.CountByRating()
+	cpu, mem := model.ReclaimableCapacity(plan, snap)
+
 	return Stats{
-		NodesBefore: plan.NodesBefore,
-		Reclaimable: plan.ReclaimedNodes(),
-		Steps:       len(plan.Steps),
+		NodesBefore:         plan.NodesBefore,
+		Reclaimable:         plan.ReclaimedNodes(),
+		CPUReclaimableMilli: cpu,
+		MemReclaimableBytes: mem,
+		Steps:               len(plan.Steps),
 		Ratings: map[string]int{
 			"Green":  ratings[model.ImpactGreen],
 			"Yellow": ratings[model.ImpactYellow],

--- a/internal/api/graph/graph_test.go
+++ b/internal/api/graph/graph_test.go
@@ -1,0 +1,37 @@
+package graph
+
+import (
+	"testing"
+
+	"github.com/atedgimo/k8s-dencer/internal/model"
+)
+
+// The capacity figures must be the allocatable of the drained nodes — not the
+// requested, not the whole cluster's, and absent nodes must not panic.
+func TestStatsPriceTheReclaimableNodes(t *testing.T) {
+	snap := &model.ClusterSnapshot{
+		Nodes: []model.Node{
+			{Name: "a", Allocatable: model.Resources{MilliCPU: 8000, MemoryBytes: 32 << 30}},
+			{Name: "b", Allocatable: model.Resources{MilliCPU: 4000, MemoryBytes: 16 << 30}},
+			{Name: "c", Allocatable: model.Resources{MilliCPU: 96000, MemoryBytes: 768 << 30}},
+		},
+	}
+	plan := &model.Plan{
+		NodesBefore: 3,
+		Steps: []model.PlanStep{
+			{SequenceNumber: 1, TargetNode: "a"},
+			{SequenceNumber: 2, TargetNode: "b"},
+			// A node that vanished between planning and serving: skipped, not fatal.
+			{SequenceNumber: 3, TargetNode: "gone"},
+		},
+	}
+
+	p := Build(plan, snap, nil)
+
+	if got, want := p.Stats.CPUReclaimableMilli, int64(12000); got != want {
+		t.Errorf("cpu reclaimable = %d, want %d (a+b only; c stays, gone is gone)", got, want)
+	}
+	if got, want := p.Stats.MemReclaimableBytes, int64(48<<30); got != want {
+		t.Errorf("mem reclaimable = %d, want %d", got, want)
+	}
+}

--- a/internal/api/rest/rest.go
+++ b/internal/api/rest/rest.go
@@ -334,12 +334,17 @@ func planResponse(rec store.Record) map[string]any {
 	if rec.Plan.Steps == nil {
 		rec.Plan.Steps = []model.PlanStep{}
 	}
+	// The same figure the UI's verdict shows, so the CLI does not state a
+	// bare node count the web page qualifies.
+	cpu, mem := model.ReclaimableCapacity(rec.Plan, rec.Snapshot)
 	return map[string]any{
-		"plan":     rec.Plan,
-		"strategy": rec.Strategy,
-		"storedAt": rec.StoredAt,
-		"ratings":  rec.Plan.CountByRating(),
-		"readOnly": true,
+		"plan":                rec.Plan,
+		"strategy":            rec.Strategy,
+		"storedAt":            rec.StoredAt,
+		"ratings":             rec.Plan.CountByRating(),
+		"cpuReclaimableMilli": cpu,
+		"memReclaimableBytes": mem,
+		"readOnly":            true,
 	}
 }
 

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -19,6 +19,11 @@ type PlanEnvelope struct {
 	Strategy string         `json:"strategy"`
 	StoredAt time.Time      `json:"storedAt"`
 	Ratings  map[string]int `json:"ratings"`
+	// What the reclaimable count is worth — the summed allocatable of every
+	// node the plan drains. Server-computed, so the CLI and the UI cannot
+	// disagree about it.
+	CPUReclaimableMilli int64 `json:"cpuReclaimableMilli"`
+	MemReclaimableBytes int64 `json:"memReclaimableBytes"`
 }
 
 type RunEnvelope struct {

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -106,6 +106,19 @@ func Encode(w io.Writer, f Format, v any) error {
 	return fmt.Errorf("unknown format %q", f)
 }
 
+// reclaimSummary states what the reclaimable count is worth. A node count
+// alone cannot say whether a plan matters — 15 nodes may be a rack of 96-core
+// machines or a drawer of 2-core ones. Older servers do not send the capacity
+// fields; a bare count is then the honest fallback, not a zero.
+func reclaimSummary(env *PlanEnvelope) string {
+	n := env.Plan.ReclaimedNodes()
+	if env.CPUReclaimableMilli <= 0 {
+		return fmt.Sprintf("%d reclaimable", n)
+	}
+	return fmt.Sprintf("%d reclaimable (%s cores, %s)",
+		n, formatMilli(env.CPUReclaimableMilli), formatBytes(env.MemReclaimableBytes))
+}
+
 // PrintPlan renders a plan as a table.
 func PrintPlan(w io.Writer, env *PlanEnvelope, awaiting int) {
 	p := env.Plan
@@ -113,7 +126,7 @@ func PrintPlan(w io.Writer, env *PlanEnvelope, awaiting int) {
 
 	fmt.Fprintf(w, "%s  %s\n", bold("plan "+p.ID), dim(fmt.Sprintf("%s old, %s", age, env.Strategy)))
 	fmt.Fprintf(w, "%d nodes now, %d after, %s\n\n",
-		p.NodesBefore, p.NodesAfter, bold(fmt.Sprintf("%d reclaimable", p.ReclaimedNodes())))
+		p.NodesBefore, p.NodesAfter, bold(reclaimSummary(env)))
 
 	if len(p.Steps) == 0 {
 		fmt.Fprintln(w, "No steps. Nothing to consolidate — every node is either needed or undrainable.")
@@ -425,4 +438,29 @@ func humanDuration(d time.Duration) string {
 	default:
 		return fmt.Sprintf("%ds", int(d.Seconds()))
 	}
+}
+
+func formatMilli(milli int64) string {
+	if milli%1000 == 0 {
+		return fmt.Sprintf("%d", milli/1000)
+	}
+	return fmt.Sprintf("%.1f", float64(milli)/1000)
+}
+
+func formatBytes(b int64) string {
+	const unit = 1024
+	if b < unit {
+		return fmt.Sprintf("%d B", b)
+	}
+	div, exp := int64(unit), 0
+	for n := b / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	v := float64(b) / float64(div)
+	units := []string{"KiB", "MiB", "GiB", "TiB"}
+	if v == float64(int64(v)) {
+		return fmt.Sprintf("%d %s", int64(v), units[exp])
+	}
+	return fmt.Sprintf("%.1f %s", v, units[exp])
 }

--- a/internal/model/plan.go
+++ b/internal/model/plan.go
@@ -127,3 +127,25 @@ type Move struct {
 	CPUMilli    int64 `json:"cpuMilli,omitempty"`
 	MemoryBytes int64 `json:"memoryBytes,omitempty"`
 }
+
+// ReclaimableCapacity sums the allocatable of every node the plan drains —
+// what the plan's node count is actually worth. Nodes are not fungible:
+// "reclaim 15 nodes" may be a rack of 96-core machines or a drawer of 2-core
+// ones, and the count alone cannot say whether the plan matters.
+//
+// Computed from the snapshot rather than stored on the plan, because the plan
+// persists in columns the schema would have to grow, while every consumer that
+// wants this figure already holds the snapshot the plan was made from.
+func ReclaimableCapacity(plan *Plan, snap *ClusterSnapshot) (cpuMilli, memBytes int64) {
+	byName := make(map[string]*Node, len(snap.Nodes))
+	for i := range snap.Nodes {
+		byName[snap.Nodes[i].Name] = &snap.Nodes[i]
+	}
+	for _, step := range plan.Steps {
+		if n, ok := byName[step.TargetNode]; ok {
+			cpuMilli += n.Allocatable.MilliCPU
+			memBytes += n.Allocatable.MemoryBytes
+		}
+	}
+	return cpuMilli, memBytes
+}

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -95,6 +95,13 @@ export interface GraphStats {
   steps: number;
   ratings: Record<Impact, number>;
   podsMoved: number;
+  /**
+   * The summed allocatable of every node the plan drains. Nodes are not
+   * fungible — a count of 15 may be a rack of 96-core machines or a drawer
+   * of 2-core ones — so the verdict states what the count is worth.
+   */
+  cpuReclaimableMilli: number;
+  memReclaimableBytes: number;
 }
 
 export interface GraphPayload {

--- a/ui/src/components/Verdict.tsx
+++ b/ui/src/components/Verdict.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { GraphStats, Impact, PlanStep } from "../api";
+import { formatBytes, formatCPU, GraphStats, Impact, PlanStep } from "../api";
 import { GLYPH } from "./Impact";
 
 /**
@@ -76,6 +76,19 @@ export default function Verdict({
         <h1 className="verdict-line">
           Reclaim <span className="verdict-figure num">{stats.reclaimable}</span> of{" "}
           <span className="num">{stats.nodesBefore}</span> nodes
+          {/* What the count is worth. Nodes are not fungible: "15 nodes" may
+              be a rack of 96-core machines or a drawer of 2-core ones, and
+              the count alone cannot say whether this plan matters. Zero is
+              omitted rather than rendered — "0 cores" under a real headline
+              would read as a bug, and the one honest case for it (a plan
+              with no steps) already says so in words. */}
+          {stats.cpuReclaimableMilli > 0 && (
+            <span className="verdict-capacity num">
+              {" "}
+              · {formatCPU(stats.cpuReclaimableMilli)} cores ·{" "}
+              {formatBytes(stats.memReclaimableBytes)}
+            </span>
+          )}
         </h1>
         {/* The nodes, named. "Run the 5 safe steps" is abstract; a list of
             machines is something an operator can picture and sanity-check

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -150,6 +150,15 @@
   font-weight: 600;
 }
 
+/* What the node count is worth, in capacity. Quieter than the headline it
+   qualifies — the count is the verdict, this is its denomination. */
+.verdict-capacity {
+  font-size: 0.55em;
+  font-weight: 400;
+  color: var(--graphite);
+  letter-spacing: 0.01em;
+}
+
 .verdict-sub {
   margin: 0.5rem 0 0;
   max-width: 46ch;


### PR DESCRIPTION
P1 from the priority list — the first slice of cost-awareness, deliberately report-only.

**Before:** "Reclaim 11 of 31 nodes"
**After:** "Reclaim 11 of 31 nodes **· 88 cores · 352 GiB**" — and `dencer plan` prints `11 reclaimable (88 cores, 352 GiB)`.

- Computed once in `model.ReclaimableCapacity` (summed allocatable of drained nodes), served from both the graph stats and the plan envelope — **CLI and UI cannot disagree**
- *Reclaimable*, not *reclaimed* — the reclamation loop's tense rules apply to capacity too
- These fields existed once and were **removed as data nothing read**, with the comment "they can come back the day something reads them." That day — and the contract test that evicted them now enforces their readers both ways
- Vanished node → contributes nothing; zero → renders nothing (not "0 cores"); old server → CLI falls back to the bare count

Verified live: identical figures from both endpoints. All gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)