### PR TITLE
Cost awareness, first slice: what the machines are, said everywhere

### DIFF
--- a/docs/product-roadmap.md
+++ b/docs/product-roadmap.md
@@ -117,8 +117,12 @@ consolidation's.
    no kubelets, so the feature could not be verified here, and shipping an
    unverifiable feature is how confident wrong numbers happen. First
    verifiable on k3d with metrics-server or the GCP run.*
-7. **Cost awareness** — instance type and capacity type (spot/on-demand) in
-   the model, so "better plan" can mean "cheaper estate", not "fewer nodes".
+7. **Cost awareness, remaining slices** — pricing and a cost-aware planner
+   objective. The facts shipped first: instance type and capacity type are on
+   every node (Inspector), and the plan states how its reclaimable nodes are
+   bought — "7 spot, 4 on-demand" — with unpriced nodes omitted rather than
+   invented. Turning "fewer nodes" into "cheaper estate" as the *objective*
+   is the remaining, deliberately separate, step.
 8. **What-if simulation** — the planner against a modified snapshot: "can I
    lose zone B? can this workload fit?" Capacity planning as a question, not
    a spreadsheet.

--- a/internal/api/graph/graph.go
+++ b/internal/api/graph/graph.go
@@ -74,6 +74,8 @@ type Data struct {
 
 	// Node fields.
 	Zone           string `json:"zone,omitempty"`
+	InstanceType   string `json:"instanceType,omitempty"`
+	CapacityType   string `json:"capacityType,omitempty"`
 	Ready          bool   `json:"ready,omitempty"`
 	Cordoned       bool   `json:"cordoned,omitempty"`
 	CPUAllocatable int64  `json:"cpuAllocatable,omitempty"`
@@ -190,6 +192,8 @@ func BuildWith(plan *model.Plan, snap *model.ClusterSnapshot, analysis *constrai
 				Kind:           "node",
 				Label:          n.Name,
 				Zone:           n.Zone(),
+				InstanceType:   n.InstanceType(),
+				CapacityType:   n.CapacityType(),
 				Ready:          n.Ready,
 				Cordoned:       n.Unschedulable,
 				CPUAllocatable: n.Allocatable.MilliCPU,

--- a/internal/api/rest/rest.go
+++ b/internal/api/rest/rest.go
@@ -345,14 +345,32 @@ func planResponse(rec store.Record) map[string]any {
 	// The same figure the UI's verdict shows, so the CLI does not state a
 	// bare node count the web page qualifies.
 	cpu, mem := model.ReclaimableCapacity(rec.Plan, rec.Snapshot)
+
+	// How the reclaimable nodes are bought, when the platform says. Spot
+	// nodes reclaimed and on-demand nodes reclaimed are different amounts of
+	// money, and the count alone hides that. Unpriced nodes (fixtures, bare
+	// metal) are omitted rather than invented.
+	byCapacity := map[string]int{}
+	byName := make(map[string]model.Node, len(rec.Snapshot.Nodes))
+	for _, n := range rec.Snapshot.Nodes {
+		byName[n.Name] = n
+	}
+	for _, step := range rec.Plan.Steps {
+		if n, ok := byName[step.TargetNode]; ok {
+			if ct := n.CapacityType(); ct != "" {
+				byCapacity[ct]++
+			}
+		}
+	}
 	return map[string]any{
-		"plan":                rec.Plan,
-		"strategy":            rec.Strategy,
-		"storedAt":            rec.StoredAt,
-		"ratings":             rec.Plan.CountByRating(),
-		"cpuReclaimableMilli": cpu,
-		"memReclaimableBytes": mem,
-		"readOnly":            true,
+		"plan":                  rec.Plan,
+		"strategy":              rec.Strategy,
+		"storedAt":              rec.StoredAt,
+		"ratings":               rec.Plan.CountByRating(),
+		"cpuReclaimableMilli":   cpu,
+		"memReclaimableBytes":   mem,
+		"reclaimableByCapacity": byCapacity,
+		"readOnly":              true,
 	}
 }
 

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -24,6 +24,8 @@ type PlanEnvelope struct {
 	// disagree about it.
 	CPUReclaimableMilli int64 `json:"cpuReclaimableMilli"`
 	MemReclaimableBytes int64 `json:"memReclaimableBytes"`
+	// How the reclaimable nodes are bought, when the platform says.
+	ReclaimableByCapacity map[string]int `json:"reclaimableByCapacity,omitempty"`
 }
 
 type RunEnvelope struct {

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -115,8 +115,12 @@ func reclaimSummary(env *PlanEnvelope) string {
 	if env.CPUReclaimableMilli <= 0 {
 		return fmt.Sprintf("%d reclaimable", n)
 	}
-	return fmt.Sprintf("%d reclaimable (%s cores, %s)",
+	out := fmt.Sprintf("%d reclaimable (%s cores, %s",
 		n, formatMilli(env.CPUReclaimableMilli), formatBytes(env.MemReclaimableBytes))
+	if spot, od := env.ReclaimableByCapacity["spot"], env.ReclaimableByCapacity["on-demand"]; spot > 0 || od > 0 {
+		out += fmt.Sprintf("; %d spot, %d on-demand", spot, od)
+	}
+	return out + ")"
 }
 
 // PrintPlan renders a plan as a table.

--- a/internal/model/cluster.go
+++ b/internal/model/cluster.go
@@ -46,6 +46,35 @@ type Node struct {
 // Zone returns the node's failure domain, or "" if unlabelled.
 func (n Node) Zone() string { return n.Labels[LabelZone] }
 
+// InstanceType returns the machine shape, from the standard well-known label.
+// Empty when the platform does not set it (KWOK fixtures, bare metal).
+func (n Node) InstanceType() string { return n.Labels["node.kubernetes.io/instance-type"] }
+
+// CapacityType reports how the node is bought: "spot" when any of the
+// platforms' spot/preemptible markers is present, "on-demand" when the
+// platform is recognisably present without one, and "" when nothing can be
+// said. Three-valued for the usual reason — a KWOK node is not "on-demand",
+// it is unpriced, and pretending otherwise would put a made-up word in a
+// cost report.
+func (n Node) CapacityType() string {
+	switch {
+	case n.Labels["karpenter.sh/capacity-type"] == "spot",
+		n.Labels["cloud.google.com/gke-spot"] == "true",
+		n.Labels["cloud.google.com/gke-preemptible"] == "true",
+		n.Labels["eks.amazonaws.com/capacityType"] == "SPOT",
+		n.Labels["kubernetes.azure.com/scalesetpriority"] == "spot":
+		return "spot"
+	case n.Labels["karpenter.sh/capacity-type"] != "",
+		n.Labels["eks.amazonaws.com/capacityType"] != "":
+		return "on-demand"
+	case n.InstanceType() != "":
+		// A cloud set the instance type; absent any spot marker, on-demand is
+		// what remains.
+		return "on-demand"
+	}
+	return ""
+}
+
 // Well-known label keys the planner reads directly.
 const (
 	LabelZone     = "topology.kubernetes.io/zone"

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -268,3 +268,29 @@ func TestSnapshotAggregation(t *testing.T) {
 		t.Errorf("PodsOnNode = %d, want 3 (unfiltered)", got)
 	}
 }
+
+// CapacityType is three-valued on purpose: a KWOK node is not "on-demand",
+// it is unpriced, and a made-up word in a cost report poisons the report.
+func TestCapacityTypeIsThreeValued(t *testing.T) {
+	cases := []struct {
+		name   string
+		labels map[string]string
+		want   string
+	}{
+		{"karpenter spot", map[string]string{"karpenter.sh/capacity-type": "spot"}, "spot"},
+		{"gke spot", map[string]string{"cloud.google.com/gke-spot": "true"}, "spot"},
+		{"gke preemptible", map[string]string{"cloud.google.com/gke-preemptible": "true"}, "spot"},
+		{"eks spot", map[string]string{"eks.amazonaws.com/capacityType": "SPOT"}, "spot"},
+		{"aks spot", map[string]string{"kubernetes.azure.com/scalesetpriority": "spot"}, "spot"},
+		{"karpenter on-demand", map[string]string{"karpenter.sh/capacity-type": "on-demand"}, "on-demand"},
+		{"cloud with instance type only", map[string]string{"node.kubernetes.io/instance-type": "n2-standard-8"}, "on-demand"},
+		{"nothing known", map[string]string{}, ""},
+		{"kwok fixture", map[string]string{"topology.kubernetes.io/zone": "z1"}, ""},
+	}
+	for _, c := range cases {
+		n := model.Node{Labels: c.labels}
+		if got := n.CapacityType(); got != c.want {
+			t.Errorf("%s: CapacityType() = %q, want %q", c.name, got, c.want)
+		}
+	}
+}

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -65,6 +65,8 @@ export interface GraphData {
   label: string;
 
   zone?: string;
+  instanceType?: string;
+  capacityType?: string;
   ready?: boolean;
   cordoned?: boolean;
   cpuAllocatable?: number;

--- a/ui/src/components/Inspector.tsx
+++ b/ui/src/components/Inspector.tsx
@@ -194,6 +194,17 @@ function NodePanel({
       <dl className="facts">
         <dt>Zone</dt>
         <dd>{node.zone || "—"}</dd>
+        {/* The machine, priced in kind if not in money. Absent on fixtures
+            and bare metal — shown only when the platform actually said. */}
+        {node.instanceType && (
+          <>
+            <dt>Machine</dt>
+            <dd>
+              {node.instanceType}
+              {node.capacityType && <span className="mono"> · {node.capacityType}</span>}
+            </dd>
+          </>
+        )}
         <dt>CPU</dt>
         <dd>
           {formatCPU(node.cpuRequested ?? 0)} / {formatCPU(node.cpuAllocatable ?? 0)} cores (


### PR DESCRIPTION
The facts before the objective. The model now knows, in kind if not yet in money:

- **InstanceType** — the standard label, empty when no platform set it
- **CapacityType** — three-valued *on purpose*: `spot` (Karpenter / GKE spot+preemptible / EKS / AKS markers), `on-demand` (cloud present, no spot marker), and `""` for KWOK/bare-metal — which is not "on-demand", it is **unpriced**, and a made-up word poisons a cost report. Table-tested across all nine cases.

Surfaced where decisions happen: Inspector shows the machine per node; the plan envelope and `dencer plan` state how the reclaimable nodes are bought — *"11 reclaimable (88 cores, 352 GiB; **7 spot, 4 on-demand**)"* — seven spot and seven on-demand reclaimed are different money wearing the same count.

The planner's **objective is deliberately unchanged**; making "cheaper estate" the optimisation target is its own step with its own plan-stability questions, and the roadmap now says exactly that.

All 19 packages green; payload contract test enforces the new fields' readers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)