### PR TITLE
e2e: show the image-build error instead of discarding it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ ui/dist/
 /executor
 /ui-backend
 bin/
+.e2e-images.log

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -279,7 +279,14 @@ green "  restricted enforced on $NS and $APP_NS"
 bold "==> images"
 if [[ "$PROVIDER" == "k3d" ]]; then
   TAG="$(make -s -C "$REPO" print-tag)"
-  make -s -C "$REPO" images >/dev/null 2>&1 || fail "image build failed"
+  # Output kept and shown on failure. This line used to discard it, which
+  # turned a CI flake into an hour of local reproduction attempts for a
+  # failure whose reason had been printed and thrown away — the "reported
+  # failure while hiding the cause" cousin of everything in findings.md.
+  if ! make -s -C "$REPO" images >"$REPO/.e2e-images.log" 2>&1; then
+    tail -n 40 "$REPO/.e2e-images.log"
+    fail "image build failed"
+  fi
   k3d image import -c "$CLUSTER" \
     "k8s-dencer-planner:${TAG}" "k8s-dencer-ui-backend:${TAG}" \
     "k8s-dencer-executor:${TAG}" "k8s-dencer-ui-frontend:${TAG}" >/dev/null 2>&1 \


### PR DESCRIPTION
A docs-only PR failed CI on `image build failed` with zero further output — `hack/e2e.sh` redirected the build's output to /dev/null. The failure was a runner flake, but proving that took cold rebuilds on two platforms locally, because the line naming the real cause had been printed inside CI and discarded. The build log now lands in a file whose tail prints on failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)