### PR TITLE
M24 and M25, finished: the envelope reaches the UI, evicted pods stop lying

### DIFF
--- a/docs/product-roadmap.md
+++ b/docs/product-roadmap.md
@@ -29,6 +29,11 @@ deciding what to build next and telling users what they get.
   5,026 pods, measured; no cluster required to benchmark
 
 ### Execution
+- **Closed-loop consolidation** — "Run to optimum" in the UI and `dencer
+  converge` in the CLI: the executor re-plans from *observed* state after
+  every drain, inside an explicit envelope (max nodes, impact ceiling), with
+  three mutation-tested termination rails. Consent is to a policy, and both
+  surfaces say so in those words
 - **Off by default**, and the chart refuses to enable it without
   authentication and persistence
 - **Runs only the steps a human picked**, through the eviction API — the API
@@ -94,12 +99,6 @@ what it already records and packs. Chosen because they reuse the machinery
 as it stands, and two of them serve audiences far larger than
 consolidation's.
 
-1. **Closed-loop consolidation** (M25, designed) — re-plan from observed state
-   after every step instead of executing a forecast; bounded by an explicit
-   operator-approved envelope (max nodes, window, impact ceiling). Ends the
-   gap where a run aborts on divergence a fresh plan would simply absorb.
-   Includes per-pod placement during a run, the first consumer of its live
-   data.
 4. **Right-sizing signal** — requests versus actual usage per workload:
    "your top 10 over-requested workloads are holding 6 nodes hostage."
    Multiplies the core value, because consolidation packs requests and most

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -53,8 +53,8 @@ estimated — every milestone here starts from a number in
 | **M21b** | Real ingress controller and StorageClass, exercised in the e2e | **done** |
 | **M22** | Reclamation loop — observe whether a drained node was actually removed | **done** |
 | **M23** | Cloud test on GKE — GKE's autoscaler reclaimed a drained node in **11m9s**, observed | **done** |
-| **M24** | The field shows what *is*, not only what *would be* — observed node states overlaid on the plan | **done for nodes**; per-pod placement waits on M25 |
-| **M25** | Closed-loop consolidation — re-plan from observed state after every step, inside an operator-approved envelope | **core shipped**; UI affordance pending |
+| **M24** | The field shows what *is*, not only what *would be* — observed states overlaid on the plan, nodes and pods | **done** |
+| **M25** | Closed-loop consolidation — re-plan from observed state after every step, inside an operator-approved envelope | **done** — engine, CLI and UI |
 
 High availability and a Postgres store were **dropped, not deferred**: a
 consolidation planner is not a serving path. The run queue is already crash-safe
@@ -231,8 +231,13 @@ A converge dry run rehearses exactly one round and says so. Rehearsing further
 rounds would mean pretending to know where evicted pods land — a forecast
 wearing a safety vest, the exact thing this mode exists to retire.
 
-**Still open for M25:** a UI affordance for the envelope (the CLI carries it
-today), and the KWOK fixpoint-vs-forecast comparison.
+**Closed since:** the UI carries the envelope too — "Run to optimum…" opens
+a consent sheet that is deliberately not the steps sheet with different text:
+policy wording, both bounds as explicit inputs with no defaulted node budget,
+rehearse-one-round beside approve. And M24's last gap closed with it: a pod
+the run has actually evicted ghosts at its origin — dashed and hollow, the
+observed-fact texture — until the next snapshot says where it landed, instead
+of being drawn at a destination the scheduler never confirmed.
 
 ## What actually runs today
 

--- a/test/ui/client_test.go
+++ b/test/ui/client_test.go
@@ -259,7 +259,15 @@ func TestObservedNodeStatesAreDrawnNotJustParsed(t *testing.T) {
 	// And the overlay must actually be mounted: derived in a hook nothing
 	// calls is the parsed-but-never-drawn bug with an extra step.
 	app := read(t, "App.tsx")
-	if !strings.Contains(app, "useObserved(") || !strings.Contains(app, "observed={observed}") {
+	if !strings.Contains(app, "useObserved(") || !strings.Contains(app, "observed={observed.nodes}") {
 		t.Error("App does not wire the observed overlay into the field")
+	}
+
+	// The evicted-pod half of the overlay: a run's Evict events must reach
+	// the field, or in-flight pods go back to being drawn at destinations
+	// the scheduler never confirmed.
+	if !strings.Contains(app, "evictedPods={observed.evictedPods}") {
+		t.Error("App does not pass the evicted-pod set to the field; " +
+			"pods evicted mid-run are drawn as if the plan's destination were fact")
 	}
 }

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Impact, PlanStep } from "./api";
 import Inspector, { Selection } from "./components/Inspector";
 import PackingField from "./components/PackingField";
-import { ConfirmRun, RunTrail } from "./components/RunPanel";
+import { ConfirmConverge, ConfirmRun, RunTrail } from "./components/RunPanel";
 import Scrubber from "./components/Scrubber";
 import { SignIn } from "./components/SignIn";
 import StepLedger from "./components/StepLedger";
@@ -57,6 +57,7 @@ export default function App() {
   const [selection, setSelection] = useState<Selection>(null);
   const [focusedRating, setFocusedRating] = useState<Impact | null>(null);
   const [pending, setPending] = useState<{ steps: PlanStep[]; dryRun: boolean } | null>(null);
+  const [convergeOpen, setConvergeOpen] = useState(false);
   const lastToggled = useRef<number | null>(null);
 
   const planId = state.status === "ready" ? state.plan.plan.id : null;
@@ -223,6 +224,7 @@ export default function App() {
             focusedRating={focusedRating}
             onFocusRating={setFocusedRating}
             onRun={requestRun}
+            onConverge={() => setConvergeOpen(true)}
             busy={busy}
             picked={pickedSteps}
             onClearPicked={() => setChecked(new Set())}
@@ -249,7 +251,8 @@ export default function App() {
               reclaimedForReal={reclamations.stats.reclaimed}
               ledgerCpuMilli={reclamations.stats.reclaimedCpuMilli}
               ledgerMemBytes={reclamations.stats.reclaimedMemBytes}
-              observed={observed}
+              observed={observed.nodes}
+              evictedPods={observed.evictedPods}
               graph={state.graph}
               steps={steps}
               step={step}
@@ -311,6 +314,16 @@ export default function App() {
           dryRun={pending.dryRun}
           onConfirm={confirmRun}
           onCancel={() => setPending(null)}
+        />
+      )}
+      {convergeOpen && state.status === "ready" && (
+        <ConfirmConverge
+          planReclaims={state.graph.stats.reclaimable}
+          onConfirm={(maxNodes, maxImpact, dryRun) => {
+            setConvergeOpen(false);
+            void run.startConverge(maxNodes, maxImpact, dryRun);
+          }}
+          onCancel={() => setConvergeOpen(false)}
         />
       )}
     </div>

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -348,6 +348,16 @@ export const api = {
       signal,
     ),
 
+  /** Queues a closed-loop run: the executor re-plans after every drain,
+   *  inside the envelope. Consent to a policy, not a list — the caller must
+   *  have shown the policy wording before calling this. */
+  converge: (maxNodes: number, maxImpact: "Green" | "Yellow", dryRun: boolean) =>
+    post<{ runId: string; status: RunStatus }>(`/api/v1/converge`, {
+      maxNodes,
+      maxImpact,
+      dryRun,
+    }),
+
   run: (runId: string, signal?: AbortSignal) => get<RunDetail>(`/api/v1/runs/${runId}`, signal),
 
   /** The in-flight run, if any. Lets a page reload rejoin a consolidation

--- a/ui/src/components/PackingField.tsx
+++ b/ui/src/components/PackingField.tsx
@@ -79,6 +79,9 @@ interface Props {
    * so all three views agree on what is real.
    */
   observed?: Map<string, ObservedNode>;
+  /** Pods the current run genuinely evicted; ghosted at origin until the
+   *  next snapshot says where they landed. Observed, never predicted. */
+  evictedPods?: Set<string>;
 }
 
 export default function PackingField({
@@ -96,6 +99,7 @@ export default function PackingField({
   ledgerCpuMilli = 0,
   ledgerMemBytes = 0,
   observed,
+  evictedPods,
 }: Props) {
   const model: Model = useMemo(() => toModel(graph), [graph]);
   const peak = useMemo(() => peakOccupancy(model, steps), [model, steps]);
@@ -390,6 +394,10 @@ export default function PackingField({
             if (!pos) return null;
             const host = placement.get(pod.key) ?? pod.homeNode;
             const leaving = reclaimed.has(host);
+            // Actually evicted by the run in flight — as opposed to
+            // "leaving", which is the scrubber's forecast. The block ghosts
+            // in place: gone from here, landing not yet observed.
+            const inFlight = evictedPods?.has(pod.key) ?? false;
 
             return (
               <div
@@ -400,6 +408,7 @@ export default function PackingField({
                   !pod.movable ? "blk-pinned" : "",
                   selectedPod === pod.key ? "blk-selected" : "",
                   leaving ? "blk-orphan" : "",
+                  inFlight ? "blk-inflight" : "",
                 ]
                   .filter(Boolean)
                   .join(" ")}
@@ -416,7 +425,7 @@ export default function PackingField({
                 tabIndex={-1}
                 title={`${pod.key}${pod.blocked ? " — blocked" : ""}${
                   !pod.movable ? " — pinned to this node" : ""
-                }`}
+                }${inFlight ? " — evicted; where it landed arrives with the next snapshot" : ""}`}
               />
             );
           })}

--- a/ui/src/components/RunPanel.tsx
+++ b/ui/src/components/RunPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { PlanStep, RunEvent, RunStatus } from "../api";
 import { RunState } from "../useRun";
 
@@ -184,4 +184,111 @@ function headline(status: RunStatus, dryRun: boolean): string {
 /** Events worth surfacing without expanding — used for the compact readout. */
 export function lastMeaningful(events: RunEvent[]): RunEvent | undefined {
   return events[events.length - 1];
+}
+
+/* -------------------------------------------------------- converge consent */
+
+interface ConvergeProps {
+  /** The current plan's reclaimable count — context only, and labelled so. */
+  planReclaims: number;
+  onConfirm: (maxNodes: number, maxImpact: "Green" | "Yellow", dryRun: boolean) => void;
+  onCancel: () => void;
+}
+
+/**
+ * The consent sheet for a closed-loop run, and deliberately not ConfirmRun
+ * with different text. A steps run approves a concrete list an operator can
+ * picture; a converge run approves a POLICY — the executor re-plans after
+ * every drain and picks its own targets — and this sheet exists to make that
+ * difference impossible to miss. Both bounds are explicit inputs with no
+ * pre-filled node budget, because a defaulted consent is not consent.
+ */
+export function ConfirmConverge({ planReclaims, onConfirm, onCancel }: ConvergeProps) {
+  const [maxNodes, setMaxNodes] = useState("");
+  const [ceiling, setCeiling] = useState<"Green" | "Yellow">("Green");
+  const ref = useRef<HTMLInputElement>(null);
+  useEffect(() => ref.current?.focus(), []);
+
+  const n = parseInt(maxNodes, 10);
+  const valid = Number.isFinite(n) && n >= 1 && n <= 200;
+
+  return (
+    <div className="sheet-backdrop" onClick={onCancel} role="presentation">
+      <div
+        className="sheet"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Approve a closed-loop consolidation policy"
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.key === "Escape" && onCancel()}
+      >
+        <h2 className="sheet-title">Run to optimum</h2>
+
+        <p className="sheet-detail">
+          <strong>You are approving a policy, not a list of steps.</strong> The executor will
+          repeatedly observe the cluster, plan <em>one</em> drain against live state, run the full
+          Safety Guard, drain, and wait for recovery — until nothing worthwhile remains or a bound
+          below is reached. Every round must free a node or the run stops, and no node is drained
+          twice.
+        </p>
+
+        <div className="sheet-bounds">
+          <label className="sheet-bound">
+            <span className="eyebrow">at most</span>
+            <input
+              ref={ref}
+              className="sheet-input num"
+              inputMode="numeric"
+              placeholder="?"
+              value={maxNodes}
+              onChange={(e) => setMaxNodes(e.target.value)}
+              aria-label="Maximum nodes this run may drain"
+            />
+            <span className="sheet-bound-unit">nodes drained</span>
+          </label>
+          <div className="sheet-bound">
+            <span className="eyebrow">nothing above</span>
+            <div className="sheet-seg" role="radiogroup" aria-label="Impact ceiling">
+              {(["Green", "Yellow"] as const).map((c) => (
+                <button
+                  key={c}
+                  type="button"
+                  role="radio"
+                  aria-checked={ceiling === c}
+                  className={ceiling === c ? "sheet-seg-on" : ""}
+                  onClick={() => setCeiling(c)}
+                >
+                  {c}
+                </button>
+              ))}
+            </div>
+            <span className="sheet-bound-unit">is executed. Red always needs a window.</span>
+          </div>
+        </div>
+
+        {planReclaims > 0 && (
+          <p className="sheet-context">
+            For context only — targets are re-chosen live: the current plan frees {planReclaims}{" "}
+            node{planReclaims === 1 ? "" : "s"}.
+          </p>
+        )}
+
+        <div className="sheet-actions">
+          <button className="btn" onClick={onCancel}>
+            Cancel
+          </button>
+          <button className="btn" disabled={!valid} onClick={() => onConfirm(n, ceiling, true)}>
+            Rehearse one round
+          </button>
+          <button
+            className="btn btn-primary"
+            disabled={!valid}
+            onClick={() => onConfirm(n, ceiling, false)}
+          >
+            Approve this policy
+          </button>
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/ui/src/components/Verdict.tsx
+++ b/ui/src/components/Verdict.tsx
@@ -37,6 +37,8 @@ interface Props {
   onFocusRating: (impact: Impact | null) => void;
   focusedRating: Impact | null;
   onRun: (dryRun: boolean) => void;
+  /** Opens the closed-loop consent sheet. */
+  onConverge: () => void;
   busy: boolean;
   /** Steps ticked in the ledger. Empty means "the Green ones". */
   picked: PlanStep[];
@@ -50,6 +52,7 @@ export default function Verdict({
   onFocusRating,
   focusedRating,
   onRun,
+  onConverge,
   busy,
   picked,
   onClearPicked,
@@ -156,6 +159,17 @@ export default function Verdict({
           title="Run the full Safety Guard and show the same trail, without touching anything."
         >
           Dry run
+        </button>
+        {/* The closed loop's door. Quieter than the primary action on
+            purpose: approving a policy deserves a deliberate step through
+            the consent sheet, not a one-click reflex beside it. */}
+        <button
+          className="btn btn-quiet"
+          onClick={onConverge}
+          disabled={busy}
+          title="Approve a bounded policy: re-plan after every drain until nothing worthwhile remains."
+        >
+          Run to optimum…
         </button>
 
         {custom ? (

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -2164,3 +2164,92 @@
   font-size: var(--text-2xs);
   letter-spacing: 0.01em;
 }
+
+/* ------------------------------------------------- converge consent sheet */
+
+/* Quieter than .btn: the closed loop's door should be discoverable, not
+   competing with the primary action beside it. */
+.btn-quiet {
+  border-style: dashed;
+  color: var(--graphite);
+}
+
+.btn-quiet:hover:not(:disabled) {
+  color: var(--text-primary);
+  border-style: solid;
+}
+
+.sheet-bounds {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  margin: var(--space-5) 0;
+  padding: var(--space-4);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface-1);
+}
+
+.sheet-bound {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.sheet-input {
+  width: 4.5rem;
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  background: var(--surface-0);
+  color: var(--text-primary);
+  font-size: var(--text-lg);
+  text-align: center;
+}
+
+.sheet-input:focus {
+  outline: 2px solid var(--focus);
+  outline-offset: 1px;
+}
+
+.sheet-seg {
+  display: inline-flex;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+
+.sheet-seg button {
+  padding: var(--space-1) var(--space-3);
+  border: 0;
+  background: transparent;
+  color: var(--graphite);
+  font-size: var(--text-sm);
+  cursor: pointer;
+}
+
+.sheet-seg .sheet-seg-on {
+  background: var(--surface-3);
+  color: var(--text-primary);
+}
+
+.sheet-bound-unit {
+  color: var(--graphite);
+  font-size: var(--text-sm);
+}
+
+.sheet-context {
+  margin: 0 0 var(--space-4);
+  color: var(--graphite-dim);
+  font-size: var(--text-xs);
+}
+
+/* A pod the run has actually evicted, ghosted at its origin. Distinct in
+   kind from .blk-orphan (the scrubber's forecast): dashed and hollow, the
+   texture this surface uses for observed facts, held until the next
+   snapshot says where the pod landed. */
+.blk-inflight {
+  opacity: 0.35;
+  background: transparent;
+  border: 1px dashed var(--border-strong);
+}

--- a/ui/src/useObserved.ts
+++ b/ui/src/useObserved.ts
@@ -17,12 +17,25 @@ import { RunState } from "./useRun";
  * confusion this overlay exists to end, rebuilt one layer up. Guarded by
  * test/ui, mutation-tested.
  */
+export interface Observed {
+  nodes: Map<string, ObservedNode>;
+  /**
+   * Pods the current run has genuinely evicted, by "namespace/name". Their
+   * drawn position is a lie waiting to happen: the plan says where they were
+   * going, the scheduler decided for itself, and the truth arrives only with
+   * the next snapshot. Until then the field ghosts them at their origin —
+   * gone from here, landed somewhere not yet known.
+   */
+  evictedPods: Set<string>;
+}
+
 export function useObserved(
   reclamations: ReclamationState,
   runState: RunState,
-): Map<string, ObservedNode> {
+): Observed {
   return useMemo(() => {
     const m = new Map<string, ObservedNode>();
+    const evicted = new Set<string>();
     for (const r of reclamations.awaiting) {
       m.set(r.node, { reclaim: "awaiting" });
     }
@@ -34,6 +47,7 @@ export function useObserved(
     if (runState.status === "active" || runState.status === "done") {
       if (!runState.run.dryRun) {
         for (const e of runState.events) {
+          if (e.action === "Evict" && e.pod) evicted.add(e.pod);
           if (!e.node) continue;
           if (e.action === "Cordon") {
             m.set(e.node, { ...m.get(e.node), cordoned: true });
@@ -44,6 +58,6 @@ export function useObserved(
         }
       }
     }
-    return m;
+    return { nodes: m, evictedPods: evicted };
   }, [reclamations, runState]);
 }

--- a/ui/src/useRun.ts
+++ b/ui/src/useRun.ts
@@ -74,6 +74,26 @@ export function useRun(onFinished?: () => void) {
     [follow, stop],
   );
 
+  // Converge shares everything with start except the request: same follow,
+  // same trail, same rejoin-on-reload. The run mode lives server-side.
+  const startConverge = useCallback(
+    async (maxNodes: number, maxImpact: "Green" | "Yellow", dryRun: boolean) => {
+      stop();
+      setState({ status: "starting" });
+      try {
+        const { runId } = await api.converge(maxNodes, maxImpact, dryRun);
+        follow(runId);
+      } catch (err) {
+        setState({
+          status: "error",
+          message: describe(err),
+          grantWith: err instanceof ApiError ? err.grantWith : undefined,
+        });
+      }
+    },
+    [follow, stop],
+  );
+
   const dismiss = useCallback(() => {
     stop();
     setState({ status: "idle" });
@@ -98,7 +118,7 @@ export function useRun(onFinished?: () => void) {
     };
   }, [follow, stop]);
 
-  return { state, start, dismiss };
+  return { state, start, startConverge, dismiss };
 }
 
 function describe(err: unknown): string {


### PR DESCRIPTION
The finishing arc, part 1 — closes the noted remainders of both milestones.

## M25: "Run to optimum…" in the UI

A consent sheet that is deliberately **not** the steps sheet with different words: *"you are approving a policy, not a list of steps"*, the loop and both rails stated, and both bounds as **explicit inputs — the node budget has no default**, because a defaulted consent is not consent. *Rehearse one round* sits beside *Approve this policy*. The entry button is quiet by design: a policy deserves a deliberate step through the sheet, not a reflex click.

## M24: evicted pods ghost at origin

During a run, a pod the executor actually evicted used to keep its drawn position — the plan's predicted destination, which the scheduler never promised. The run's `Evict` events now feed the observed overlay; an evicted pod renders **dashed and hollow at its origin** (the observed-fact texture) until the next snapshot says where it landed. *Gone from here, landing not yet known* — drawn as exactly that, with the tooltip saying so.

## Guarded

The overlay guard grew the matching assertion (mutation-verified), and **caught the `useObserved` signature change mid-build** — the guard doing precisely what it exists for.

Deployed to OrbStack; bundle verified to carry the sheet and the in-flight class. Both milestones now read **done** in both roadmaps, honest scope recorded. All gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)