### PR TITLE
M25: the closed loop — stop executing forecasts

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ happens to be able to execute, not an autoscaler with a UI.
   risky ones are visible before anyone clicks anything.
 - **Executes only what you pick**, through the Kubernetes eviction API, so the
   API server itself enforces your PodDisruptionBudgets.
+- **Or closes the loop, inside bounds you set.** `dencer converge` re-plans
+  from *observed* state after every drain — one step at a time, full Safety
+  Guard each round — until nothing worthwhile remains or your envelope (max
+  nodes, max impact) is reached. You approve a policy with explicit bounds,
+  never an open-ended "optimize".
 - **Refuses steps that became unsafe** between planning and execution, naming
   the rule that stopped it.
 - **Checks whether draining actually saved anything.** k8s-dencer never deletes

--- a/charts/k8s-dencer/templates/executor/deployment.yaml
+++ b/charts/k8s-dencer/templates/executor/deployment.yaml
@@ -81,6 +81,22 @@ spec:
               value: {{ .Values.safety.minReadyNodes | quote }}
             - name: EXECUTOR_READINESS
               value: {{ .Values.executor.readiness | quote }}
+            # Converge runs re-plan and re-rate locally, so the executor reads
+            # the SAME planner values the planner deployment does — one values
+            # block, two consumers, and a step is Yellow in a converge run
+            # exactly when the operator's screen would have called it Yellow.
+            - name: MIN_NODE_AGE
+              value: {{ .Values.planner.minNodeAge | quote }}
+            {{- with .Values.planner.excludeNamespaces }}
+            - name: EXCLUDE_NAMESPACES
+              value: {{ join "," . | quote }}
+            {{- end }}
+            - name: YELLOW_PODS_MOVED
+              value: {{ .Values.planner.impact.yellowPodsMoved | quote }}
+            - name: RED_PODS_MOVED
+              value: {{ .Values.planner.impact.redPodsMoved | quote }}
+            - name: TIGHT_PDB_HEADROOM
+              value: {{ .Values.planner.impact.tightPDBHeadroom | quote }}
             - name: STEP_TIMEOUT
               value: {{ .Values.executor.stepTimeout | quote }}
             - name: SETTLE_TIMEOUT

--- a/cmd/dencer/main.go
+++ b/cmd/dencer/main.go
@@ -36,6 +36,7 @@ Commands:
   explain <step>        why a step is rated as it is, and what it moves
   why <ns>/<pod>        why a pod can or cannot move
   run --steps 1,3-5     execute selected steps and watch them
+  converge              closed loop: re-plan after every drain, inside bounds
   status                the run in flight, or the last one
   reclamations          what actually became of the nodes you drained
   version
@@ -55,6 +56,7 @@ Examples:
   dencer explain 3
   dencer why shop/web-7d9f-abcde
   dencer run --steps 1,2 --dry-run
+  dencer converge --max-nodes 5 --max-impact Green
   dencer reclamations
   dencer plan -o json | jq '.plan.steps[] | select(.impact=="Red")'
 `
@@ -103,6 +105,8 @@ func run() error {
 		return cmdExplain(ctx, args)
 	case "why":
 		return cmdWhy(ctx, args)
+	case "converge":
+		return cmdConverge(ctx, os.Args[2:])
 	case "run":
 		return cmdRun(ctx, args)
 	case "status":
@@ -247,6 +251,78 @@ func cmdWhy(ctx context.Context, args []string) error {
 	}
 	cli.PrintPodConstraints(os.Stdout, pc)
 	return nil
+}
+
+func cmdConverge(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("converge", flag.ExitOnError)
+	g := bind(fs)
+	maxNodes := fs.Int("max-nodes", 0, "most nodes this run may drain (required)")
+	maxImpact := fs.String("max-impact", "Green", "highest impact executed without a human: Green or Yellow")
+	dryRun := fs.Bool("dry-run", false, "rehearse one round without cordoning or evicting")
+	watch := fs.Bool("watch", true, "follow the run until it finishes")
+	yes := fs.Bool("yes", false, "skip the policy confirmation prompt")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *maxNodes < 1 {
+		return errors.New("how many nodes may this run drain? e.g. dencer converge --max-nodes 5")
+	}
+	if *maxImpact != "Green" && *maxImpact != "Yellow" {
+		return errors.New("--max-impact must be Green or Yellow; Red always requires a maintenance window")
+	}
+
+	c, err := connect(ctx, g)
+	if err != nil {
+		return err
+	}
+	defer c.Close()
+
+	// Context for the consent prompt; the run does not execute this plan.
+	plan, _ := c.Plan(ctx, "latest")
+
+	if !*dryRun && !*yes {
+		confirmed, err := cli.ConfirmConverge(os.Stdout, os.Stdin, plan, *maxNodes, *maxImpact)
+		if err != nil {
+			return err
+		}
+		if !confirmed {
+			fmt.Println("Nothing was run.")
+			return nil
+		}
+	}
+
+	runID, err := c.Converge(ctx, *maxNodes, *maxImpact, *dryRun)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("converge run %s queued (up to %d nodes, ceiling %s)", runID, *maxNodes, *maxImpact)
+	if *dryRun {
+		fmt.Print(" (dry run: one round is rehearsed, nothing is touched)")
+	}
+	fmt.Println()
+
+	if !*watch {
+		fmt.Printf("Follow it with: dencer status --run %s\n", runID)
+		return nil
+	}
+
+	final, err := c.Wait(ctx, runID, func(ev store.RunEvent) {
+		cli.PrintEvent(os.Stdout, ev)
+	})
+	if err != nil {
+		return err
+	}
+
+	fmt.Println()
+	switch final.Status {
+	case store.RunSucceeded:
+		fmt.Printf("Succeeded. %s\n", final.Summary)
+		return nil
+	case store.RunBlocked:
+		return fmt.Errorf("blocked by the Safety Guard: %s", final.Summary)
+	default:
+		return fmt.Errorf("run %s: %s", final.Status, final.Summary)
+	}
 }
 
 func cmdRun(ctx context.Context, args []string) error {

--- a/cmd/executor/main.go
+++ b/cmd/executor/main.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -23,6 +24,8 @@ import (
 	"github.com/atedgimo/k8s-dencer/internal/cluster"
 	"github.com/atedgimo/k8s-dencer/internal/executor"
 	"github.com/atedgimo/k8s-dencer/internal/httpserver"
+	"github.com/atedgimo/k8s-dencer/internal/impact"
+	"github.com/atedgimo/k8s-dencer/internal/planner"
 	"github.com/atedgimo/k8s-dencer/internal/safety"
 	"github.com/atedgimo/k8s-dencer/internal/store"
 	sqlitestore "github.com/atedgimo/k8s-dencer/internal/store/sqlite"
@@ -88,8 +91,22 @@ func run(ctx context.Context, log *slog.Logger) error {
 	}
 	go windows.Run(ctx, duration(log, "WINDOW_SYNC_INTERVAL", 30*time.Second))
 
+	// Converge runs re-plan locally, so the executor carries the same planning
+	// and rating knobs as the planner component — same env names on purpose,
+	// so one values block in the chart configures both and a step is Yellow
+	// here exactly when the operator's screen would have said Yellow.
+	planOpts := planner.DefaultOptions()
+	planOpts.MinNodeAge = duration(log, "MIN_NODE_AGE", planOpts.MinNodeAge)
+	planOpts.ExcludeNamespaces = splitList(os.Getenv("EXCLUDE_NAMESPACES"))
+
 	metrics := telemetry.NewMetrics(telemetry.ComponentExecutor)
 	exec := executor.New(executor.NewK8sCluster(reader), db, db, log, executor.Options{
+		Planner: planOpts,
+		Classifier: impact.New(impact.Thresholds{
+			YellowPodsMoved:  intEnv("YELLOW_PODS_MOVED", 0),
+			RedPodsMoved:     intEnv("RED_PODS_MOVED", 0),
+			TightPDBHeadroom: int32(intEnv("TIGHT_PDB_HEADROOM", 0)),
+		}),
 		Worker:        env("POD_NAME", "executor"),
 		Limits:        limits,
 		StepTimeout:   duration(log, "STEP_TIMEOUT", 10*time.Minute),
@@ -143,6 +160,20 @@ func env(key, fallback string) string {
 		return v
 	}
 	return fallback
+}
+
+func splitList(s string) []string {
+	if strings.TrimSpace(s) == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
 }
 
 func intEnv(key string, fallback int) int {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -136,3 +136,27 @@ distinguish red from green.
 ---
 
 [← Documentation index](README.md) · [Project README](../README.md)
+
+## `dencer converge` — closed-loop consolidation
+
+```
+dencer converge --max-nodes 5 --max-impact Green [--dry-run] [--yes]
+```
+
+Instead of executing a plan's steps, the executor repeats: observe the
+cluster, plan **one** drain against live state, run the full Safety Guard,
+drain, wait for recovery — until nothing worthwhile remains or a bound is hit.
+
+You are approving a **policy, not a list**, and the prompt says so. The
+bounds are the consent:
+
+- `--max-nodes` — the most nodes the run may drain (required, no default)
+- `--max-impact` — `Green` or `Yellow`; nothing rated above it is executed.
+  Red always requires a maintenance window, converge or not.
+
+Two rails hold regardless: every round must actually free a node (measured
+after the drain settles, not predicted) or the run stops, and no node is
+drained twice in one run.
+
+`--dry-run` rehearses exactly one round. A converge rehearsal cannot honestly
+simulate where evicted pods land, so it does not pretend to.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -54,7 +54,7 @@ estimated — every milestone here starts from a number in
 | **M22** | Reclamation loop — observe whether a drained node was actually removed | **done** |
 | **M23** | Cloud test on GKE — GKE's autoscaler reclaimed a drained node in **11m9s**, observed | **done** |
 | **M24** | The field shows what *is*, not only what *would be* — observed node states overlaid on the plan | **done for nodes**; per-pod placement waits on M25 |
-| **M25** | Closed-loop consolidation — re-plan from observed state after every step, instead of executing a forecast | planned |
+| **M25** | Closed-loop consolidation — re-plan from observed state after every step, inside an operator-approved envelope | **core shipped**; UI affordance pending |
 
 High availability and a Postgres store were **dropped, not deferred**: a
 consolidation planner is not a serving path. The run queue is already crash-safe
@@ -205,6 +205,34 @@ Verification, in the order that matters:
 - KWOK end-to-end: run to fixpoint and compare the result against what the
   one-shot plan predicted, which finally measures the gap this milestone exists
   to close
+
+**What shipped (core):** `dencer converge --max-nodes N --max-impact Green|Yellow`
+queues a converge run through `POST /api/v1/converge` (same
+`ExecuteConsolidations` grant — one permission, two shapes of consent). The
+executor loop plans one step per round against a fresh snapshot, using the
+same planner library and the same impact thresholds as the planner component
+(one chart values block feeds both), runs the full Safety Guard per step, and
+stops on the first of: optimum reached, envelope's node budget, impact
+ceiling, a round that freed no node, or a guard refusal.
+
+The termination rails, each mutation-tested: removing the monotonic rail, the
+node budget, or the ceiling check makes a named test fail. The
+scheduler-divergence fixture is the interesting one — the planner itself
+refuses non-consolidating moves, so the naive oscillation fixture *cannot
+fail*; the fixture that works has the fake scheduler ignore the plan's target
+the way a real scheduler may, which is the exact case the rail exists for.
+
+The consent prompt for converge is deliberately not the steps prompt with
+different words: it says "you are approving a policy, not a list", states both
+bounds and both rails, and shows the current plan only as explicitly
+non-binding context.
+
+A converge dry run rehearses exactly one round and says so. Rehearsing further
+rounds would mean pretending to know where evicted pods land — a forecast
+wearing a safety vest, the exact thing this mode exists to retire.
+
+**Still open for M25:** a UI affordance for the envelope (the CLI carries it
+today), and the KWOK fixpoint-vs-forecast comparison.
 
 ## What actually runs today
 

--- a/internal/api/rest/execute.go
+++ b/internal/api/rest/execute.go
@@ -225,3 +225,97 @@ func (s *Server) failRun(w http.ResponseWriter, err error) {
 	s.log.Error("run request failed", "error", err)
 	writeError(w, http.StatusInternalServerError, "internal error")
 }
+
+// convergeRequest is the body of POST /api/v1/converge.
+//
+// It is an envelope, not a step list. A steps request approves concrete
+// nodes; this approves a policy — "keep consolidating inside these bounds" —
+// and both bounds are required, because a defaulted consent is not consent.
+type convergeRequest struct {
+	MaxNodes  int    `json:"maxNodes"`
+	MaxImpact string `json:"maxImpact"`
+	DryRun    bool   `json:"dryRun"`
+}
+
+// handleConverge queues a closed-loop run. Same shape as handleExecute — this
+// route authorizes and writes a row; only the unreachable executor drains.
+func (s *Server) handleConverge(w http.ResponseWriter, r *http.Request) {
+	if s.runs == nil {
+		writeError(w, http.StatusNotImplemented,
+			"this deployment has no executor; install with executor.enabled=true")
+		return
+	}
+
+	var req convergeRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<16)).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "request body is not valid JSON")
+		return
+	}
+	if req.MaxNodes < 1 || req.MaxNodes > maxStepsPerRequest {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf(
+			"maxNodes must be between 1 and %d; an unbounded loop is not a grantable consent", maxStepsPerRequest))
+		return
+	}
+	ceiling := model.ImpactRating(req.MaxImpact)
+	if ceiling != model.ImpactGreen && ceiling != model.ImpactYellow {
+		writeError(w, http.StatusBadRequest,
+			"maxImpact must be Green or Yellow; Red always requires a maintenance window and cannot be pre-consented here")
+		return
+	}
+
+	// One consolidation at a time, converge included.
+	if active, err := s.runs.ActiveRun(r.Context()); err == nil {
+		writeJSON(w, http.StatusConflict, map[string]any{
+			"error":  fmt.Sprintf("run %s is already %s", active.ID, active.Status),
+			"code":   "run_in_progress",
+			"runId":  active.ID,
+			"status": active.Status,
+		})
+		return
+	} else if !errors.Is(err, store.ErrNotFound) {
+		s.fail(w, err)
+		return
+	}
+
+	actor := auth.Identity{Username: "auth-disabled", Source: auth.SourceAnonymous}
+	if id, ok := auth.IdentityFrom(r.Context()); ok {
+		actor = id
+	}
+
+	// The latest plan ID is recorded for audit context — "what was on the
+	// screen when this policy was approved" — not as an execution input; the
+	// whole point of converge is that it re-plans for itself.
+	planID := ""
+	if rec, err := s.store.Latest(r.Context()); err == nil {
+		planID = rec.Plan.ID
+	}
+
+	runID, err := s.runs.Enqueue(r.Context(), store.Run{
+		PlanID: planID,
+		Mode:   store.RunModeConverge,
+		Envelope: &store.Envelope{
+			MaxNodes:  req.MaxNodes,
+			MaxImpact: ceiling,
+		},
+		DryRun: req.DryRun,
+		Actor:  actor.Username, ActorGroups: actor.Groups,
+	})
+	if err != nil {
+		s.fail(w, err)
+		return
+	}
+
+	s.log.Info("converge requested", "run", runID, "maxNodes", req.MaxNodes,
+		"maxImpact", req.MaxImpact, "dryRun", req.DryRun, "actor", actor.Username)
+
+	s.events.Publish(Event{Type: "run", Data: map[string]any{
+		"runId": runID, "planId": planID, "status": store.RunPending,
+		"mode": store.RunModeConverge, "dryRun": req.DryRun,
+	}})
+
+	writeJSON(w, http.StatusAccepted, map[string]any{
+		"runId": runID, "planId": planID, "mode": store.RunModeConverge,
+		"maxNodes": req.MaxNodes, "maxImpact": req.MaxImpact,
+		"dryRun": req.DryRun, "status": store.RunPending,
+	})
+}

--- a/internal/api/rest/rest.go
+++ b/internal/api/rest/rest.go
@@ -141,6 +141,9 @@ func (s *Server) Routes(mux *http.ServeMux) {
 	// separate grants, which is the entire reason for putting this behind
 	// SubjectAccessReview rather than a single "authenticated" check.
 	route("POST /api/v1/plans/{id}/execute", auth.ExecuteConsolidations, s.handleExecute)
+	// Converge is consent to a policy rather than a list, but it is the same
+	// grant: the ability to have nodes drained. One permission, two shapes.
+	route("POST /api/v1/converge", auth.ExecuteConsolidations, s.handleConverge)
 }
 
 func (s *Server) handleAuthInfo(w http.ResponseWriter, _ *http.Request) {

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -209,3 +209,16 @@ func (c *Client) Reclamations(ctx context.Context) (*ReclamationsEnvelope, error
 	}
 	return &out, nil
 }
+
+// Converge queues a closed-loop run and returns the run id. The caller has
+// already confirmed the policy; this just carries it.
+func (c *Client) Converge(ctx context.Context, maxNodes int, maxImpact string, dryRun bool) (string, error) {
+	var out struct {
+		RunID string `json:"runId"`
+	}
+	body := map[string]any{"maxNodes": maxNodes, "maxImpact": maxImpact, "dryRun": dryRun}
+	if err := c.do(ctx, "POST", "/api/v1/converge", body, &out); err != nil {
+		return "", err
+	}
+	return out.RunID, nil
+}

--- a/internal/cli/confirm.go
+++ b/internal/cli/confirm.go
@@ -50,3 +50,32 @@ func Confirm(out io.Writer, in io.Reader, plan *PlanEnvelope, want []int) (bool,
 	answer = strings.ToLower(strings.TrimSpace(answer))
 	return answer == "y" || answer == "yes", nil
 }
+
+// ConfirmConverge is the consent prompt for a closed-loop run, and it is
+// deliberately not Confirm with different text. A steps run approves a
+// concrete list an operator can picture; a converge run approves a POLICY —
+// the executor will re-plan after every drain and pick its own targets — and
+// the prompt must make that difference impossible to miss. What is shown is
+// the current plan's outlook as context, explicitly labelled as non-binding.
+func ConfirmConverge(out io.Writer, in io.Reader, plan *PlanEnvelope, maxNodes int, maxImpact string) (bool, error) {
+	fmt.Fprintf(out, "You are approving a policy, not a list of steps.\n\n")
+	fmt.Fprintf(out, "The executor will repeatedly: observe the cluster, plan ONE drain against\n")
+	fmt.Fprintf(out, "live state, run the full Safety Guard, drain, wait for recovery — until no\n")
+	fmt.Fprintf(out, "worthwhile step remains or a bound below is reached.\n\n")
+	fmt.Fprintf(out, "  bound: at most %d node(s) drained\n", maxNodes)
+	fmt.Fprintf(out, "  bound: nothing rated above %s is executed\n", maxImpact)
+	fmt.Fprintf(out, "  rail:  every round must free a node, or the run stops\n")
+	fmt.Fprintf(out, "  rail:  no node is drained twice in one run\n")
+	if plan != nil && plan.Plan != nil {
+		fmt.Fprintf(out, "\nFor context only (targets are re-chosen live): the current plan frees %d node(s).\n",
+			plan.Plan.ReclaimedNodes())
+	}
+	fmt.Fprint(out, "\nApprove this policy? [y/N] ")
+
+	answer, err := bufio.NewReader(in).ReadString('\n')
+	if err != nil && answer == "" {
+		return false, nil
+	}
+	answer = strings.ToLower(strings.TrimSpace(answer))
+	return answer == "y" || answer == "yes", nil
+}

--- a/internal/executor/converge.go
+++ b/internal/executor/converge.go
@@ -1,0 +1,208 @@
+package executor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/atedgimo/k8s-dencer/internal/constraints"
+	"github.com/atedgimo/k8s-dencer/internal/model"
+	"github.com/atedgimo/k8s-dencer/internal/planner"
+	"github.com/atedgimo/k8s-dencer/internal/safety"
+	"github.com/atedgimo/k8s-dencer/internal/store"
+)
+
+// M25: closed-loop consolidation.
+//
+// A steps run executes a forecast: steps 2..N were computed against one
+// snapshot, assuming 1..N-1 landed exactly as predicted. They may not have,
+// because the plan does not tell the scheduler anything — the executor
+// cordons and evicts, and where pods land is kube-scheduler's decision. The
+// old answer to divergence was abort; converge's answer is to stop
+// forecasting: observe, plan ONE step against what is actually true, execute
+// it, settle, observe again.
+//
+// What makes this safe to run at all is that it can always stop and never
+// wander:
+//
+//   - the ENVELOPE is the operator's consent, recorded on the run: at most
+//     MaxNodes drained, nothing above MaxImpact executed. A steps run
+//     approves a list; a converge run approves a policy, and the policy's
+//     bounds are explicit because a defaulted consent is not consent.
+//   - MONOTONIC PROGRESS: every round must strictly reduce the number of
+//     occupied nodes, measured — not predicted — after the drain settles. The
+//     round that fails to ends the run. This is the rail that kills
+//     oscillation: drain A, scheduler fills B, "drain B" now looks appealing
+//     — but if that dance frees nothing, the count does not fall, and the
+//     loop halts instead of walking the cluster.
+//   - NO SECOND VISIT: a node this run has already drained is never targeted
+//     again, however drainable a re-plan says it looks.
+//   - every step still passes the full Safety Guard against fresh state, and
+//     Red still requires a maintenance window. The envelope tightens the
+//     rails; it cannot loosen them.
+//
+// A dry-run converge rehearses one round and stops, saying so. Rehearsing
+// further rounds would require pretending to know where evicted pods land,
+// and a rehearsal built on a simulated scheduler is a forecast wearing a
+// safety vest — the exact thing this mode exists to retire.
+
+// maxConvergeRounds is an absolute bound above any envelope, so a bug in the
+// progress accounting costs a bounded number of drains, not an estate.
+const maxConvergeRounds = 50
+
+// converge runs the closed loop for one claimed run.
+func (e *Executor) converge(ctx context.Context, run store.Run) {
+	env := run.Envelope
+	if env == nil || env.MaxNodes < 1 ||
+		(env.MaxImpact != model.ImpactGreen && env.MaxImpact != model.ImpactYellow) {
+		e.fail(ctx, run, "converge run has no valid envelope; refusing an unbounded loop")
+		return
+	}
+
+	rounds := env.MaxNodes
+	if rounds > maxConvergeRounds {
+		rounds = maxConvergeRounds
+	}
+
+	e.event(ctx, run, store.RunEvent{
+		Action: "Claim",
+		Message: fmt.Sprintf(
+			"converge run claimed by %s for %s: up to %d node(s), impact ceiling %s%s",
+			e.opts.Worker, run.Actor, env.MaxNodes, env.MaxImpact, dryRunSuffix(run.DryRun)),
+	})
+
+	state := safety.RunState{}
+	drained := map[string]bool{}
+
+	for round := 1; round <= rounds; round++ {
+		live, err := e.cluster.Snapshot(ctx)
+		if err != nil {
+			e.fail(ctx, run, fmt.Sprintf("round %d: read cluster state: %v", round, err))
+			return
+		}
+		occBefore := occupiedNodes(live)
+
+		step, why := e.planOneStep(live, drained)
+		if step == nil {
+			e.finish(ctx, run, store.RunSucceeded, fmt.Sprintf(
+				"converged after %d node(s): %s", state.NodesDrainedSoFar, why))
+			return
+		}
+
+		if exceedsCeiling(step.Impact, env.MaxImpact) {
+			// The envelope working as designed: the next-best step needs more
+			// consent than this run carries. Succeeded, not Blocked — nothing
+			// broke, and "come back for a human" is the designed outcome.
+			e.finish(ctx, run, store.RunSucceeded, fmt.Sprintf(
+				"stopped at the envelope after %d node(s): the next step (drain %s) is rated %s, ceiling is %s",
+				state.NodesDrainedSoFar, step.TargetNode, step.Impact, env.MaxImpact))
+			return
+		}
+
+		e.event(ctx, run, store.RunEvent{
+			Step: round, Node: step.TargetNode, Action: "Plan",
+			Message: fmt.Sprintf("round %d: planned against live state — drain %s (%s, %d pods)%s",
+				round, step.TargetNode, step.Impact, len(step.Moves), dryRunSuffix(run.DryRun)),
+		})
+
+		stepCtx, cancel := context.WithTimeout(ctx, e.opts.StepTimeout)
+		err = e.performStep(stepCtx, run, *step, &state)
+		cancel()
+		if err != nil {
+			var blocked *safety.Blocked
+			if errors.As(err, &blocked) {
+				e.finish(ctx, run, store.RunBlocked, fmt.Sprintf(
+					"stopped in round %d after %d node(s): %s",
+					round, state.NodesDrainedSoFar, blocked.Reason))
+				return
+			}
+			e.finish(ctx, run, store.RunFailed, fmt.Sprintf(
+				"failed in round %d after %d node(s): %v",
+				round, state.NodesDrainedSoFar, err))
+			return
+		}
+		drained[step.TargetNode] = true
+
+		if run.DryRun {
+			// One round is all a rehearsal can honestly claim; see the
+			// package comment.
+			e.finish(ctx, run, store.RunSucceeded, fmt.Sprintf(
+				"dry run rehearsed round 1 (drain %s); a converge rehearsal cannot "+
+					"simulate where pods land, so further rounds are not pretended",
+				step.TargetNode))
+			return
+		}
+
+		// The monotonic rail, against reality: re-read the cluster after the
+		// drain settled and require the occupied-node count to have fallen.
+		after, err := e.cluster.Snapshot(ctx)
+		if err != nil {
+			e.fail(ctx, run, fmt.Sprintf("round %d: read cluster state after drain: %v", round, err))
+			return
+		}
+		occAfter := occupiedNodes(after)
+		if occAfter >= occBefore {
+			e.finish(ctx, run, store.RunSucceeded, fmt.Sprintf(
+				"stopped after %d node(s): round %d freed no node (%d occupied before, %d after) — "+
+					"the workload dance is not consolidating, so continuing would churn pods for nothing",
+				state.NodesDrainedSoFar, round, occBefore, occAfter))
+			return
+		}
+	}
+
+	e.finish(ctx, run, store.RunSucceeded, fmt.Sprintf(
+		"drained %d node(s), the envelope's limit; re-run to continue if the plan still shows more",
+		state.NodesDrainedSoFar))
+}
+
+// planOneStep plans against live state and returns the single next step, or
+// nil with the reason there is none. Nodes in skip are never proposed.
+func (e *Executor) planOneStep(live *model.ClusterSnapshot, skip map[string]bool) (*model.PlanStep, string) {
+	analysis := constraints.Analyze(live)
+	plan, err := planner.Greedy{}.Plan(live, analysis, e.opts.Planner)
+	if err != nil {
+		return nil, fmt.Sprintf("planning failed: %v", err)
+	}
+	e.opts.Classifier.ClassifyPlan(plan, live, analysis)
+
+	for i := range plan.Steps {
+		if !skip[plan.Steps[i].TargetNode] {
+			return &plan.Steps[i], ""
+		}
+	}
+	if len(plan.Steps) == 0 {
+		return nil, "no further step is worth taking; every remaining node is either needed or undrainable"
+	}
+	return nil, "every remaining candidate was already drained by this run"
+}
+
+// occupiedNodes counts nodes holding at least one movable pod — the quantity
+// a consolidation exists to reduce, and the one the monotonic rail measures.
+func occupiedNodes(snap *model.ClusterSnapshot) int {
+	occupied := map[string]bool{}
+	for _, p := range snap.Pods {
+		if p.NodeName != "" && p.IsMovable() {
+			occupied[p.NodeName] = true
+		}
+	}
+	return len(occupied)
+}
+
+// exceedsCeiling reports whether a step's rating needs more consent than the
+// envelope grants. Green < Yellow < Red, and an unknown rating exceeds
+// everything — fail closed.
+func exceedsCeiling(rating, ceiling model.ImpactRating) bool {
+	rank := func(r model.ImpactRating) int {
+		switch r {
+		case model.ImpactGreen:
+			return 0
+		case model.ImpactYellow:
+			return 1
+		case model.ImpactRed:
+			return 2
+		default:
+			return 3
+		}
+	}
+	return rank(rating) > rank(ceiling)
+}

--- a/internal/executor/converge_test.go
+++ b/internal/executor/converge_test.go
@@ -1,0 +1,245 @@
+package executor_test
+
+// M25's tests, in the order the roadmap said they matter:
+//
+//   1. the loop TERMINATES — a plausible-looking implementation that never
+//      halts is the failure mode of this whole design
+//   2. the envelope is never exceeded, including when a re-plan wants to
+//   3. the ceiling stops execution BEFORE the step runs, not after
+//
+// The harness is the same fake cluster the steps tests use — including its
+// controller-like rescheduling, which is exactly what makes closed-loop
+// behaviour testable: where pods land is the fake's decision, not the plan's.
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/atedgimo/k8s-dencer/internal/executor"
+
+	"github.com/atedgimo/k8s-dencer/internal/impact"
+	"github.com/atedgimo/k8s-dencer/internal/model"
+	"github.com/atedgimo/k8s-dencer/internal/store"
+)
+
+// rebuildWithClassifier swaps in an executor whose classifier rates steps
+// differently; everything else matches newHarness.
+func (h *harness) rebuildWithClassifier(t *testing.T, c impact.Classifier) *executor.Executor {
+	t.Helper()
+	return executor.New(h.cluster, h.db, h.db, slog.New(slog.DiscardHandler), executor.Options{
+		Worker: "test-worker", Limits: permissive(),
+		StepTimeout: 5 * time.Second, SettleTimeout: 2 * time.Second,
+		PollInterval: time.Millisecond, Classifier: c,
+	})
+}
+
+// requestConverge enqueues a converge run and lets the executor claim it.
+func (h *harness) requestConverge(t *testing.T, env *store.Envelope, dryRun bool) store.Run {
+	t.Helper()
+	ctx := context.Background()
+	id, err := h.db.Enqueue(ctx, store.Run{
+		PlanID: h.planID, Mode: store.RunModeConverge, Envelope: env,
+		DryRun: dryRun, Actor: "alice@example.com",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := h.exec.Poll(ctx); err != nil {
+		t.Fatal(err)
+	}
+	run, err := h.db.RunByID(ctx, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return run
+}
+
+// A cluster three lightly-loaded nodes wide plus one receiver. Every drain
+// frees a node, so the loop's natural stop is the budget or the optimum.
+func convergeSnapshot() model.ClusterSnapshot {
+	return model.ClusterSnapshot{
+		Nodes: []model.Node{
+			testNode("a"), testNode("b"), testNode("c"), testNode("big"),
+		},
+		Pods: []model.Pod{
+			testPod("shop", "web-1", "a", "web"),
+			testPod("shop", "web-2", "b", "web"),
+			testPod("shop", "web-3", "c", "web"),
+			testPod("shop", "api-1", "big", "api"),
+		},
+	}
+}
+
+func TestConvergeHonoursTheNodeBudget(t *testing.T) {
+	h := newHarness(t, convergeSnapshot(), nil, permissive())
+
+	run := h.requestConverge(t, &store.Envelope{MaxNodes: 2, MaxImpact: model.ImpactYellow}, false)
+
+	if run.Status != store.RunSucceeded {
+		t.Fatalf("status = %s (%s), want Succeeded", run.Status, run.Summary)
+	}
+	if !strings.Contains(run.Summary, "2 node(s)") || !strings.Contains(run.Summary, "limit") {
+		t.Errorf("summary does not state the envelope stopped it: %q", run.Summary)
+	}
+
+	// The budget in the transcript, not just the summary: exactly two cordons,
+	// on two different nodes — which also covers the never-twice rail.
+	cordoned := map[string]int{}
+	for _, call := range h.cluster.transcript() {
+		if name, ok := strings.CutPrefix(call, "cordon:"); ok {
+			cordoned[name]++
+		}
+	}
+	if len(cordoned) != 2 {
+		t.Errorf("cordoned %d distinct nodes, want 2: %v", len(cordoned), cordoned)
+	}
+	for name, n := range cordoned {
+		if n != 1 {
+			t.Errorf("node %s cordoned %d times; a converge run must never revisit a node", name, n)
+		}
+	}
+}
+
+func TestConvergeStopsWhenARoundFreesNoNode(t *testing.T) {
+	// Scheduler divergence, the exact case this rail exists for. The planner
+	// proposes moving a's pod onto c — the consolidating choice; it refuses
+	// to target the empty node, which is why the naive version of this
+	// fixture could not fail. But the plan does not bind the scheduler, and
+	// the fake (like a real scheduler with its own preferences) puts the
+	// replacement on "spare", first schedulable in list order. A node was
+	// emptied AND a node was filled: nothing was freed, and without the
+	// monotonic rail the next round would happily drain "spare" back the
+	// other way, forever.
+	snap := model.ClusterSnapshot{
+		Nodes: []model.Node{testNode("spare"), testNode("a"), testNode("c")},
+		Pods: []model.Pod{
+			testPod("shop", "web-1", "a", "web"),
+			testPod("shop", "web-2", "c", "web"),
+		},
+	}
+	h := newHarness(t, snap, nil, permissive())
+
+	run := h.requestConverge(t, &store.Envelope{MaxNodes: 10, MaxImpact: model.ImpactYellow}, false)
+
+	if run.Status != store.RunSucceeded {
+		t.Fatalf("status = %s (%s), want Succeeded", run.Status, run.Summary)
+	}
+	if !strings.Contains(run.Summary, "freed no node") {
+		t.Errorf("summary does not name the monotonic rail: %q", run.Summary)
+	}
+	// Termination, concretely: one round, not ten.
+	cordons := 0
+	for _, call := range h.cluster.transcript() {
+		if strings.HasPrefix(call, "cordon:") {
+			cordons++
+		}
+	}
+	if cordons != 1 {
+		t.Errorf("loop ran %d rounds against a cluster that cannot consolidate; the monotonic rail is not terminating it", cordons)
+	}
+}
+
+func TestConvergeStopsAtTheImpactCeilingBeforeExecuting(t *testing.T) {
+	h := newHarness(t, convergeSnapshot(), nil, permissive())
+	// Every step moves at least one pod, so this threshold rates every
+	// possible step Yellow — the ceiling must stop the run before anything
+	// is touched.
+	h.exec = h.rebuildWithClassifier(t, impact.New(impact.Thresholds{YellowPodsMoved: 1}))
+
+	run := h.requestConverge(t, &store.Envelope{MaxNodes: 5, MaxImpact: model.ImpactGreen}, false)
+
+	if run.Status != store.RunSucceeded {
+		t.Fatalf("status = %s (%s), want Succeeded", run.Status, run.Summary)
+	}
+	if !strings.Contains(run.Summary, "Yellow") || !strings.Contains(run.Summary, "ceiling") {
+		t.Errorf("summary does not explain the ceiling: %q", run.Summary)
+	}
+	for _, call := range h.cluster.transcript() {
+		if strings.HasPrefix(call, "cordon:") || strings.HasPrefix(call, "evict:") {
+			t.Fatalf("the ceiling stopped nothing: cluster call %q", call)
+		}
+	}
+}
+
+func TestConvergeStopsAtTheOptimum(t *testing.T) {
+	// One node whose only pod is immovable: nothing is worth draining, and
+	// the loop must say so rather than fail.
+	pinned := testPod("kube-system", "ds-1", "a", "ds")
+	pinned.Owner = &model.OwnerRef{Kind: "DaemonSet", Name: "ds"}
+	snap := model.ClusterSnapshot{
+		Nodes: []model.Node{testNode("a"), testNode("b")},
+		Pods:  []model.Pod{pinned},
+	}
+	h := newHarness(t, snap, nil, permissive())
+
+	run := h.requestConverge(t, &store.Envelope{MaxNodes: 5, MaxImpact: model.ImpactYellow}, false)
+
+	if run.Status != store.RunSucceeded {
+		t.Fatalf("status = %s (%s), want Succeeded", run.Status, run.Summary)
+	}
+	if !strings.Contains(run.Summary, "converged after 0 node(s)") {
+		t.Errorf("summary = %q, want the optimum stated with zero drains", run.Summary)
+	}
+}
+
+func TestConvergeDryRunRehearsesExactlyOneRound(t *testing.T) {
+	h := newHarness(t, convergeSnapshot(), nil, permissive())
+
+	run := h.requestConverge(t, &store.Envelope{MaxNodes: 5, MaxImpact: model.ImpactYellow}, true)
+
+	if run.Status != store.RunSucceeded {
+		t.Fatalf("status = %s (%s), want Succeeded", run.Status, run.Summary)
+	}
+	if !strings.Contains(run.Summary, "round 1") {
+		t.Errorf("summary does not limit the rehearsal's claim: %q", run.Summary)
+	}
+	// A rehearsal touches nothing, however many rounds it might have run.
+	for _, call := range h.cluster.transcript() {
+		if strings.HasPrefix(call, "cordon:") || strings.HasPrefix(call, "evict:") {
+			t.Fatalf("dry run touched the cluster: %q", call)
+		}
+	}
+}
+
+func TestConvergeRefusesAMissingOrInvalidEnvelope(t *testing.T) {
+	h := newHarness(t, convergeSnapshot(), nil, permissive())
+
+	for name, env := range map[string]*store.Envelope{
+		"nil envelope":  nil,
+		"zero nodes":    {MaxNodes: 0, MaxImpact: model.ImpactGreen},
+		"red ceiling":   {MaxNodes: 3, MaxImpact: model.ImpactRed},
+		"empty ceiling": {MaxNodes: 3},
+	} {
+		run := h.requestConverge(t, env, false)
+		if run.Status != store.RunFailed {
+			t.Errorf("%s: status = %s, want Failed — an unbounded or malformed consent must not run", name, run.Status)
+		}
+	}
+}
+
+func TestConvergeEnvelopeSurvivesTheStore(t *testing.T) {
+	h := newHarness(t, convergeSnapshot(), nil, permissive())
+	ctx := context.Background()
+
+	id, err := h.db.Enqueue(ctx, store.Run{
+		PlanID: h.planID, Mode: store.RunModeConverge,
+		Envelope: &store.Envelope{MaxNodes: 7, MaxImpact: model.ImpactYellow},
+		Actor:    "alice@example.com",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := h.db.RunByID(ctx, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Mode != store.RunModeConverge {
+		t.Errorf("mode = %q, want converge", got.Mode)
+	}
+	if got.Envelope == nil || got.Envelope.MaxNodes != 7 || got.Envelope.MaxImpact != model.ImpactYellow {
+		t.Errorf("envelope did not survive the store: %+v — the audit row no longer records what was consented to", got.Envelope)
+	}
+}

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -26,7 +26,9 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/atedgimo/k8s-dencer/internal/impact"
 	"github.com/atedgimo/k8s-dencer/internal/model"
+	"github.com/atedgimo/k8s-dencer/internal/planner"
 	"github.com/atedgimo/k8s-dencer/internal/safety"
 	"github.com/atedgimo/k8s-dencer/internal/store"
 	"github.com/atedgimo/k8s-dencer/internal/telemetry"
@@ -63,6 +65,18 @@ type Options struct {
 	// Phase 2 behaviour of refusing Red outright.
 	Windows safety.Windows
 
+	// Planner configures the local re-planning a converge run does each
+	// round. The same knobs as the planner component (min node age, excluded
+	// namespaces), because a converge step must be one the planner could have
+	// proposed — the loop changes when planning happens, not what is
+	// plannable.
+	Planner planner.Options
+
+	// Classifier rates the steps a converge run plans, with the same
+	// thresholds as the planner component, so a step is Yellow here exactly
+	// when the plan on the operator's screen would have called it Yellow.
+	Classifier impact.Classifier
+
 	// Readiness is how a replacement pod is judged recovered. Defaults to
 	// Ready; only the KWOK overlay sets Running.
 	Readiness Readiness
@@ -84,6 +98,19 @@ func (o Options) withDefaults() Options {
 	}
 	if o.SettleTimeout <= 0 {
 		o.SettleTimeout = 5 * time.Minute
+	}
+	if o.Classifier == (impact.Classifier{}) {
+		// A zero-value Classifier has zero thresholds WITHOUT impact.New's
+		// defaulting, which makes RedPodsMoved 0 — every step "at or above"
+		// it, everything Red. Unset must never mean the strangest option:
+		// default through the constructor, the same way the planner does.
+		o.Classifier = impact.New(impact.Thresholds{})
+	}
+	if o.Planner.MinNodeAge == 0 && o.Planner.ExcludeNodeLabels == nil {
+		// The zero Options would plan with no minimum node age and no
+		// control-plane exclusion — more permissive than any configured
+		// planner. Default to the planner's own defaults instead.
+		o.Planner = planner.DefaultOptions()
 	}
 	if o.PollInterval <= 0 {
 		o.PollInterval = 2 * time.Second
@@ -143,8 +170,12 @@ func (e *Executor) Poll(ctx context.Context) (bool, error) {
 	}
 
 	e.log.Info("claimed run", "run", run.ID, "plan", run.PlanID,
-		"steps", run.Steps, "dryRun", run.DryRun, "actor", run.Actor)
-	e.perform(ctx, run)
+		"steps", run.Steps, "mode", run.Mode, "dryRun", run.DryRun, "actor", run.Actor)
+	if run.Mode == store.RunModeConverge {
+		e.converge(ctx, run)
+	} else {
+		e.perform(ctx, run)
+	}
 	return true, nil
 }
 

--- a/internal/store/execution.go
+++ b/internal/store/execution.go
@@ -3,6 +3,8 @@ package store
 import (
 	"context"
 	"time"
+
+	"github.com/atedgimo/k8s-dencer/internal/model"
 )
 
 // RunStatus is the lifecycle of an execution request.
@@ -40,6 +42,19 @@ type Run struct {
 	DryRun bool      `json:"dryRun"`
 	Status RunStatus `json:"status"`
 
+	// Mode selects what the executor does with this run. Empty means steps:
+	// perform the listed steps of the referenced plan, the shape the product
+	// has always had. "converge" means closed-loop: re-plan from observed
+	// state after every drained node, inside the Envelope, until no
+	// worthwhile step remains.
+	Mode string `json:"mode,omitempty"`
+
+	// Envelope is the operator's consent, for converge runs. A steps run
+	// approves a concrete list of nodes; a converge run approves a *policy*,
+	// and the policy's bounds are recorded on the run so the audit trail
+	// shows exactly what was consented to.
+	Envelope *Envelope `json:"envelope,omitempty"`
+
 	// Actor is the authenticated identity that requested the run, captured at
 	// enqueue. Authorization happens once, up front, so a run outlives the
 	// token that authorized it — a 15-minute ID token can start a 40-minute
@@ -56,6 +71,24 @@ type Run struct {
 
 	// Summary is the closing human-readable outcome.
 	Summary string `json:"summary,omitempty"`
+}
+
+// RunModeConverge marks a closed-loop run. The zero value of Run.Mode is the
+// classic steps run; a named constant for it would suggest other values are
+// equally ordinary, and they are not.
+const RunModeConverge = "converge"
+
+// Envelope bounds a converge run. Both fields are the operator's explicit
+// choice — there are no defaults here, because a defaulted consent is not
+// consent.
+type Envelope struct {
+	// MaxNodes is the most nodes this run may drain, however inviting the
+	// re-planning gets. Doubles as the loop's hard round bound.
+	MaxNodes int `json:"maxNodes"`
+	// MaxImpact is the highest impact rating the run may execute without
+	// coming back for a human. Green or Yellow; Red always needs a window
+	// regardless, enforced by the Safety Guard.
+	MaxImpact model.ImpactRating `json:"maxImpact"`
 }
 
 // EventLevel separates progress from refusals and errors.

--- a/internal/store/sqlite/execution.go
+++ b/internal/store/sqlite/execution.go
@@ -33,12 +33,21 @@ func (s *Store) Enqueue(ctx context.Context, run store.Run) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	// nil marshals to the string "null"; a steps run should store SQL NULL so
+	// "no envelope" and "an envelope" stay distinguishable in the audit row.
+	var envelope []byte
+	if run.Envelope != nil {
+		if envelope, err = json.Marshal(run.Envelope); err != nil {
+			return "", err
+		}
+	}
 
 	_, err = s.db.ExecContext(ctx, `
-		INSERT INTO runs (id, plan_id, steps, dry_run, status, actor, actor_groups, requested_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		INSERT INTO runs (id, plan_id, steps, dry_run, status, actor, actor_groups, requested_at, mode, envelope)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		run.ID, run.PlanID, steps, boolToInt(run.DryRun), string(run.Status),
-		run.Actor, groups, run.RequestedAt.UTC().Format(time.RFC3339Nano))
+		run.Actor, groups, run.RequestedAt.UTC().Format(time.RFC3339Nano),
+		run.Mode, envelope)
 	if err != nil {
 		return "", fmt.Errorf("enqueue run: %w", err)
 	}
@@ -123,7 +132,7 @@ func (s *Store) Finish(ctx context.Context, runID string, status store.RunStatus
 func (s *Store) RunByID(ctx context.Context, runID string) (store.Run, error) {
 	row := s.db.QueryRowContext(ctx, `
 		SELECT id, plan_id, steps, dry_run, status, actor, actor_groups,
-		       requested_at, started_at, finished_at, worker, summary
+		       requested_at, started_at, finished_at, worker, summary, mode, envelope
 		FROM runs WHERE id = ?`, runID)
 	return scanRun(row)
 }
@@ -132,7 +141,7 @@ func (s *Store) RunByID(ctx context.Context, runID string) (store.Run, error) {
 func (s *Store) ActiveRun(ctx context.Context) (store.Run, error) {
 	row := s.db.QueryRowContext(ctx, `
 		SELECT id, plan_id, steps, dry_run, status, actor, actor_groups,
-		       requested_at, started_at, finished_at, worker, summary
+		       requested_at, started_at, finished_at, worker, summary, mode, envelope
 		FROM runs WHERE status IN (?, ?)
 		ORDER BY requested_at LIMIT 1`,
 		string(store.RunPending), string(store.RunRunning))
@@ -146,7 +155,7 @@ func (s *Store) RunsForPlan(ctx context.Context, planID string, limit int) ([]st
 	}
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT id, plan_id, steps, dry_run, status, actor, actor_groups,
-		       requested_at, started_at, finished_at, worker, summary
+		       requested_at, started_at, finished_at, worker, summary, mode, envelope
 		FROM runs WHERE plan_id = ? ORDER BY requested_at DESC, rowid DESC LIMIT ?`,
 		planID, limit)
 	if err != nil {
@@ -199,13 +208,14 @@ func scanRun(row scanner) (store.Run, error) {
 	var (
 		run                   store.Run
 		steps, groups         []byte
+		envelope              []byte
 		dryRun                int
 		status, requestedAt   string
 		startedAt, finishedAt sql.NullString
 		worker, summary       sql.NullString
 	)
 	err := row.Scan(&run.ID, &run.PlanID, &steps, &dryRun, &status, &run.Actor, &groups,
-		&requestedAt, &startedAt, &finishedAt, &worker, &summary)
+		&requestedAt, &startedAt, &finishedAt, &worker, &summary, &run.Mode, &envelope)
 	if errors.Is(err, sql.ErrNoRows) {
 		return store.Run{}, store.ErrNotFound
 	}
@@ -218,6 +228,15 @@ func scanRun(row scanner) (store.Run, error) {
 	}
 	if len(groups) > 0 {
 		_ = json.Unmarshal(groups, &run.ActorGroups)
+	}
+	if len(envelope) > 0 {
+		var env store.Envelope
+		if err := json.Unmarshal(envelope, &env); err != nil {
+			// An unreadable consent record must fail loudly, not degrade into
+			// an unbounded run.
+			return store.Run{}, fmt.Errorf("decode run envelope: %w", err)
+		}
+		run.Envelope = &env
 	}
 	run.DryRun = dryRun != 0
 	run.Status = store.RunStatus(status)

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -56,7 +56,7 @@ func Open(path string) (*Store, error) {
 // Close releases the database handle.
 func (s *Store) Close() error { return s.db.Close() }
 
-const schemaVersion = 3
+const schemaVersion = 4
 
 // Migrate creates or upgrades the schema.
 func (s *Store) Migrate(ctx context.Context) error {
@@ -87,6 +87,11 @@ func (s *Store) Migrate(ctx context.Context) error {
 	if current < 3 {
 		if _, err := tx.ExecContext(ctx, schemaV3); err != nil {
 			return fmt.Errorf("apply schema v3: %w", err)
+		}
+	}
+	if current < 4 {
+		if _, err := tx.ExecContext(ctx, schemaV4); err != nil {
+			return fmt.Errorf("apply schema v4: %w", err)
 		}
 	}
 
@@ -202,6 +207,15 @@ CREATE TABLE IF NOT EXISTS reclamations (
 CREATE INDEX IF NOT EXISTS reclamations_pending ON reclamations (resolved_at);
 CREATE INDEX IF NOT EXISTS reclamations_recent ON reclamations (drained_at DESC);
 `
+// Schema v4 — M25: converge runs. A run gains a mode and, for converge, the
+// envelope the operator consented to. Stored as columns-plus-blob in the
+// established shape: mode is queried (the executor logs it), the envelope is
+// opaque consent detail read back whole.
+const schemaV4 = `
+ALTER TABLE runs ADD COLUMN mode TEXT NOT NULL DEFAULT '';
+ALTER TABLE runs ADD COLUMN envelope BLOB;
+`
+
 
 // Save persists a record unless it duplicates the latest plan.
 func (s *Store) Save(ctx context.Context, rec store.Record) (bool, error) {

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -207,6 +207,7 @@ CREATE TABLE IF NOT EXISTS reclamations (
 CREATE INDEX IF NOT EXISTS reclamations_pending ON reclamations (resolved_at);
 CREATE INDEX IF NOT EXISTS reclamations_recent ON reclamations (drained_at DESC);
 `
+
 // Schema v4 — M25: converge runs. A run gains a mode and, for converge, the
 // envelope the operator consented to. Stored as columns-plus-blob in the
 // established shape: mode is queried (the executor logs it), the envelope is
@@ -215,7 +216,6 @@ const schemaV4 = `
 ALTER TABLE runs ADD COLUMN mode TEXT NOT NULL DEFAULT '';
 ALTER TABLE runs ADD COLUMN envelope BLOB;
 `
-
 
 // Save persists a record unless it duplicates the latest plan.
 func (s *Store) Save(ctx context.Context, rec store.Record) (bool, error) {


### PR DESCRIPTION
The milestone the roadmap designed, built to its two stated design problems.

## The loop

`observe → plan ONE step → full Safety Guard → drain → settle → observe → …` — the executor re-plans each round with the planner's own library and re-rates with the same thresholds (one chart values block feeds both components), so a converge step is Yellow exactly when the operator's screen would say Yellow.

## Consent changes in kind

A steps run approves a **list**; a converge run approves a **policy**. So: an explicit envelope (`maxNodes`, `maxImpact` — no defaults, a defaulted consent is not consent), stored on the run for the audit trail, behind the same `ExecuteConsolidations` grant. The CLI prompt says *"you are approving a policy, not a list"* and states both bounds and both rails. Red is untouched: windows or nothing.

## Termination, held three ways — each mutation-tested

| Rail | Kills |
|---|---|
| **monotonic progress** — every round must strictly reduce occupied nodes, *measured after settle* | the drain-A-fill-B-drain-B-fill-A oscillation: it never lowers the count, so it never gets round 2 |
| **node budget** — envelope's MaxNodes under an absolute cap | runaway loops |
| **never twice** — a drained node is not re-targeted | ping-pong on one node |

The scheduler-divergence fixture earned its place: the planner *itself* refuses non-consolidating moves, so the naive oscillation fixture **cannot fail** — the working fixture has the fake scheduler ignore the plan's target the way a real one may, which is exactly the case the rail exists for.

Bonus find: the zero-value `impact.Classifier` rates **everything Red** (zero thresholds without the constructor's defaulting). Caught by the first test run; now defaulted through the constructor in `withDefaults`.

## Honest dry runs

A converge rehearsal does one round and says so — further rounds would mean pretending to know where pods land, a forecast wearing a safety vest.

## Verified live

Deployed to OrbStack, `POST /api/v1/converge {maxNodes:3, maxImpact:Green, dryRun:true}`: planned round 1 against live state (`kwok-node-0`, Green, 4 pods), rehearsed the full chain, closed with the one-round statement.

**Remaining for M25 (noted in roadmap):** UI envelope affordance; KWOK fixpoint-vs-forecast comparison. All 19 packages green, chart contract green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)