### PR TITLE
The lookahead question, closed by measurement: there is nothing to recover

### DIFF
--- a/docs/product-roadmap.md
+++ b/docs/product-roadmap.md
@@ -127,8 +127,7 @@ consolidation's.
 9. **Reclaimer detection** — warn *before* draining when no autoscaler or
    Karpenter is present to remove the emptied node (drained-but-not-removed
    is pure cost).
-10. **Planner lookahead** — evaluate whether draining A forecloses draining B
-    and C; adopt only if measurably better plans result.
+
 
 ## Explicitly not planned
 
@@ -140,6 +139,12 @@ Decisions, not omissions — recorded so they are not re-litigated by accident:
   approves eviction; scheduled unattended execution stays out until the
   closed-loop envelope model proves itself
 - **Multi-cluster orchestration** — one cluster per install
+- **Planner lookahead** — measured before building, 2026-08: greedy already
+  averages 0.2 nodes *below* the constraint-free capacity bound across 15
+  synthetic runs (worst case +2, small clusters only). A lookahead can only
+  recover the gap to that bound, and there is essentially none. The measuring
+  test stays in the suite and reopens the question automatically if the
+  planner ever drifts
 
 ---
 

--- a/internal/planner/bound_test.go
+++ b/internal/planner/bound_test.go
@@ -1,0 +1,79 @@
+package planner_test
+
+// The lookahead question, answered by measurement before any implementation:
+// how many nodes does greedy leave on the table? A one-step lookahead (or any
+// smarter search) can recover AT MOST the gap between greedy's result and the
+// capacity lower bound — the fewest nodes that could possibly hold the
+// cluster's requests if packing were perfect and constraints did not exist.
+// If that gap is near zero, lookahead is complexity with no purchase.
+//
+// The bound is generous to the challenger: it ignores every constraint
+// (anti-affinity, spread, PDBs, daemonsets pinning nodes open), so the true
+// attainable minimum is higher than the bound and the true recoverable gap
+// smaller than measured here.
+
+import (
+	"testing"
+
+	"github.com/atedgimo/k8s-dencer/internal/constraints"
+	"github.com/atedgimo/k8s-dencer/internal/model"
+	"github.com/atedgimo/k8s-dencer/internal/planner"
+)
+
+func TestGreedyIsNearTheCapacityBound(t *testing.T) {
+	totalGap := 0
+	runs := 0
+	for _, nodes := range []int{30, 60, 100} {
+		for seed := int64(1); seed <= 5; seed++ {
+			opts := model.DefaultSynthetic(nodes)
+			opts.Seed = seed
+			snap := model.Synthesize(opts)
+
+			analysis := constraints.Analyze(snap)
+			popts := planner.DefaultOptions()
+			popts.MinNodeAge = 0 // synthetic nodes have no age
+			plan, err := planner.Greedy{}.Plan(snap, analysis, popts)
+			if err != nil {
+				t.Fatalf("nodes=%d seed=%d: %v", nodes, seed, err)
+			}
+
+			// The constraint-free lower bound on nodes, per dimension.
+			alloc, req := snap.Totals()
+			bound := 0
+			if alloc.MilliCPU > 0 {
+				perNodeCPU := alloc.MilliCPU / int64(len(snap.Nodes))
+				bound = max(bound, int((req.MilliCPU+perNodeCPU-1)/perNodeCPU))
+			}
+			if alloc.MemoryBytes > 0 {
+				perNodeMem := alloc.MemoryBytes / int64(len(snap.Nodes))
+				bound = max(bound, int((req.MemoryBytes+perNodeMem-1)/perNodeMem))
+			}
+
+			gap := plan.NodesAfter - bound
+			totalGap += gap
+			runs++
+			t.Logf("nodes=%3d seed=%d  after=%3d  bound=%3d  gap=%d",
+				nodes, seed, plan.NodesAfter, bound, gap)
+		}
+	}
+	avg := float64(totalGap) / float64(runs)
+	t.Logf("average gap over %d runs: %.2f nodes", runs, avg)
+
+	// Measured 2026-08: average gap -0.20 over 15 runs (30/60/100 nodes,
+	// seeds 1-5). Negative is possible because the bound rounds up from
+	// cluster-average capacity; at or below it means greedy is at the packing
+	// ceiling within the bound's own rounding. Worst observed: +2 at 30
+	// nodes. Conclusion: a lookahead could recover at most a node or two in
+	// small-cluster edge cases and usually nothing — not worth its complexity
+	// or the plan-stability risk. This test stays so the conclusion is
+	// re-verified on every change to the planner, and the assertion below
+	// reopens the question automatically if greedy ever drifts.
+
+	// The experiment's conclusion, pinned: if greedy ever drifts far from the
+	// bound, this fails and the lookahead question reopens with data.
+	if avg > 3.0 {
+		t.Errorf(
+			"greedy averages %.2f nodes above the capacity bound; a lookahead could be worth building — reopen the experiment",
+			avg)
+	}
+}


### PR DESCRIPTION
The last open planner question from the cordon-algorithm discussion, answered the agreed way: **measure before adopting**.

```
nodes= 30  seeds 1-5:  gaps  +1 +2 +1  0 +1
nodes= 60  seeds 1-5:  gaps  -1  0  0 -1 -1
nodes=100  seeds 1-5:  gaps  -1 -1 -1 -1 -1
average: -0.20 nodes
```

Greedy is **at the constraint-free capacity bound** within its own rounding. A lookahead can only recover the gap to that bound — and the bound ignores every constraint, so the true recoverable gap is smaller than measured. Verdict: at most a node or two in small-cluster edge cases, against real costs (planner complexity; content-hashed plan IDs flap if the search isn't deterministic).

**Closed, not forgotten:** the experiment ships as a test that re-verifies on every planner change and automatically reopens the question if greedy drifts >3 nodes from the bound. Roadmap moves lookahead to *explicitly not planned — decided by measurement*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)