### PR TITLE
App sheds its plumbing into three hooks before M25 adds more

### DIFF
--- a/test/ui/client_test.go
+++ b/test/ui/client_test.go
@@ -163,16 +163,23 @@ func TestOidcUsesTheIdTokenAsTheCredential(t *testing.T) {
 // The fix is a poll, and a poll is one deleted line away from being a fetch
 // again, with no compile error and no visible symptom until an hour in.
 func TestPlanConfirmationIsPolledRatherThanFetchedOnce(t *testing.T) {
-	app := read(t, "App.tsx")
-
 	// The version fetch and a setInterval must live in the same effect. A
 	// bare api.version() somewhere plus an unrelated interval elsewhere would
 	// satisfy a naive substring check while leaving the value frozen.
+	ver := read(t, "useVersion.ts")
 	poll := regexp.MustCompile(`api\s*\n?\s*\.version\(\)[\s\S]{0,600}?setInterval\(`)
-	if !poll.MatchString(app) {
-		t.Error("App fetches the version once instead of polling it; " +
+	if !poll.MatchString(ver) {
+		t.Error("useVersion fetches the version once instead of polling it; " +
 			"planConfirmedAt will freeze at page load and the plan will " +
 			"appear to go stale while the planner is still confirming it")
+	}
+
+	// And App must actually use the polling hook — extracting it and then
+	// fetching directly in App would satisfy the check above while the page
+	// froze anyway.
+	app := read(t, "App.tsx")
+	if !strings.Contains(app, "useVersion()") {
+		t.Error("App does not use the useVersion poll; the confirmation freezes at load")
 	}
 
 	// Ageing the displayed plan by another plan's confirmation would be worse
@@ -231,21 +238,28 @@ func TestObservedNodeStatesAreDrawnNotJustParsed(t *testing.T) {
 			"ready field; NotReady nodes are invisible again")
 	}
 
-	app := read(t, "App.tsx")
+	obs := read(t, "useObserved.ts")
 
 	// A rehearsal must never mark a node as actually drained. Dry runs emit
 	// the same event stream on purpose (the UI renders both with one
 	// component), so the observed overlay has to filter them or a dry run
 	// paints the field with drains that never happened.
-	if !regexp.MustCompile(`(?s)const observed = useMemo.{0,900}?!run\.state\.run\.dryRun`).MatchString(app) {
+	if !regexp.MustCompile(`(?s)return useMemo.{0,900}?!runState\.run\.dryRun`).MatchString(obs) {
 		t.Error("the observed overlay does not exclude dry runs; a rehearsal " +
 			"would mark nodes as genuinely drained")
 	}
 
 	// The reclamation lists must reach the overlay as names, not just counts.
 	// The counts-only version shipped and the first question was "which node?".
-	if !strings.Contains(app, `{ reclaim: "awaiting" }`) {
-		t.Error("App no longer maps awaiting reclamations onto named nodes; " +
-			"the field cannot mark which node is dead weight")
+	if !strings.Contains(obs, `{ reclaim: "awaiting" }`) {
+		t.Error("useObserved no longer maps awaiting reclamations onto named " +
+			"nodes; the field cannot mark which node is dead weight")
+	}
+
+	// And the overlay must actually be mounted: derived in a hook nothing
+	// calls is the parsed-but-never-drawn bug with an extra step.
+	app := read(t, "App.tsx")
+	if !strings.Contains(app, "useObserved(") || !strings.Contains(app, "observed={observed}") {
+		t.Error("App does not wire the observed overlay into the field")
 	}
 }

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,8 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { api, Impact, PlanStep, Reclamation, VersionResponse } from "./api";
+import { Impact, PlanStep } from "./api";
 import Inspector, { Selection } from "./components/Inspector";
 import PackingField from "./components/PackingField";
-import { ObservedNode } from "./components/FieldViews";
 import { ConfirmRun, RunTrail } from "./components/RunPanel";
 import Scrubber from "./components/Scrubber";
 import { SignIn } from "./components/SignIn";
@@ -13,8 +12,11 @@ import { FieldView, defaultView, rememberView, storedView } from "./view";
 import { authInfo, token as tokenStore } from "./auth";
 import { onRenewed } from "./oidc";
 import { runtimeConfig } from "./runtime-config";
+import { useObserved } from "./useObserved";
 import { usePlan } from "./usePlan";
+import { useReclamations } from "./useReclamations";
 import { useRun } from "./useRun";
+import { useVersion } from "./useVersion";
 
 export default function App() {
   // Pinned while there is a selection to protect or a run to watch. Step
@@ -28,61 +30,12 @@ export default function App() {
   const [step, setStep] = useState(0);
   const [playing, setPlaying] = useState(false);
 
-  // Observed reclamation, as distinct from what the plan predicts. Polled
-  // rather than pushed: it changes on the planner's resync, which is tens of
-  // seconds, and it is never the reason someone is watching the screen.
-  //
-  // The full lists, not just the tallies. The names in them are the difference
-  // between "2 awaiting" in a tray and the actual node on the field being
-  // marked — the tray version shipped first and a user immediately asked
-  // *which* node. Stats ride along for the tray so its numbers stay the
-  // server's own (the recent list is windowed; recounting it would drift).
-  const [reclamations, setReclamations] = useState<{
-    awaiting: Reclamation[];
-    recent: Reclamation[];
-    stats: { awaiting: number; reclaimed: number };
-  }>({ awaiting: [], recent: [], stats: { awaiting: 0, reclaimed: 0 } });
+  const reclamations = useReclamations();
 
-  // Identity and cluster, for the header. Fetched once — neither changes
-  // within a session, and re-polling them would be noise.
-  const [server, setServer] = useState<VersionResponse | null>(null);
+  const server = useVersion();
 
   // null means "follow cluster size", which is right until someone disagrees.
   const [viewPref, setViewPref] = useState<FieldView | null>(storedView);
-  // Polled, not fetched once, because this response carries the only
-  // liveness signal the client gets.
-  //
-  // A plan re-publishes when its *content* changes. On a steady cluster it
-  // never does — which is the healthiest possible state — so the client would
-  // sit on the storedAt it was handed at load and watch it age past the
-  // staleness threshold while the planner went on confirming the plan every
-  // resync. The warning fired precisely when nothing was wrong. Re-reading
-  // planConfirmedAt is what makes "confirmed just now" stay true, and what
-  // makes the warning mean the thing it says.
-  //
-  // Identity and cluster label ride along unchanged; they are cheap and cannot
-  // drift within a session.
-  useEffect(() => {
-    let cancelled = false;
-    const load = () => {
-      api
-        .version()
-        .then((v) => {
-          if (!cancelled) setServer(v);
-        })
-        .catch(() => {
-          // Leave the last good response in place. A dropped poll is not
-          // evidence the plan went stale, and blanking the header over one
-          // failed request would be its own kind of lie.
-        });
-    };
-    load();
-    const t = setInterval(load, 30_000);
-    return () => {
-      cancelled = true;
-      clearInterval(t);
-    };
-  }, []);
 
   // Sign out clears the credential this tab is carrying, and asks the OIDC
   // provider to forget the session too when there is one. Without the second
@@ -100,31 +53,6 @@ export default function App() {
     tokenStore.clear();
   }, []);
 
-  useEffect(() => {
-    let cancelled = false;
-    const load = async () => {
-      try {
-        const r = await api.reclamations();
-        if (!cancelled && r.tracking) {
-          setReclamations({
-            awaiting: r.awaiting ?? [],
-            recent: r.recent ?? [],
-            stats: { awaiting: r.stats.awaiting, reclaimed: r.stats.reclaimed },
-          });
-        }
-      } catch {
-        // Reclamation tracking is supplementary. A backend that does not have
-        // it, or a transient failure, must never blank the page — the field
-        // and the ledger are what the operator came for.
-      }
-    };
-    void load();
-    const t = setInterval(load, 30_000);
-    return () => {
-      cancelled = true;
-      clearInterval(t);
-    };
-  }, []);
   const [selectedStep, setSelectedStep] = useState<number | null>(null);
   const [selection, setSelection] = useState<Selection>(null);
   const [focusedRating, setFocusedRating] = useState<Impact | null>(null);
@@ -145,42 +73,7 @@ export default function App() {
   // on a picture that no longer matches their cluster.
   const run = useRun(state.status === "ready" ? state.reload : undefined);
 
-  // Everything known about nodes from *outside* the plan's snapshot, keyed by
-  // node name. Two sources, layered oldest-first:
-  //
-  //   - the reclamation tracker: nodes drained for real and what became of them
-  //   - the current run's event trail: the executor saying what it just did,
-  //     which matters most at exactly the moment the plan is pinned and its
-  //     snapshot is at its most wrong
-  //
-  // A dry run is excluded outright. Its events say "would", and letting a
-  // rehearsal mark nodes as actually drained would be the predicted/observed
-  // confusion this overlay exists to end, rebuilt one layer up.
-  const observed = useMemo(() => {
-    const m = new Map<string, ObservedNode>();
-    for (const r of reclamations.awaiting) {
-      m.set(r.node, { reclaim: "awaiting" });
-    }
-    for (const r of reclamations.recent) {
-      if (r.outcome === "reclaimed") m.set(r.node, { reclaim: "reclaimed" });
-      // "returned" is deliberately not drawn: the node is back in service and
-      // is, once again, just a node. The tray still counts it.
-    }
-    if (run.state.status === "active" || run.state.status === "done") {
-      if (!run.state.run.dryRun) {
-        for (const e of run.state.events) {
-          if (!e.node) continue;
-          if (e.action === "Cordon") {
-            m.set(e.node, { ...m.get(e.node), cordoned: true });
-          } else if (e.action === "Drained") {
-            const cur = m.get(e.node);
-            m.set(e.node, { ...cur, cordoned: true, reclaim: cur?.reclaim ?? "awaiting" });
-          }
-        }
-      }
-    }
-    return m;
-  }, [reclamations, run.state]);
+  const observed = useObserved(reclamations, run.state);
 
   const greenSteps = useMemo(() => steps.filter((s) => s.impact === "Green"), [steps]);
 

--- a/ui/src/useObserved.ts
+++ b/ui/src/useObserved.ts
@@ -1,0 +1,49 @@
+import { useMemo } from "react";
+import { ObservedNode } from "./components/FieldViews";
+import { ReclamationState } from "./useReclamations";
+import { RunState } from "./useRun";
+
+/**
+ * Everything known about nodes from *outside* the plan's snapshot, keyed by
+ * node name. Two sources, layered oldest-first:
+ *
+ *   - the reclamation tracker: nodes drained for real and what became of them
+ *   - the current run's event trail: the executor saying what it just did,
+ *     which matters most at exactly the moment the plan is pinned and its
+ *     snapshot is at its most wrong
+ *
+ * A dry run is excluded outright. Its events say "would", and letting a
+ * rehearsal mark nodes as actually drained would be the predicted/observed
+ * confusion this overlay exists to end, rebuilt one layer up. Guarded by
+ * test/ui, mutation-tested.
+ */
+export function useObserved(
+  reclamations: ReclamationState,
+  runState: RunState,
+): Map<string, ObservedNode> {
+  return useMemo(() => {
+    const m = new Map<string, ObservedNode>();
+    for (const r of reclamations.awaiting) {
+      m.set(r.node, { reclaim: "awaiting" });
+    }
+    for (const r of reclamations.recent) {
+      if (r.outcome === "reclaimed") m.set(r.node, { reclaim: "reclaimed" });
+      // "returned" is deliberately not drawn: the node is back in service and
+      // is, once again, just a node. The tray still counts it.
+    }
+    if (runState.status === "active" || runState.status === "done") {
+      if (!runState.run.dryRun) {
+        for (const e of runState.events) {
+          if (!e.node) continue;
+          if (e.action === "Cordon") {
+            m.set(e.node, { ...m.get(e.node), cordoned: true });
+          } else if (e.action === "Drained") {
+            const cur = m.get(e.node);
+            m.set(e.node, { ...cur, cordoned: true, reclaim: cur?.reclaim ?? "awaiting" });
+          }
+        }
+      }
+    }
+    return m;
+  }, [reclamations, runState]);
+}

--- a/ui/src/useReclamations.ts
+++ b/ui/src/useReclamations.ts
@@ -1,0 +1,58 @@
+import { useEffect, useState } from "react";
+import { api, Reclamation } from "./api";
+
+export interface ReclamationState {
+  awaiting: Reclamation[];
+  recent: Reclamation[];
+  /** The server's own tallies, for the tray. The recent list is windowed;
+   *  recounting it client-side would drift from what the server reports. */
+  stats: { awaiting: number; reclaimed: number };
+}
+
+const EMPTY: ReclamationState = {
+  awaiting: [],
+  recent: [],
+  stats: { awaiting: 0, reclaimed: 0 },
+};
+
+/**
+ * Observed reclamation, as distinct from what the plan predicts. Polled
+ * rather than pushed: it changes on the planner's resync, which is tens of
+ * seconds, and it is never the reason someone is watching the screen.
+ *
+ * The full lists, not just the tallies. The names in them are the difference
+ * between "2 awaiting" in a tray and the actual node on the field being
+ * marked — the tray version shipped first and a user immediately asked
+ * *which* node.
+ */
+export function useReclamations(): ReclamationState {
+  const [state, setState] = useState<ReclamationState>(EMPTY);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      try {
+        const r = await api.reclamations();
+        if (!cancelled && r.tracking) {
+          setState({
+            awaiting: r.awaiting ?? [],
+            recent: r.recent ?? [],
+            stats: { awaiting: r.stats.awaiting, reclaimed: r.stats.reclaimed },
+          });
+        }
+      } catch {
+        // Reclamation tracking is supplementary. A backend that does not have
+        // it, or a transient failure, must never blank the page — the field
+        // and the ledger are what the operator came for.
+      }
+    };
+    void load();
+    const t = setInterval(load, 30_000);
+    return () => {
+      cancelled = true;
+      clearInterval(t);
+    };
+  }, []);
+
+  return state;
+}

--- a/ui/src/useVersion.ts
+++ b/ui/src/useVersion.ts
@@ -1,0 +1,48 @@
+import { useEffect, useState } from "react";
+import { api, VersionResponse } from "./api";
+
+/**
+ * The server's version payload, polled — not fetched once — because this
+ * response carries the only liveness signal the client gets.
+ *
+ * A plan re-publishes when its *content* changes. On a steady cluster it
+ * never does — which is the healthiest possible state — so a client that
+ * fetched this once would sit on the storedAt it was handed at load and watch
+ * it age past the staleness threshold while the planner went on confirming
+ * the plan every resync. The warning fired precisely when nothing was wrong.
+ * Re-reading planConfirmedAt is what makes "confirmed just now" stay true,
+ * and what makes the warning mean the thing it says.
+ *
+ * Identity and cluster label ride along unchanged; they are cheap and cannot
+ * drift within a session.
+ *
+ * Guarded by test/ui: the poll and the version fetch must stay in one
+ * effect, or planConfirmedAt freezes at page load.
+ */
+export function useVersion(): VersionResponse | null {
+  const [server, setServer] = useState<VersionResponse | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = () => {
+      api
+        .version()
+        .then((v) => {
+          if (!cancelled) setServer(v);
+        })
+        .catch(() => {
+          // Leave the last good response in place. A dropped poll is not
+          // evidence the plan went stale, and blanking the header over one
+          // failed request would be its own kind of lie.
+        });
+    };
+    load();
+    const t = setInterval(load, 30_000);
+    return () => {
+      cancelled = true;
+      clearInterval(t);
+    };
+  }, []);
+
+  return server;
+}


### PR DESCRIPTION
Code-review item #4, scheduled for exactly this moment: M25's closed loop adds per-pod live state to this surface, and it should land in clean hooks rather than a 452-line component.

| Hook | Owns |
|---|---|
| `useVersion` | the `confirmedAt` heartbeat — the client's only liveness signal |
| `useReclamations` | the observed lists **with their names**, plus the server's tallies for the tray |
| `useObserved` | the overlay merge: tracker → run event trail, dry runs excluded |

**Behaviour-identical** — moved code kept its comments and exact logic; App is now 345 lines of composition.

**Guards moved with their code**, each re-verified by mutation in its new home. One new assertion: App must actually *mount* the hook — a hook nothing calls is the parsed-but-never-drawn bug with an extra step.

CSS split stays deferred until M25's UI lands — splitting a file the next milestone rearranges would be churn twice.

All gates green: test/ui, test/palette, density, typecheck, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)