### PR TITLE
Resilience audit and guarded drain: the same engine, two more moods

### DIFF
--- a/cmd/dencer/main.go
+++ b/cmd/dencer/main.go
@@ -40,6 +40,8 @@ Commands:
   status                the run in flight, or the last one
   reclamations          what actually became of the nodes you drained
   preflight             will every node drain? run before a node-pool rotation
+  audit                 what cannot survive a node loss, and why
+  drain <node>          guarded drain of one node: the rails, not bare kubectl
   version
 
 Global flags:
@@ -114,6 +116,10 @@ func run() error {
 		return cmdStatus(ctx, args)
 	case "preflight":
 		return cmdPreflight(ctx, os.Args[2:])
+	case "audit", "resilience":
+		return cmdAudit(ctx, os.Args[2:])
+	case "drain":
+		return cmdDrain(ctx, os.Args[2:])
 	case "reclamations", "reclaim":
 		return cmdReclamations(ctx, args)
 	default:
@@ -316,6 +322,91 @@ func cmdConverge(ctx context.Context, args []string) error {
 		return err
 	}
 
+	fmt.Println()
+	switch final.Status {
+	case store.RunSucceeded:
+		fmt.Printf("Succeeded. %s\n", final.Summary)
+		return nil
+	case store.RunBlocked:
+		return fmt.Errorf("blocked by the Safety Guard: %s", final.Summary)
+	default:
+		return fmt.Errorf("run %s: %s", final.Status, final.Summary)
+	}
+}
+
+func cmdAudit(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("audit", flag.ExitOnError)
+	g := bind(fs)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	c, err := connect(ctx, g)
+	if err != nil {
+		return err
+	}
+	defer c.Close()
+	env, err := c.Resilience(ctx)
+	if err != nil {
+		return err
+	}
+	if g.format != cli.FormatText {
+		return cli.Encode(os.Stdout, g.format, env)
+	}
+	cli.PrintResilience(os.Stdout, env)
+	return nil
+}
+
+func cmdDrain(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("drain", flag.ExitOnError)
+	g := bind(fs)
+	dryRun := fs.Bool("dry-run", false, "run every guard check and emit the same events without touching the node")
+	watch := fs.Bool("watch", true, "follow the drain until it finishes")
+	yes := fs.Bool("yes", false, "skip the confirmation prompt")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		return errors.New("which node? e.g. dencer drain worker-3")
+	}
+	node := fs.Arg(0)
+
+	c, err := connect(ctx, g)
+	if err != nil {
+		return err
+	}
+	defer c.Close()
+
+	if !*dryRun && !*yes {
+		fmt.Printf("Drain %s through the guard chain? Evicted pods are not restored if this aborts. [y/N] ", node)
+		var answer string
+		_, _ = fmt.Scanln(&answer)
+		answer = strings.ToLower(strings.TrimSpace(answer))
+		if answer != "y" && answer != "yes" {
+			fmt.Println("Nothing was drained.")
+			return nil
+		}
+	}
+
+	runID, err := c.Drain(ctx, node, *dryRun)
+	if err != nil {
+		return err
+	}
+	suffix := ""
+	if *dryRun {
+		suffix = " (dry run)"
+	}
+	fmt.Printf("drain of %s queued as run %s%s\n", node, runID, suffix)
+
+	if !*watch {
+		fmt.Printf("Follow it with: dencer status --run %s\n", runID)
+		return nil
+	}
+	final, err := c.Wait(ctx, runID, func(ev store.RunEvent) {
+		cli.PrintEvent(os.Stdout, ev)
+	})
+	if err != nil {
+		return err
+	}
 	fmt.Println()
 	switch final.Status {
 	case store.RunSucceeded:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -175,3 +175,27 @@ blocking pod — the same engine that plans consolidations, asked a different
 question, so the preflight always agrees with the plan beside it.
 
 State changes; re-run immediately before upgrading.
+
+## `dencer audit` — what cannot survive a node loss
+
+```
+dencer audit [-o json]
+```
+
+The consolidation analysis read in the opposite mood: the PDB that blocks a
+voluntary drain is the same PDB a dying node violates, and the pod with no
+controller that eviction would delete permanently is deleted just as
+permanently by hardware. Findings are grouped by kind, each quoting the
+analyzer's own explanation.
+
+## `dencer drain <node>` — kubectl drain, with the rails
+
+```
+dencer drain worker-3 [--dry-run] [--yes]
+```
+
+The drain everyone does with kubectl, but guarded: the step is **rated with
+the same impact thresholds as a planned step** (a Red drain needs a
+maintenance window — naming the node is not a side-channel), every eviction
+passes the PDB pre-check against fresh state, recovery is verified on
+readiness, aborting uncordons, and the whole thing lands in the audit trail.

--- a/docs/product-roadmap.md
+++ b/docs/product-roadmap.md
@@ -10,6 +10,9 @@ deciding what to build next and telling users what they get.
 ## Shipped
 
 ### Analysis and planning
+- **Resilience audit** — `dencer audit`: the never-evictable list read as an
+  availability report; the PDB that blocks a drain is the PDB a dying node
+  violates. Findings quote the analyzer's own explanations
 - **Upgrade preflight** — `dencer preflight`: will a node-pool rotation
   wedge, on which node, because of which pod, and why — answered before
   anything is touched, by the same analyzer that plans consolidations
@@ -34,6 +37,10 @@ deciding what to build next and telling users what they get.
   every drain, inside an explicit envelope (max nodes, impact ceiling), with
   three mutation-tested termination rails. Consent is to a policy, and both
   surfaces say so in those words
+- **Guarded drain** — `dencer drain <node>`: kubectl drain with the rails.
+  Rated with the same impact thresholds as a planned step (Red still needs a
+  window — naming the node is not a side-channel), per-eviction PDB checks
+  against fresh state, recovery verified, audited
 - **Off by default**, and the chart refuses to enable it without
   authentication and persistence
 - **Runs only the steps a human picked**, through the eviction API — the API
@@ -110,13 +117,6 @@ consolidation's.
    no kubelets, so the feature could not be verified here, and shipping an
    unverifiable feature is how confident wrong numbers happen. First
    verifiable on k3d with metrics-server or the GCP run.*
-5. **Resilience audit** — the analyzer's never-evictable list, re-sorted into
-   an availability risk report: zero-headroom PDBs, single replicas,
-   controller-less pods — the cluster's inability to survive a node loss,
-   named before the incident.
-6. **Guarded drain** — `dencer drain <node>`: the drain everyone does with
-   kubectl, but with the PDB pre-check, readiness verification and audit
-   trail the executor already has.
 7. **Cost awareness** — instance type and capacity type (spot/on-demand) in
    the model, so "better plan" can mean "cheaper estate", not "fewer nodes".
 8. **What-if simulation** — the planner against a modified snapshot: "can I

--- a/internal/api/rest/execute.go
+++ b/internal/api/rest/execute.go
@@ -319,3 +319,89 @@ func (s *Server) handleConverge(w http.ResponseWriter, r *http.Request) {
 		"dryRun": req.DryRun, "status": store.RunPending,
 	})
 }
+
+// drainRequest is the body of POST /api/v1/drain.
+type drainRequest struct {
+	Node   string `json:"node"`
+	DryRun bool   `json:"dryRun"`
+}
+
+// handleDrain queues a guarded drain of one named node — kubectl drain with
+// the rails. Same shape as every execution route: authorize, validate, write
+// a row; only the unreachable executor touches the cluster.
+func (s *Server) handleDrain(w http.ResponseWriter, r *http.Request) {
+	if s.runs == nil {
+		writeError(w, http.StatusNotImplemented,
+			"this deployment has no executor; install with executor.enabled=true")
+		return
+	}
+
+	var req drainRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<16)).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "request body is not valid JSON")
+		return
+	}
+	if req.Node == "" {
+		writeError(w, http.StatusBadRequest, "which node? a drain names exactly one")
+		return
+	}
+
+	// Validated against the latest snapshot so a typo fails here with a clear
+	// message, not in the executor with an audit row. The executor re-checks
+	// against live state regardless; this is courtesy, not the guard.
+	if rec, err := s.store.Latest(r.Context()); err == nil {
+		known := false
+		for _, n := range rec.Snapshot.Nodes {
+			if n.Name == req.Node {
+				known = true
+				break
+			}
+		}
+		if !known {
+			writeError(w, http.StatusBadRequest,
+				fmt.Sprintf("node %q is not in the latest snapshot", req.Node))
+			return
+		}
+	}
+
+	if active, err := s.runs.ActiveRun(r.Context()); err == nil {
+		writeJSON(w, http.StatusConflict, map[string]any{
+			"error": fmt.Sprintf("run %s is already %s", active.ID, active.Status),
+			"code":  "run_in_progress", "runId": active.ID, "status": active.Status,
+		})
+		return
+	} else if !errors.Is(err, store.ErrNotFound) {
+		s.fail(w, err)
+		return
+	}
+
+	actor := auth.Identity{Username: "auth-disabled", Source: auth.SourceAnonymous}
+	if id, ok := auth.IdentityFrom(r.Context()); ok {
+		actor = id
+	}
+
+	planID := ""
+	if rec, err := s.store.Latest(r.Context()); err == nil {
+		planID = rec.Plan.ID
+	}
+
+	runID, err := s.runs.Enqueue(r.Context(), store.Run{
+		PlanID: planID, Mode: store.RunModeDrain, Node: req.Node, DryRun: req.DryRun,
+		Actor: actor.Username, ActorGroups: actor.Groups,
+	})
+	if err != nil {
+		s.fail(w, err)
+		return
+	}
+
+	s.log.Info("drain requested", "run", runID, "node", req.Node,
+		"dryRun", req.DryRun, "actor", actor.Username)
+	s.events.Publish(Event{Type: "run", Data: map[string]any{
+		"runId": runID, "status": store.RunPending, "mode": store.RunModeDrain,
+		"node": req.Node, "dryRun": req.DryRun,
+	}})
+	writeJSON(w, http.StatusAccepted, map[string]any{
+		"runId": runID, "mode": store.RunModeDrain, "node": req.Node,
+		"dryRun": req.DryRun, "status": store.RunPending,
+	})
+}

--- a/internal/api/rest/resilience.go
+++ b/internal/api/rest/resilience.go
@@ -1,0 +1,74 @@
+package rest
+
+import (
+	"net/http"
+	"sort"
+)
+
+// The resilience audit: the analyzer's never-evictable list, re-sorted into
+// the question it also answers — can this cluster survive losing a node?
+//
+// A pod that cannot be evicted *voluntarily* is also a pod that handles an
+// involuntary node loss badly: the zero-headroom PDB that blocks a drain is
+// the same PDB that will be violated when the node dies, and the pod with no
+// controller that eviction would delete permanently is deleted just as
+// permanently by hardware. Consolidation and resilience are the same analysis
+// read in opposite moods, which is why this endpoint is a projection rather
+// than a feature.
+
+type resilienceFinding struct {
+	// Kind is the analyzer's constraint kind, e.g. PDB, Controller, Resources.
+	Kind string `json:"kind"`
+	Pod  string `json:"pod"`
+	Node string `json:"node,omitempty"`
+	// Explanation is the analyzer's canonical text, quoted not paraphrased.
+	Explanation string `json:"explanation"`
+}
+
+func (s *Server) handleResilience(w http.ResponseWriter, r *http.Request) {
+	rec, err := s.record(r.Context(), "latest")
+	if err != nil {
+		s.fail(w, err)
+		return
+	}
+
+	findings := []resilienceFinding{}
+	for _, pc := range rec.Analysis.Pods {
+		if pc.Movable {
+			continue
+		}
+		for _, c := range pc.Blockers() {
+			findings = append(findings, resilienceFinding{
+				Kind: string(c.Kind), Pod: pc.Key(), Node: pc.NodeName,
+				Explanation: c.Explanation,
+			})
+		}
+	}
+
+	// Zero-headroom PDBs are a finding even when their pods are movable on
+	// paper: zero headroom means any single disruption — voluntary or a node
+	// simply dying — violates the budget.
+	for _, pdb := range rec.Snapshot.PDBs {
+		if pdb.Blocks() {
+			findings = append(findings, resilienceFinding{
+				Kind: "PDBZeroHeadroom", Pod: pdb.Key(),
+				Explanation: "This PodDisruptionBudget allows zero disruptions right now. " +
+					"A node loss — voluntary or not — violates it immediately.",
+			})
+		}
+	}
+
+	sort.SliceStable(findings, func(i, j int) bool {
+		if findings[i].Kind != findings[j].Kind {
+			return findings[i].Kind < findings[j].Kind
+		}
+		return findings[i].Pod < findings[j].Pod
+	})
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"takenAt":  rec.Snapshot.TakenAt,
+		"planId":   rec.Plan.ID,
+		"findings": findings,
+		"pods":     len(rec.Analysis.Pods),
+	})
+}

--- a/internal/api/rest/rest.go
+++ b/internal/api/rest/rest.go
@@ -119,6 +119,7 @@ func (s *Server) Routes(mux *http.ServeMux) {
 	read("/api/v1/version", s.handleVersion)
 	read("/api/v1/reclamations", s.handleReclamations)
 	read("/api/v1/preflight", s.handlePreflight)
+	read("/api/v1/resilience", s.handleResilience)
 	read("/api/v1/plans", s.handleListPlans)
 	read("/api/v1/plans/latest", s.handleLatestPlan)
 	read("/api/v1/plans/{id}", s.handlePlan)
@@ -145,6 +146,9 @@ func (s *Server) Routes(mux *http.ServeMux) {
 	// Converge is consent to a policy rather than a list, but it is the same
 	// grant: the ability to have nodes drained. One permission, two shapes.
 	route("POST /api/v1/converge", auth.ExecuteConsolidations, s.handleConverge)
+	// A named drain is the same grant again: the ability to have nodes
+	// drained, in its third shape.
+	route("POST /api/v1/drain", auth.ExecuteConsolidations, s.handleDrain)
 }
 
 func (s *Server) handleAuthInfo(w http.ResponseWriter, _ *http.Request) {

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -259,3 +259,38 @@ func (c *Client) Preflight(ctx context.Context) (*PreflightEnvelope, error) {
 	}
 	return &out, nil
 }
+
+// ResilienceEnvelope is what GET /api/v1/resilience returns.
+type ResilienceEnvelope struct {
+	TakenAt  time.Time           `json:"takenAt"`
+	PlanID   string              `json:"planId"`
+	Findings []ResilienceFinding `json:"findings"`
+	Pods     int                 `json:"pods"`
+}
+
+type ResilienceFinding struct {
+	Kind        string `json:"kind"`
+	Pod         string `json:"pod"`
+	Node        string `json:"node,omitempty"`
+	Explanation string `json:"explanation"`
+}
+
+// Resilience reports what cannot survive a node loss, and why.
+func (c *Client) Resilience(ctx context.Context) (*ResilienceEnvelope, error) {
+	var out ResilienceEnvelope
+	if err := c.get(ctx, "/api/v1/resilience", &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// Drain queues a guarded drain of one named node.
+func (c *Client) Drain(ctx context.Context, node string, dryRun bool) (string, error) {
+	var out struct {
+		RunID string `json:"runId"`
+	}
+	if err := c.do(ctx, "POST", "/api/v1/drain", map[string]any{"node": node, "dryRun": dryRun}, &out); err != nil {
+		return "", err
+	}
+	return out.RunID, nil
+}

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -506,3 +506,32 @@ func PrintPreflight(w io.Writer, env *PreflightEnvelope) {
 	fmt.Fprintf(w, "\nA rotation will stall at %d node(s) unless the blockers above are resolved first.\n", blocked)
 	fmt.Fprintln(w, "State changes; re-run this immediately before upgrading.")
 }
+
+// PrintResilience renders the availability audit: what cannot survive a node
+// loss. The same analysis consolidation runs on, read in the opposite mood —
+// the PDB that blocks a voluntary drain is the PDB a dying node violates.
+func PrintResilience(w io.Writer, env *ResilienceEnvelope) {
+	if len(env.Findings) == 0 {
+		fmt.Fprintf(w, "%s\n", bold("No availability findings."))
+		fmt.Fprintf(w, "Every pod can be evicted and every PodDisruptionBudget has headroom (%d pods analysed).\n", env.Pods)
+		return
+	}
+
+	fmt.Fprintf(w, "%s  %s\n\n",
+		bold(fmt.Sprintf("%d availability finding(s)", len(env.Findings))),
+		dim(fmt.Sprintf("across %d pods, as of %s ago", env.Pods, humanDuration(time.Since(env.TakenAt)))))
+
+	kind := ""
+	for _, f := range env.Findings {
+		if f.Kind != kind {
+			kind = f.Kind
+			fmt.Fprintf(w, "%s\n", bold(kind))
+		}
+		where := f.Pod
+		if f.Node != "" {
+			where += dim(" on " + f.Node)
+		}
+		fmt.Fprintf(w, "  %s %s\n    %s\n", yellow("▲"), where, f.Explanation)
+	}
+	fmt.Fprintln(w, "\nEach finding names a pod a node loss would hurt — voluntarily drained or not.")
+}

--- a/internal/executor/drain_mode.go
+++ b/internal/executor/drain_mode.go
@@ -1,0 +1,90 @@
+package executor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/atedgimo/k8s-dencer/internal/constraints"
+	"github.com/atedgimo/k8s-dencer/internal/model"
+	"github.com/atedgimo/k8s-dencer/internal/safety"
+	"github.com/atedgimo/k8s-dencer/internal/store"
+)
+
+// drainNode performs a guarded drain of one operator-named node: kubectl
+// drain with the rails. The step is synthesized rather than taken from a
+// plan, because the operator chose the node — but it is synthesized honestly:
+// classified with the same impact thresholds as everything else, so a drain
+// that would move thirty pods is Red here exactly as it would be in a plan,
+// and Red still needs a maintenance window. Naming the node is not a
+// side-channel around the ratings.
+func (e *Executor) drainNode(ctx context.Context, run store.Run) {
+	if run.Node == "" {
+		e.fail(ctx, run, "drain run names no node")
+		return
+	}
+
+	e.event(ctx, run, store.RunEvent{
+		Action: "Claim", Node: run.Node,
+		Message: fmt.Sprintf("guarded drain of %s claimed by %s for %s%s",
+			run.Node, e.opts.Worker, run.Actor, dryRunSuffix(run.DryRun)),
+	})
+
+	live, err := e.cluster.Snapshot(ctx)
+	if err != nil {
+		e.fail(ctx, run, fmt.Sprintf("read cluster state: %v", err))
+		return
+	}
+	found := false
+	for _, n := range live.Nodes {
+		if n.Name == run.Node {
+			found = true
+			break
+		}
+	}
+	if !found {
+		e.fail(ctx, run, fmt.Sprintf("node %s does not exist", run.Node))
+		return
+	}
+
+	step := model.PlanStep{SequenceNumber: 1, TargetNode: run.Node}
+	// Rated like any planned step, against live state. The moves list is
+	// what the classifier weighs, so it is filled with what is actually
+	// there rather than left empty — an empty list would rate every drain
+	// Green regardless of what it moves.
+	for _, pod := range movablePodsOn(live, run.Node) {
+		step.Moves = append(step.Moves, model.Move{
+			Namespace: pod.Namespace, Pod: pod.Name, FromNode: run.Node,
+			CPUMilli: pod.Requests.MilliCPU, MemoryBytes: pod.Requests.MemoryBytes,
+		})
+	}
+	analysis := constraints.Analyze(live)
+	plan := &model.Plan{Steps: []model.PlanStep{step}}
+	e.opts.Classifier.ClassifyPlan(plan, live, analysis)
+	step = plan.Steps[0]
+
+	e.event(ctx, run, store.RunEvent{
+		Step: 1, Node: run.Node, Action: "Plan",
+		Message: fmt.Sprintf("drain of %s rated %s (%d movable pods)%s",
+			run.Node, step.Impact, len(step.Moves), dryRunSuffix(run.DryRun)),
+	})
+
+	state := safety.RunState{}
+	stepCtx, cancel := context.WithTimeout(ctx, e.opts.StepTimeout)
+	err = e.performStep(stepCtx, run, step, &state)
+	cancel()
+	if err != nil {
+		var blocked *safety.Blocked
+		if errors.As(err, &blocked) {
+			e.finish(ctx, run, store.RunBlocked, fmt.Sprintf(
+				"drain of %s stopped: %s", run.Node, blocked.Reason))
+			return
+		}
+		e.finish(ctx, run, store.RunFailed, fmt.Sprintf(
+			"drain of %s failed: %v", run.Node, err))
+		return
+	}
+
+	e.finish(ctx, run, store.RunSucceeded, fmt.Sprintf(
+		"drained %s%s", run.Node, dryRunSuffix(run.DryRun)))
+}

--- a/internal/executor/drain_mode_test.go
+++ b/internal/executor/drain_mode_test.go
@@ -1,0 +1,89 @@
+package executor_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/atedgimo/k8s-dencer/internal/impact"
+	"github.com/atedgimo/k8s-dencer/internal/model"
+	"github.com/atedgimo/k8s-dencer/internal/store"
+)
+
+func (h *harness) requestDrain(t *testing.T, node string, dryRun bool) store.Run {
+	t.Helper()
+	ctx := context.Background()
+	id, err := h.db.Enqueue(ctx, store.Run{
+		PlanID: h.planID, Mode: store.RunModeDrain, Node: node,
+		DryRun: dryRun, Actor: "alice@example.com",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := h.exec.Poll(ctx); err != nil {
+		t.Fatal(err)
+	}
+	run, err := h.db.RunByID(ctx, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return run
+}
+
+// The guarded drain is kubectl drain with the rails: cordon, per-eviction
+// guard checks, recovery verification — the full performStep chain, on a node
+// the operator named rather than a plan proposed.
+func TestGuardedDrainDrainsTheNamedNode(t *testing.T) {
+	snap := model.ClusterSnapshot{
+		Nodes: []model.Node{testNode("a"), testNode("b")},
+		Pods: []model.Pod{
+			testPod("shop", "web-1", "a", "web"),
+			testPod("shop", "web-2", "b", "web"),
+		},
+	}
+	h := newHarness(t, snap, nil, permissive())
+
+	run := h.requestDrain(t, "a", false)
+
+	if run.Status != store.RunSucceeded {
+		t.Fatalf("status = %s (%s), want Succeeded", run.Status, run.Summary)
+	}
+	calls := strings.Join(h.cluster.transcript(), " ")
+	if !strings.Contains(calls, "cordon:a") || !strings.Contains(calls, "evict:shop/web-1") {
+		t.Errorf("drain did not cordon and evict through the cluster interface: %v", h.cluster.transcript())
+	}
+}
+
+// A named drain must not be a side-channel around the impact ratings: a drain
+// the classifier rates Red needs a maintenance window like any planned step.
+func TestGuardedDrainIsRatedNotWavedThrough(t *testing.T) {
+	snap := model.ClusterSnapshot{
+		Nodes: []model.Node{testNode("a"), testNode("b")},
+		Pods: []model.Pod{
+			testPod("shop", "web-1", "a", "web"),
+			testPod("shop", "web-2", "b", "web"),
+		},
+	}
+	h := newHarness(t, snap, nil, permissive())
+	// Everything is Red at this threshold; no window is configured.
+	h.exec = h.rebuildWithClassifier(t, impact.New(impact.Thresholds{RedPodsMoved: 1}))
+
+	run := h.requestDrain(t, "a", false)
+
+	if run.Status != store.RunBlocked {
+		t.Fatalf("status = %s (%s), want Blocked — a named drain rated Red must need a window", run.Status, run.Summary)
+	}
+	for _, call := range h.cluster.transcript() {
+		if strings.HasPrefix(call, "evict:") {
+			t.Fatalf("a Red-rated drain evicted %q before being blocked", call)
+		}
+	}
+}
+
+func TestGuardedDrainRefusesAnUnknownNode(t *testing.T) {
+	h := newHarness(t, convergeSnapshot(), nil, permissive())
+	run := h.requestDrain(t, "no-such-node", false)
+	if run.Status != store.RunFailed {
+		t.Fatalf("status = %s, want Failed for an unknown node", run.Status)
+	}
+}

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -171,9 +171,12 @@ func (e *Executor) Poll(ctx context.Context) (bool, error) {
 
 	e.log.Info("claimed run", "run", run.ID, "plan", run.PlanID,
 		"steps", run.Steps, "mode", run.Mode, "dryRun", run.DryRun, "actor", run.Actor)
-	if run.Mode == store.RunModeConverge {
+	switch run.Mode {
+	case store.RunModeConverge:
 		e.converge(ctx, run)
-	} else {
+	case store.RunModeDrain:
+		e.drainNode(ctx, run)
+	default:
 		e.perform(ctx, run)
 	}
 	return true, nil

--- a/internal/store/execution.go
+++ b/internal/store/execution.go
@@ -49,6 +49,10 @@ type Run struct {
 	// worthwhile step remains.
 	Mode string `json:"mode,omitempty"`
 
+	// Node is the target of a drain run — one named node, guarded. Empty for
+	// every other mode.
+	Node string `json:"node,omitempty"`
+
 	// Envelope is the operator's consent, for converge runs. A steps run
 	// approves a concrete list of nodes; a converge run approves a *policy*,
 	// and the policy's bounds are recorded on the run so the audit trail
@@ -77,6 +81,11 @@ type Run struct {
 // classic steps run; a named constant for it would suggest other values are
 // equally ordinary, and they are not.
 const RunModeConverge = "converge"
+
+// RunModeDrain drains one operator-named node through the full guard chain —
+// kubectl drain with the rails: PDB pre-checks per eviction, readiness
+// verification, audit trail, abort-means-uncordon.
+const RunModeDrain = "drain"
 
 // Envelope bounds a converge run. Both fields are the operator's explicit
 // choice — there are no defaults here, because a defaulted consent is not

--- a/internal/store/sqlite/execution.go
+++ b/internal/store/sqlite/execution.go
@@ -43,11 +43,11 @@ func (s *Store) Enqueue(ctx context.Context, run store.Run) (string, error) {
 	}
 
 	_, err = s.db.ExecContext(ctx, `
-		INSERT INTO runs (id, plan_id, steps, dry_run, status, actor, actor_groups, requested_at, mode, envelope)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		INSERT INTO runs (id, plan_id, steps, dry_run, status, actor, actor_groups, requested_at, mode, envelope, node)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		run.ID, run.PlanID, steps, boolToInt(run.DryRun), string(run.Status),
 		run.Actor, groups, run.RequestedAt.UTC().Format(time.RFC3339Nano),
-		run.Mode, envelope)
+		run.Mode, envelope, run.Node)
 	if err != nil {
 		return "", fmt.Errorf("enqueue run: %w", err)
 	}
@@ -132,7 +132,7 @@ func (s *Store) Finish(ctx context.Context, runID string, status store.RunStatus
 func (s *Store) RunByID(ctx context.Context, runID string) (store.Run, error) {
 	row := s.db.QueryRowContext(ctx, `
 		SELECT id, plan_id, steps, dry_run, status, actor, actor_groups,
-		       requested_at, started_at, finished_at, worker, summary, mode, envelope
+		       requested_at, started_at, finished_at, worker, summary, mode, envelope, node
 		FROM runs WHERE id = ?`, runID)
 	return scanRun(row)
 }
@@ -141,7 +141,7 @@ func (s *Store) RunByID(ctx context.Context, runID string) (store.Run, error) {
 func (s *Store) ActiveRun(ctx context.Context) (store.Run, error) {
 	row := s.db.QueryRowContext(ctx, `
 		SELECT id, plan_id, steps, dry_run, status, actor, actor_groups,
-		       requested_at, started_at, finished_at, worker, summary, mode, envelope
+		       requested_at, started_at, finished_at, worker, summary, mode, envelope, node
 		FROM runs WHERE status IN (?, ?)
 		ORDER BY requested_at LIMIT 1`,
 		string(store.RunPending), string(store.RunRunning))
@@ -155,7 +155,7 @@ func (s *Store) RunsForPlan(ctx context.Context, planID string, limit int) ([]st
 	}
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT id, plan_id, steps, dry_run, status, actor, actor_groups,
-		       requested_at, started_at, finished_at, worker, summary, mode, envelope
+		       requested_at, started_at, finished_at, worker, summary, mode, envelope, node
 		FROM runs WHERE plan_id = ? ORDER BY requested_at DESC, rowid DESC LIMIT ?`,
 		planID, limit)
 	if err != nil {
@@ -215,7 +215,7 @@ func scanRun(row scanner) (store.Run, error) {
 		worker, summary       sql.NullString
 	)
 	err := row.Scan(&run.ID, &run.PlanID, &steps, &dryRun, &status, &run.Actor, &groups,
-		&requestedAt, &startedAt, &finishedAt, &worker, &summary, &run.Mode, &envelope)
+		&requestedAt, &startedAt, &finishedAt, &worker, &summary, &run.Mode, &envelope, &run.Node)
 	if errors.Is(err, sql.ErrNoRows) {
 		return store.Run{}, store.ErrNotFound
 	}

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -56,7 +56,7 @@ func Open(path string) (*Store, error) {
 // Close releases the database handle.
 func (s *Store) Close() error { return s.db.Close() }
 
-const schemaVersion = 5
+const schemaVersion = 6
 
 // Migrate creates or upgrades the schema.
 func (s *Store) Migrate(ctx context.Context) error {
@@ -97,6 +97,11 @@ func (s *Store) Migrate(ctx context.Context) error {
 	if current < 5 {
 		if _, err := tx.ExecContext(ctx, schemaV5); err != nil {
 			return fmt.Errorf("apply schema v5: %w", err)
+		}
+	}
+	if current < 6 {
+		if _, err := tx.ExecContext(ctx, schemaV6); err != nil {
+			return fmt.Errorf("apply schema v6: %w", err)
 		}
 	}
 
@@ -230,6 +235,11 @@ ALTER TABLE runs ADD COLUMN envelope BLOB;
 const schemaV5 = `
 ALTER TABLE reclamations ADD COLUMN cpu_milli INTEGER NOT NULL DEFAULT 0;
 ALTER TABLE reclamations ADD COLUMN mem_bytes INTEGER NOT NULL DEFAULT 0;
+`
+
+// Schema v6 — guarded drain: a run can target one named node.
+const schemaV6 = `
+ALTER TABLE runs ADD COLUMN node TEXT NOT NULL DEFAULT '';
 `
 
 // Save persists a record unless it duplicates the latest plan.


### PR DESCRIPTION
Value items #4 and #5 from the agreed roadmap, both projections of machinery that already exists.

## `dencer audit` — what cannot survive a node loss

The consolidation analysis read in the opposite mood: the zero-headroom PDB that blocks a voluntary drain is the same PDB a dying node violates; the controller-less pod that eviction would delete is deleted just as permanently by hardware. Findings quote the analyzer's canonical explanations, so the audit **cannot disagree** with the plan beside it.

## `dencer drain <node>` — kubectl drain, with the rails

The property that matters: **a named drain is not a side-channel around the ratings.** The synthesized step carries the node's actual movable pods and is classified with the same thresholds as any planned step — a Red-rated drain is Blocked without a window, pinned by a test that would have silently passed if the moves list were left empty (an empty list rates Green regardless).

Full `performStep` chain: cordon, per-eviction PDB checks against fresh state, readiness-based recovery verification, abort-means-uncordon, audit trail. Run mode `drain` with the target on the run row (schema v6).

All 19 packages green, chart contract green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)