### PR TITLE
Reclaimer evidence, three-valued: proof, promise, or honestly unknown

### DIFF
--- a/docs/product-roadmap.md
+++ b/docs/product-roadmap.md
@@ -57,6 +57,11 @@ deciding what to build next and telling users what they get.
   `pods/eviction` leaks to any other role
 
 ### Observing reality (not just predicting it)
+- **Reclaimer evidence, three-valued** — a recorded removal is proof, a
+  visible autoscaler pod is a promise, and neither is *not* "no reclaimer"
+  (managed control planes hide theirs). When drains are pending and there is
+  no evidence at all, the tray and `dencer reclamations` say so: drained
+  nodes are pure cost until something removes them
 - **Savings ledger** — capacity *actually returned*, measured: the executor
   captures each node's allocatable at drain time (the last moment it can be),
   and the summary sums it over nodes that genuinely disappeared. Pre-ledger
@@ -126,9 +131,6 @@ consolidation's.
 8. **What-if simulation** — the planner against a modified snapshot: "can I
    lose zone B? can this workload fit?" Capacity planning as a question, not
    a spreadsheet.
-9. **Reclaimer detection** — warn *before* draining when no autoscaler or
-   Karpenter is present to remove the emptied node (drained-but-not-removed
-   is pure cost).
 
 
 ## Explicitly not planned

--- a/internal/api/rest/reclamations.go
+++ b/internal/api/rest/reclamations.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/atedgimo/k8s-dencer/internal/reclaim"
 	"github.com/atedgimo/k8s-dencer/internal/store"
 )
 
@@ -45,12 +46,32 @@ func (s *Server) handleReclamations(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Whether anything here removes drained nodes — three-valued, honestly.
+	// A recorded removal is proof (measured, the strongest evidence there
+	// is). A visible autoscaler pod is a promise. Neither is NOT "no
+	// reclaimer": managed control planes run theirs where no pod scan can
+	// see them, which M23 demonstrated by watching GKE remove a node while
+	// nothing in the cluster admitted to being an autoscaler.
+	everStats, err := tracker.ReclamationSummary(ctx, time.Time{})
+	if err != nil {
+		s.fail(w, err)
+		return
+	}
+	detected := ""
+	if rec, err := s.store.Latest(ctx); err == nil {
+		detected, _ = reclaim.DetectReclaimer(rec.Snapshot)
+	}
+
 	// Seconds rather than the Go duration's nanoseconds: every consumer here
 	// is JavaScript or jq, and 180000000000 is not a number anyone reads.
 	writeJSON(w, http.StatusOK, map[string]any{
 		"tracking": true,
 		"awaiting": pending,
 		"recent":   recent,
+		"reclaimer": map[string]any{
+			"observedWorking": everStats.Reclaimed > 0,
+			"detected":        detected,
+		},
 		"stats": map[string]any{
 			"awaiting":                 stats.Awaiting,
 			"reclaimed":                stats.Reclaimed,

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -187,7 +187,11 @@ func min(a, b int) int {
 
 // ReclamationsEnvelope is what GET /api/v1/reclamations returns.
 type ReclamationsEnvelope struct {
-	Tracking bool                `json:"tracking"`
+	Tracking  bool `json:"tracking"`
+	Reclaimer *struct {
+		ObservedWorking bool   `json:"observedWorking"`
+		Detected        string `json:"detected"`
+	} `json:"reclaimer,omitempty"`
 	Awaiting []store.Reclamation `json:"awaiting"`
 	Recent   []store.Reclamation `json:"recent"`
 	Stats    ReclamationStats    `json:"stats"`

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -408,6 +408,18 @@ func PrintReclamations(w io.Writer, env *ReclamationsEnvelope) {
 		fmt.Fprintln(w)
 	}
 
+	if r := env.Reclaimer; r != nil && !r.ObservedWorking {
+		if r.Detected != "" {
+			fmt.Fprintf(w, "%s %s is present but has never been observed removing a node here.\n\n",
+				yellow("▲"), r.Detected)
+		} else {
+			fmt.Fprintf(w, "%s No node removal has ever been observed here, and no autoscaler is visible.\n", yellow("▲"))
+			fmt.Fprintln(w, "  (A managed control plane's autoscaler would be invisible to this check.)")
+			fmt.Fprintln(w, "  Until something removes them, drained nodes stay allocated — and billed.")
+			fmt.Fprintln(w)
+		}
+	}
+
 	fmt.Fprintf(w, "%s (last %d days)\n", bold("Observed"), s.WindowDays)
 	fmt.Fprintf(w, "  %s reclaimed", green(fmt.Sprintf("%d", s.Reclaimed)))
 	if s.Reclaimed > 0 && s.MedianReclamationSeconds > 0 {

--- a/internal/reclaim/detect.go
+++ b/internal/reclaim/detect.go
@@ -1,0 +1,34 @@
+package reclaim
+
+import (
+	"strings"
+
+	"github.com/atedgimo/k8s-dencer/internal/model"
+)
+
+// DetectReclaimer reports whether a known node-removing component is visible
+// in the snapshot, and which one.
+//
+// The limits are the point, so they are stated here rather than discovered:
+// this can only see reclaimers that run AS PODS in the cluster. GKE's
+// cluster autoscaler runs on the managed control plane and is invisible to
+// this scan — M23 watched it remove a node while nothing here could have
+// detected it. Absence is therefore evidence of nothing. The trustworthy
+// signal is the reclamation tracker's own history: a recorded removal proves
+// a reclaimer works here, whatever this function says. Detection exists for
+// the opposite case — warning BEFORE the first drain, when there is no
+// history to consult yet.
+func DetectReclaimer(snap *model.ClusterSnapshot) (string, bool) {
+	for _, p := range snap.Pods {
+		name := p.Labels["app.kubernetes.io/name"]
+		switch {
+		case name == "karpenter" || strings.HasPrefix(p.Name, "karpenter-"):
+			return "Karpenter", true
+		case name == "cluster-autoscaler" ||
+			p.Labels["app"] == "cluster-autoscaler" ||
+			strings.HasPrefix(p.Name, "cluster-autoscaler-"):
+			return "cluster-autoscaler", true
+		}
+	}
+	return "", false
+}

--- a/internal/reclaim/detect_test.go
+++ b/internal/reclaim/detect_test.go
@@ -1,0 +1,36 @@
+package reclaim_test
+
+import (
+	"testing"
+
+	"github.com/atedgimo/k8s-dencer/internal/model"
+	"github.com/atedgimo/k8s-dencer/internal/reclaim"
+)
+
+func TestDetectReclaimerSeesInClusterAutoscalers(t *testing.T) {
+	cases := []struct {
+		name string
+		pod  model.Pod
+		want string
+	}{
+		{"karpenter by label", model.Pod{Name: "x", Labels: map[string]string{"app.kubernetes.io/name": "karpenter"}}, "Karpenter"},
+		{"karpenter by name", model.Pod{Name: "karpenter-7d9f-abc"}, "Karpenter"},
+		{"CA by label", model.Pod{Name: "y", Labels: map[string]string{"app": "cluster-autoscaler"}}, "cluster-autoscaler"},
+		{"CA by name", model.Pod{Name: "cluster-autoscaler-6c-xyz"}, "cluster-autoscaler"},
+	}
+	for _, c := range cases {
+		got, ok := reclaim.DetectReclaimer(&model.ClusterSnapshot{Pods: []model.Pod{c.pod}})
+		if !ok || got != c.want {
+			t.Errorf("%s: got (%q,%v), want (%q,true)", c.name, got, ok, c.want)
+		}
+	}
+}
+
+// Absence must read as "none visible", never "none exists": managed control
+// planes run their autoscalers where no pod scan can see them.
+func TestDetectReclaimerAbsenceIsNotEvidence(t *testing.T) {
+	snap := &model.ClusterSnapshot{Pods: []model.Pod{{Name: "web-1"}}}
+	if name, ok := reclaim.DetectReclaimer(snap); ok {
+		t.Errorf("detected %q in a cluster with no autoscaler pods", name)
+	}
+}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -251,6 +251,7 @@ export default function App() {
               reclaimedForReal={reclamations.stats.reclaimed}
               ledgerCpuMilli={reclamations.stats.reclaimedCpuMilli}
               ledgerMemBytes={reclamations.stats.reclaimedMemBytes}
+              noReclaimerEvidence={reclamations.noReclaimerEvidence}
               observed={observed.nodes}
               evictedPods={observed.evictedPods}
               graph={state.graph}

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -277,6 +277,13 @@ export interface Reclamation {
 
 export interface ReclamationsResponse {
   tracking: boolean;
+  /**
+   * Whether anything here removes drained nodes. observedWorking is proof —
+   * a recorded removal; detected is a promise — an autoscaler pod is
+   * visible. Neither being true is NOT "no reclaimer": managed control
+   * planes run theirs out of sight.
+   */
+  reclaimer?: { observedWorking: boolean; detected: string };
   awaiting: Reclamation[];
   recent: Reclamation[];
   stats: {

--- a/ui/src/components/PackingField.tsx
+++ b/ui/src/components/PackingField.tsx
@@ -73,6 +73,8 @@ interface Props {
   /** The ledger: measured capacity those reclaimed nodes actually returned. */
   ledgerCpuMilli?: number;
   ledgerMemBytes?: number;
+  /** No removal ever recorded and no autoscaler visible; see useReclamations. */
+  noReclaimerEvidence?: boolean;
   /**
    * Per-node observed facts from outside the plan's snapshot: the reclamation
    * tracker and a run's own event trail. Merged over the snapshot here, once,
@@ -98,6 +100,7 @@ export default function PackingField({
   reclaimedForReal = 0,
   ledgerCpuMilli = 0,
   ledgerMemBytes = 0,
+  noReclaimerEvidence = false,
   observed,
   evictedPods,
 }: Props) {
@@ -263,6 +266,7 @@ export default function PackingField({
           reclaimedForReal={reclaimedForReal}
           ledgerCpuMilli={ledgerCpuMilli}
           ledgerMemBytes={ledgerMemBytes}
+          noReclaimerEvidence={noReclaimerEvidence}
         />
       </div>
     );
@@ -439,6 +443,7 @@ export default function PackingField({
         reclaimedForReal={reclaimedForReal}
         ledgerCpuMilli={ledgerCpuMilli}
         ledgerMemBytes={ledgerMemBytes}
+        noReclaimerEvidence={noReclaimerEvidence}
       />
     </div>
   );
@@ -461,6 +466,7 @@ function ReclaimedTray({
   reclaimedForReal,
   ledgerCpuMilli,
   ledgerMemBytes,
+  noReclaimerEvidence,
 }: {
   count: number;
   total: number;
@@ -468,6 +474,7 @@ function ReclaimedTray({
   reclaimedForReal: number;
   ledgerCpuMilli: number;
   ledgerMemBytes: number;
+  noReclaimerEvidence: boolean;
 }) {
   return (
     <div className="tray" aria-live="polite">
@@ -494,6 +501,15 @@ function ReclaimedTray({
               · {formatCPU(ledgerCpuMilli)} cores · {formatBytes(ledgerMemBytes)} returned
             </span>
           )}
+        </span>
+      )}
+      {/* Worth saying only when it costs money: drains are pending and
+          nothing is known to remove nodes here. Worded as absence of
+          evidence, because that is all a pod scan can establish — managed
+          control planes run their autoscalers out of sight. */}
+      {noReclaimerEvidence && awaiting > 0 && (
+        <span className="tray-warning mono" title="No node removal has ever been observed here and no autoscaler is visible in the cluster. Drained nodes stay allocated — and billed — until something removes them.">
+          no reclaimer seen — drained nodes are pure cost
         </span>
       )}
       {awaiting > 0 && (

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -2261,3 +2261,15 @@
   flex-shrink: 0;
   opacity: 0.9;
 }
+
+/* Absence-of-reclaimer warning: a word, not a colour — it is a fact about
+   the cluster's tooling, not a risk rating. */
+.tray-warning {
+  color: var(--text-primary);
+  font-size: var(--text-2xs);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  border: 1px dashed var(--border-strong);
+  border-radius: var(--radius-sm);
+  padding: 0 var(--space-2);
+}

--- a/ui/src/useReclamations.ts
+++ b/ui/src/useReclamations.ts
@@ -3,6 +3,9 @@ import { api, Reclamation } from "./api";
 
 export interface ReclamationState {
   awaiting: Reclamation[];
+  /** No removal ever recorded AND no autoscaler visible — drained nodes may
+   *  sit as pure cost. Absence of evidence, clearly labelled as only that. */
+  noReclaimerEvidence: boolean;
   recent: Reclamation[];
   /** The server's own tallies, for the tray. The recent list is windowed;
    *  recounting it client-side would drift from what the server reports. */
@@ -17,6 +20,7 @@ export interface ReclamationState {
 
 const EMPTY: ReclamationState = {
   awaiting: [],
+  noReclaimerEvidence: false,
   recent: [],
   stats: { awaiting: 0, reclaimed: 0, reclaimedCpuMilli: 0, reclaimedMemBytes: 0 },
 };
@@ -42,6 +46,8 @@ export function useReclamations(): ReclamationState {
         if (!cancelled && r.tracking) {
           setState({
             awaiting: r.awaiting ?? [],
+            noReclaimerEvidence:
+              r.reclaimer != null && !r.reclaimer.observedWorking && !r.reclaimer.detected,
             recent: r.recent ?? [],
             stats: {
               awaiting: r.stats.awaiting,


### PR DESCRIPTION
The last unstarted value item — and the naive version would have shipped a lie: on GKE, M23 watched the autoscaler remove a node while **nothing in the cluster admitted to being one**. Managed control planes hide their reclaimers from any pod scan, so absence of a pod is evidence of nothing.

The signal is three-valued, ranked by evidential weight:

| Level | Meaning | Source |
|---|---|---|
| **proof** | a removal has been recorded here | the reclamation tracker — a measurement this product already makes |
| **promise** | an autoscaler pod is visible (Karpenter / CA) | label+name scan, pure function over the snapshot, zero new RBAC |
| **unknown** | neither — worded as *absence of evidence*, never "no reclaimer" | with the managed-control-plane caveat stated |

The warning surfaces only when it costs money: drains pending, no evidence at all — tray: *"no reclaimer seen — drained nodes are pure cost"*; `dencer reclamations` spells out the caveat. A word and a dashed border, not a colour: tooling fact, not risk rating.

All 19 packages green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)