### PR TITLE
Upgrade preflight: the analyzer's answer, printed before the 3am version

### DIFF
--- a/cmd/dencer/main.go
+++ b/cmd/dencer/main.go
@@ -274,12 +274,6 @@ func cmdConverge(ctx context.Context, args []string) error {
 		return errors.New("--max-impact must be Green or Yellow; Red always requires a maintenance window")
 	}
 
-func cmdPreflight(ctx context.Context, args []string) error {
-	fs := flag.NewFlagSet("preflight", flag.ExitOnError)
-	g := bind(fs)
-	if err := fs.Parse(args); err != nil {
-		return err
-	}
 	c, err := connect(ctx, g)
 	if err != nil {
 		return err
@@ -332,6 +326,20 @@ func cmdPreflight(ctx context.Context, args []string) error {
 	default:
 		return fmt.Errorf("run %s: %s", final.Status, final.Summary)
 	}
+}
+
+func cmdPreflight(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("preflight", flag.ExitOnError)
+	g := bind(fs)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	c, err := connect(ctx, g)
+	if err != nil {
+		return err
+	}
+	defer c.Close()
+
 	env, err := c.Preflight(ctx)
 	if err != nil {
 		return err

--- a/cmd/dencer/main.go
+++ b/cmd/dencer/main.go
@@ -39,6 +39,7 @@ Commands:
   converge              closed loop: re-plan after every drain, inside bounds
   status                the run in flight, or the last one
   reclamations          what actually became of the nodes you drained
+  preflight             will every node drain? run before a node-pool rotation
   version
 
 Global flags:
@@ -111,6 +112,8 @@ func run() error {
 		return cmdRun(ctx, args)
 	case "status":
 		return cmdStatus(ctx, args)
+	case "preflight":
+		return cmdPreflight(ctx, os.Args[2:])
 	case "reclamations", "reclaim":
 		return cmdReclamations(ctx, args)
 	default:
@@ -271,6 +274,12 @@ func cmdConverge(ctx context.Context, args []string) error {
 		return errors.New("--max-impact must be Green or Yellow; Red always requires a maintenance window")
 	}
 
+func cmdPreflight(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("preflight", flag.ExitOnError)
+	g := bind(fs)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
 	c, err := connect(ctx, g)
 	if err != nil {
 		return err
@@ -323,6 +332,15 @@ func cmdConverge(ctx context.Context, args []string) error {
 	default:
 		return fmt.Errorf("run %s: %s", final.Status, final.Summary)
 	}
+	env, err := c.Preflight(ctx)
+	if err != nil {
+		return err
+	}
+	if g.format != cli.FormatText {
+		return cli.Encode(os.Stdout, g.format, env)
+	}
+	cli.PrintPreflight(os.Stdout, env)
+	return nil
 }
 
 func cmdRun(ctx context.Context, args []string) error {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -160,3 +160,18 @@ drained twice in one run.
 
 `--dry-run` rehearses exactly one round. A converge rehearsal cannot honestly
 simulate where evicted pods land, so it does not pretend to.
+## `dencer preflight` — will the rotation wedge?
+
+```
+dencer preflight [-o json]
+```
+
+The question every team asks before a node-pool rotation, answered before
+anything is touched instead of discovered mid-upgrade through a stuck PDB:
+**will every node drain, and if not, which pod is in the way and why?**
+
+Blocked nodes come first, each with the analyzer's own explanation per
+blocking pod — the same engine that plans consolidations, asked a different
+question, so the preflight always agrees with the plan beside it.
+
+State changes; re-run immediately before upgrading.

--- a/docs/product-roadmap.md
+++ b/docs/product-roadmap.md
@@ -10,6 +10,9 @@ deciding what to build next and telling users what they get.
 ## Shipped
 
 ### Analysis and planning
+- **Upgrade preflight** — `dencer preflight`: will a node-pool rotation
+  wedge, on which node, because of which pod, and why — answered before
+  anything is touched, by the same analyzer that plans consolidations
 - **Full constraint analysis** — PDBs, topology spread, pod/node affinity,
   taints and tolerations, controller ownership, local storage; every immovable
   pod explained in words, not codes
@@ -98,11 +101,6 @@ consolidation's.
    savings number a consolidation tool can show, and it compounds — every day
    unshipped is data lost. Optional `$/node/month` chart value turns it into
    money.
-3. **Upgrade preflight** — `dencer preflight`: will this node-pool rotation
-   wedge, on which node, because of which pod, and what is the fix — answered
-   *before* anyone touches anything. The analyzer unchanged, printed for a
-   different question. Everyone upgrades; not everyone consolidates — this is
-   the adoption wedge.
 4. **Right-sizing signal** — requests versus actual usage per workload:
    "your top 10 over-requested workloads are holding 6 nodes hostage."
    Multiplies the core value, because consolidation packs requests and most

--- a/docs/product-roadmap.md
+++ b/docs/product-roadmap.md
@@ -105,6 +105,13 @@ consolidation's.
    "your top 10 over-requested workloads are holding 6 nodes hostage."
    Multiplies the core value, because consolidation packs requests and most
    clusters' requests are 2–3× usage.
+   *Scoped 2026-08: the plumbing exists end to end (`metrics.Source`,
+   collector wiring, `Usage` on the model, `HasUsageData`) but the only
+   implementation is `Noop` — a `metrics.k8s.io` client is the actual work,
+   plus read-only RBAC. Deliberately not built against KWOK: fake nodes have
+   no kubelets, so the feature could not be verified here, and shipping an
+   unverifiable feature is how confident wrong numbers happen. First
+   verifiable on k3d with metrics-server or the GCP run.*
 5. **Resilience audit** — the analyzer's never-evictable list, re-sorted into
    an availability risk report: zero-headroom PDBs, single replicas,
    controller-less pods — the cluster's inability to survive a node loss,

--- a/internal/api/rest/preflight.go
+++ b/internal/api/rest/preflight.go
@@ -1,0 +1,105 @@
+package rest
+
+import (
+	"net/http"
+	"sort"
+
+	"github.com/atedgimo/k8s-dencer/internal/constraints"
+)
+
+// Preflight answers the question every team asks before a node-pool rotation
+// and usually answers mid-upgrade, at 3am, via a wedged PDB: will every node
+// actually drain, and if not, which pod is in the way and what would fix it?
+//
+// Nothing here is computed for the occasion. The constraint analyzer already
+// answers "can this node drain" for the planner on every cycle; this endpoint
+// prints that answer node by node instead of feeding it to the packer. It is
+// the same engine asked a different question — which is why an upgrade
+// preflight can be trusted to agree with the consolidation plan beside it.
+
+type preflightNode struct {
+	Node      string `json:"node"`
+	Ready     bool   `json:"ready"`
+	Cordoned  bool   `json:"cordoned"`
+	Pods      int    `json:"pods"`
+	Drainable bool   `json:"drainable"`
+	// Blockers name the pod and quote the analyzer's canonical explanation.
+	// Empty for drainable nodes rather than omitted, so clients can range
+	// without nil checks.
+	Blockers []preflightBlocker `json:"blockers"`
+}
+
+type preflightBlocker struct {
+	Pod         string `json:"pod"`
+	Kind        string `json:"kind"`
+	Explanation string `json:"explanation"`
+}
+
+func (s *Server) handlePreflight(w http.ResponseWriter, r *http.Request) {
+	rec, err := s.record(r.Context(), "latest")
+	if err != nil {
+		s.fail(w, err)
+		return
+	}
+	snap, analysis := rec.Snapshot, rec.Analysis
+
+	// One pass to group constraints by node. Analysis.ForNode scans all pods
+	// per call, which is fine for the planner's occasional question and
+	// quadratic for a report that asks it for every node.
+	byNode := map[string][]constraints.PodConstraints{}
+	for _, pc := range analysis.Pods {
+		if pc.NodeName != "" {
+			byNode[pc.NodeName] = append(byNode[pc.NodeName], pc)
+		}
+	}
+
+	nodes := make([]preflightNode, 0, len(snap.Nodes))
+	drainable := 0
+	for _, n := range snap.Nodes {
+		out := preflightNode{
+			Node:     n.Name,
+			Ready:    n.Ready,
+			Cordoned: n.Unschedulable,
+			Blockers: []preflightBlocker{},
+		}
+		for _, pc := range byNode[n.Name] {
+			out.Pods++
+			if !pc.Movable {
+				for _, c := range pc.Blockers() {
+					out.Blockers = append(out.Blockers, preflightBlocker{
+						Pod: pc.Key(), Kind: string(c.Kind), Explanation: c.Explanation,
+					})
+				}
+				continue
+			}
+			if len(pc.CandidateNodes) == 0 {
+				out.Blockers = append(out.Blockers, preflightBlocker{
+					Pod: pc.Key(), Kind: string(constraints.KindResources),
+					Explanation: "No other node can currently accept this pod.",
+				})
+			}
+		}
+		out.Drainable = len(out.Blockers) == 0
+		if out.Drainable {
+			drainable++
+		}
+		nodes = append(nodes, out)
+	}
+
+	// Blocked nodes first — they are the reason anyone runs a preflight —
+	// then by name for a stable report.
+	sort.SliceStable(nodes, func(i, j int) bool {
+		if nodes[i].Drainable != nodes[j].Drainable {
+			return !nodes[i].Drainable
+		}
+		return nodes[i].Node < nodes[j].Node
+	})
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"takenAt":   snap.TakenAt,
+		"planId":    rec.Plan.ID,
+		"nodes":     nodes,
+		"drainable": drainable,
+		"total":     len(nodes),
+	})
+}

--- a/internal/api/rest/rest.go
+++ b/internal/api/rest/rest.go
@@ -118,6 +118,7 @@ func (s *Server) Routes(mux *http.ServeMux) {
 
 	read("/api/v1/version", s.handleVersion)
 	read("/api/v1/reclamations", s.handleReclamations)
+	read("/api/v1/preflight", s.handlePreflight)
 	read("/api/v1/plans", s.handleListPlans)
 	read("/api/v1/plans/latest", s.handleLatestPlan)
 	read("/api/v1/plans/{id}", s.handlePlan)

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -221,6 +221,8 @@ func (c *Client) Converge(ctx context.Context, maxNodes int, maxImpact string, d
 		return "", err
 	}
 	return out.RunID, nil
+}
+
 // PreflightEnvelope is what GET /api/v1/preflight returns.
 type PreflightEnvelope struct {
 	TakenAt   time.Time       `json:"takenAt"`

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -221,4 +221,35 @@ func (c *Client) Converge(ctx context.Context, maxNodes int, maxImpact string, d
 		return "", err
 	}
 	return out.RunID, nil
+// PreflightEnvelope is what GET /api/v1/preflight returns.
+type PreflightEnvelope struct {
+	TakenAt   time.Time       `json:"takenAt"`
+	PlanID    string          `json:"planId"`
+	Nodes     []PreflightNode `json:"nodes"`
+	Drainable int             `json:"drainable"`
+	Total     int             `json:"total"`
+}
+
+type PreflightNode struct {
+	Node      string             `json:"node"`
+	Ready     bool               `json:"ready"`
+	Cordoned  bool               `json:"cordoned"`
+	Pods      int                `json:"pods"`
+	Drainable bool               `json:"drainable"`
+	Blockers  []PreflightBlocker `json:"blockers"`
+}
+
+type PreflightBlocker struct {
+	Pod         string `json:"pod"`
+	Kind        string `json:"kind"`
+	Explanation string `json:"explanation"`
+}
+
+// Preflight reports per-node drainability — the upgrade question.
+func (c *Client) Preflight(ctx context.Context) (*PreflightEnvelope, error) {
+	var out PreflightEnvelope
+	if err := c.get(ctx, "/api/v1/preflight", &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
 }

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -464,3 +464,34 @@ func formatBytes(b int64) string {
 	}
 	return fmt.Sprintf("%.1f %s", v, units[exp])
 }
+
+// PrintPreflight renders per-node drainability — the answer to "will my
+// node-pool rotation wedge?", given before anything is touched instead of
+// discovered mid-upgrade via a stuck PDB.
+//
+// Blocked nodes come first and get the detail; they are the reason anyone
+// runs a preflight. Drainable nodes are a one-line reassurance.
+func PrintPreflight(w io.Writer, env *PreflightEnvelope) {
+	fmt.Fprintf(w, "%s  %s\n\n",
+		bold(fmt.Sprintf("%d of %d nodes will drain cleanly", env.Drainable, env.Total)),
+		dim("as of "+humanDuration(time.Since(env.TakenAt))+" ago"))
+
+	blocked := 0
+	for _, n := range env.Nodes {
+		if n.Drainable {
+			continue
+		}
+		blocked++
+		fmt.Fprintf(w, "%s %s  (%d pods)\n", red("■"), bold(n.Node), n.Pods)
+		for _, b := range n.Blockers {
+			fmt.Fprintf(w, "    %s  %s\n", b.Pod, dim("["+b.Kind+"]"))
+			fmt.Fprintf(w, "      %s\n", b.Explanation)
+		}
+	}
+	if blocked == 0 {
+		fmt.Fprintln(w, "Every node can be drained. A rolling node replacement will not wedge on today's state.")
+		return
+	}
+	fmt.Fprintf(w, "\nA rotation will stall at %d node(s) unless the blockers above are resolved first.\n", blocked)
+	fmt.Fprintln(w, "State changes; re-run this immediately before upgrading.")
+}


### PR DESCRIPTION
The adoption wedge from the agreed value roadmap — item moved from *Next* to *Shipped*.

Every team rotating a node pool asks whether it will wedge; most find out mid-upgrade, through a PDB with no headroom. The constraint analyzer has answered exactly this question for the planner on every cycle since M3 — `GET /api/v1/preflight` and `dencer preflight` print that answer node by node instead of feeding it to the packer.

- **Blocked nodes first**, each with the analyzer's canonical explanation per blocking pod — the same text the plan and inspector quote, so the preflight *cannot* disagree with the products beside it
- Grouped in one pass rather than `Analysis.ForNode` per node (fine for the planner's occasional question, quadratic for a whole-cluster report)
- `-o json` for pipelines; "state changes; re-run immediately before upgrading" printed on the report itself

Also in this PR: **right-sizing scoped honestly** in the roadmap — the plumbing exists end to end but the only `metrics.Source` is `Noop`, and KWOK nodes have no kubelets, so the feature could not be *verified* here. Deferred with the dependency named rather than built unverifiable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)