### PR TITLE
What-if: the loss question, answered by the engine instead of a spreadsheet

### DIFF
--- a/cmd/dencer/main.go
+++ b/cmd/dencer/main.go
@@ -41,6 +41,7 @@ Commands:
   reclamations          what actually became of the nodes you drained
   preflight             will every node drain? run before a node-pool rotation
   audit                 what cannot survive a node loss, and why
+  whatif                simulate losing nodes or a zone: does everything still fit?
   drain <node>          guarded drain of one node: the rails, not bare kubectl
   version
 
@@ -118,6 +119,8 @@ func run() error {
 		return cmdPreflight(ctx, os.Args[2:])
 	case "audit", "resilience":
 		return cmdAudit(ctx, os.Args[2:])
+	case "whatif":
+		return cmdWhatif(ctx, os.Args[2:])
 	case "drain":
 		return cmdDrain(ctx, os.Args[2:])
 	case "reclamations", "reclaim":
@@ -332,6 +335,50 @@ func cmdConverge(ctx context.Context, args []string) error {
 	default:
 		return fmt.Errorf("run %s: %s", final.Status, final.Summary)
 	}
+}
+
+func cmdWhatif(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("whatif", flag.ExitOnError)
+	g := bind(fs)
+	nodes := fs.String("without-nodes", "", "comma-separated nodes to simulate losing")
+	zone := fs.String("without-zone", "", "topology zone to simulate losing")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *nodes == "" && *zone == "" {
+		return errors.New("remove something: --without-nodes a,b or --without-zone z")
+	}
+	c, err := connect(ctx, g)
+	if err != nil {
+		return err
+	}
+	defer c.Close()
+
+	env, err := c.Whatif(ctx, splitCommas(*nodes), *zone)
+	if err != nil {
+		return err
+	}
+	if g.format != cli.FormatText {
+		return cli.Encode(os.Stdout, g.format, env)
+	}
+	cli.PrintWhatif(os.Stdout, env)
+	if !env.Fits {
+		return errors.New("the simulated cluster cannot hold its workloads")
+	}
+	return nil
+}
+
+func splitCommas(s string) []string {
+	if strings.TrimSpace(s) == "" {
+		return nil
+	}
+	var out []string
+	for _, p := range strings.Split(s, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
 }
 
 func cmdAudit(ctx context.Context, args []string) error {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -199,3 +199,18 @@ the same impact thresholds as a planned step** (a Red drain needs a
 maintenance window — naming the node is not a side-channel), every eviction
 passes the PDB pre-check against fresh state, recovery is verified on
 readiness, aborting uncordons, and the whole thing lands in the audit trail.
+
+## `dencer whatif` — can I lose this?
+
+```
+dencer whatif --without-zone eu-west-1b
+dencer whatif --without-nodes worker-3,worker-4
+```
+
+The question capacity planning answers with a spreadsheet, answered instead by
+the same constraint engine that plans consolidations: the latest snapshot
+minus the removed nodes, every displaced pod re-homed by the analyzer, and the
+ones with **nowhere legal to go named, with reasons**. Exit status is non-zero
+when the simulated cluster cannot hold its workloads, so it works as a CI
+gate. A fit is the engine's answer, not a promise about the scheduler on the
+day — and the report says so.

--- a/docs/product-roadmap.md
+++ b/docs/product-roadmap.md
@@ -10,6 +10,10 @@ deciding what to build next and telling users what they get.
 ## Shipped
 
 ### Analysis and planning
+- **What-if simulation** — `dencer whatif --without-zone b`: the latest
+  snapshot minus the removed nodes, every displaced pod re-homed by the
+  constraint engine, the homeless ones named with reasons. Non-zero exit when
+  it does not fit, so it gates CI
 - **Resilience audit** — `dencer audit`: the never-evictable list read as an
   availability report; the PDB that blocks a drain is the PDB a dying node
   violates. Findings quote the analyzer's own explanations
@@ -128,9 +132,6 @@ consolidation's.
    bought — "7 spot, 4 on-demand" — with unpriced nodes omitted rather than
    invented. Turning "fewer nodes" into "cheaper estate" as the *objective*
    is the remaining, deliberately separate, step.
-8. **What-if simulation** — the planner against a modified snapshot: "can I
-   lose zone B? can this workload fit?" Capacity planning as a question, not
-   a spreadsheet.
 
 
 ## Explicitly not planned

--- a/internal/api/rest/rest.go
+++ b/internal/api/rest/rest.go
@@ -120,6 +120,10 @@ func (s *Server) Routes(mux *http.ServeMux) {
 	read("/api/v1/reclamations", s.handleReclamations)
 	read("/api/v1/preflight", s.handlePreflight)
 	read("/api/v1/resilience", s.handleResilience)
+	// A simulation is a read: it mutates a copy of a stored snapshot and
+	// touches nothing, so it carries the read grant, not the execute one —
+	// registered directly because the read() helper prepends GET.
+	route("POST /api/v1/whatif", auth.ReadPlans, s.handleWhatif)
 	read("/api/v1/plans", s.handleListPlans)
 	read("/api/v1/plans/latest", s.handleLatestPlan)
 	read("/api/v1/plans/{id}", s.handlePlan)

--- a/internal/api/rest/whatif.go
+++ b/internal/api/rest/whatif.go
@@ -1,0 +1,150 @@
+package rest
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"time"
+
+	"github.com/atedgimo/k8s-dencer/internal/constraints"
+	"github.com/atedgimo/k8s-dencer/internal/model"
+)
+
+// What-if: the planner against a cluster that has lost something.
+//
+// "Can I lose zone B?" is normally answered with a spreadsheet or a shrug.
+// Here it is answered by the same analyzer and packer that plan real
+// consolidations, run against the latest snapshot minus the removed nodes:
+// every pod that lived on them is re-homed by the constraint engine, and the
+// ones with nowhere legal to go are named, with the analyzer's explanations.
+//
+// Read-only by construction — the simulation mutates a copy of a stored
+// snapshot and touches nothing else. It answers with the same honesty rules
+// as everything here: "fits" means the constraint engine found every
+// displaced pod a legal home in the simulated cluster, not a promise about
+// what the scheduler will do on the day.
+
+// whatifRequest is the body of POST /api/v1/whatif.
+type whatifRequest struct {
+	// RemoveNodes simulates losing these nodes.
+	RemoveNodes []string `json:"removeNodes,omitempty"`
+	// RemoveZone simulates losing every node in a topology zone.
+	RemoveZone string `json:"removeZone,omitempty"`
+}
+
+type whatifHomeless struct {
+	Pod string `json:"pod"`
+	// Why quotes the analyzer's blocking constraints for this pod in the
+	// simulated cluster.
+	Why []string `json:"why"`
+}
+
+func (s *Server) handleWhatif(w http.ResponseWriter, r *http.Request) {
+	rec, err := s.record(r.Context(), "latest")
+	if err != nil {
+		s.fail(w, err)
+		return
+	}
+
+	var req whatifRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<16)).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "request body is not valid JSON")
+		return
+	}
+	if len(req.RemoveNodes) == 0 && req.RemoveZone == "" {
+		writeError(w, http.StatusBadRequest, "remove something: removeNodes or removeZone")
+		return
+	}
+
+	remove := map[string]bool{}
+	for _, n := range req.RemoveNodes {
+		remove[n] = true
+	}
+	for _, n := range rec.Snapshot.Nodes {
+		if req.RemoveZone != "" && n.Zone() == req.RemoveZone {
+			remove[n.Name] = true
+		}
+	}
+
+	// Validate before simulating, so a typo answers "no such node" rather
+	// than a confident report about a cluster that was never asked about.
+	known := map[string]bool{}
+	for _, n := range rec.Snapshot.Nodes {
+		known[n.Name] = true
+	}
+	for name := range remove {
+		if !known[name] {
+			writeError(w, http.StatusBadRequest,
+				fmt.Sprintf("node %q is not in the latest snapshot", name))
+			return
+		}
+	}
+	if len(remove) == len(rec.Snapshot.Nodes) {
+		writeError(w, http.StatusBadRequest, "that removes every node; nothing is left to simulate")
+		return
+	}
+
+	// The simulated cluster: surviving nodes, with the dead nodes' pods made
+	// homeless (NodeName cleared) so the analyzer treats them as needing a
+	// placement rather than as gone. DaemonSet pods on removed nodes are
+	// dropped — their controller would not reschedule them elsewhere.
+	sim := &model.ClusterSnapshot{
+		TakenAt: time.Now().UTC(),
+		PDBs:    rec.Snapshot.PDBs,
+	}
+	for _, n := range rec.Snapshot.Nodes {
+		if !remove[n.Name] {
+			sim.Nodes = append(sim.Nodes, n)
+		}
+	}
+	displaced := []model.Pod{}
+	for _, p := range rec.Snapshot.Pods {
+		switch {
+		case !remove[p.NodeName]:
+			sim.Pods = append(sim.Pods, p)
+		case p.IsMovable():
+			cp := p
+			cp.NodeName = ""
+			sim.Pods = append(sim.Pods, cp)
+			displaced = append(displaced, p)
+		}
+		// Immovable pods on removed nodes fall away with their node.
+	}
+
+	analysis := constraints.Analyze(sim)
+
+	homeless := []whatifHomeless{}
+	for _, p := range displaced {
+		pc, ok := analysis.ForPod(p.Key())
+		if !ok {
+			continue
+		}
+		if len(pc.CandidateNodes) == 0 {
+			why := []string{}
+			for _, c := range pc.Blockers() {
+				why = append(why, c.Explanation)
+			}
+			if len(why) == 0 {
+				why = append(why, "No surviving node has room for this pod's requests.")
+			}
+			homeless = append(homeless, whatifHomeless{Pod: p.Key(), Why: why})
+		}
+	}
+	sort.Slice(homeless, func(i, j int) bool { return homeless[i].Pod < homeless[j].Pod })
+
+	removed := make([]string, 0, len(remove))
+	for name := range remove {
+		removed = append(removed, name)
+	}
+	sort.Strings(removed)
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"removed":   removed,
+		"displaced": len(displaced),
+		"fits":      len(homeless) == 0,
+		"homeless":  homeless,
+		"basedOn":   rec.Plan.ID,
+		"takenAt":   rec.Snapshot.TakenAt,
+	})
+}

--- a/internal/api/rest/whatif_test.go
+++ b/internal/api/rest/whatif_test.go
@@ -1,0 +1,105 @@
+package rest_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/atedgimo/k8s-dencer/internal/constraints"
+	"github.com/atedgimo/k8s-dencer/internal/model"
+	"github.com/atedgimo/k8s-dencer/internal/store"
+)
+
+func whatifRecord(snap *model.ClusterSnapshot) store.Record {
+	return store.Record{
+		Plan: &model.Plan{
+			ID: "wf-test-plan", Status: model.PlanValid,
+			GeneratedAt: time.Now().UTC(), SnapshotTakenAt: time.Now().UTC(),
+			NodesBefore: len(snap.Nodes),
+		},
+		Snapshot: snap,
+		Analysis: &constraints.Analysis{},
+		Strategy: "test",
+	}
+}
+
+// The simulation's two verdicts, both grounded: a cluster with room answers
+// "fits", and one without names the pods and quotes why.
+func TestWhatifVerdicts(t *testing.T) {
+	node := func(name string, cpu int64) model.Node {
+		return model.Node{
+			Name: name, Ready: true,
+			Allocatable: model.Resources{MilliCPU: cpu, MemoryBytes: 32 << 30, Pods: 110},
+		}
+	}
+	pod := func(name, on string, cpu int64) model.Pod {
+		return model.Pod{
+			Namespace: "shop", Name: name, NodeName: on, Phase: model.PodRunning, Ready: true,
+			Requests: model.Resources{MilliCPU: cpu, MemoryBytes: 1 << 28},
+			Owner:    &model.OwnerRef{Kind: "ReplicaSet", Name: "web"},
+		}
+	}
+
+	roomy := &model.ClusterSnapshot{
+		Nodes: []model.Node{node("a", 8000), node("b", 8000)},
+		Pods:  []model.Pod{pod("web-1", "a", 500), pod("web-2", "b", 500)},
+	}
+	tight := &model.ClusterSnapshot{
+		Nodes: []model.Node{node("a", 8000), node("b", 1000)},
+		Pods:  []model.Pod{pod("big-1", "a", 4000), pod("web-2", "b", 500)},
+	}
+
+	for name, tc := range map[string]struct {
+		snap *model.ClusterSnapshot
+		fits bool
+	}{
+		"roomy cluster fits":     {roomy, true},
+		"tight cluster does not": {tight, false},
+	} {
+		srv := testServer(t, whatifRecord(tc.snap))
+		body, _ := json.Marshal(map[string]any{"removeNodes": []string{"a"}})
+		resp, err := http.Post(srv.URL+"/api/v1/whatif", "application/json", bytes.NewReader(body))
+		if err != nil {
+			t.Fatal(err)
+		}
+		var out struct {
+			Fits     bool `json:"fits"`
+			Homeless []struct {
+				Pod string   `json:"pod"`
+				Why []string `json:"why"`
+			} `json:"homeless"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+			t.Fatal(err)
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode != 200 {
+			t.Fatalf("%s: status %d", name, resp.StatusCode)
+		}
+		if out.Fits != tc.fits {
+			t.Errorf("%s: fits = %v, want %v", name, out.Fits, tc.fits)
+		}
+		if !tc.fits {
+			if len(out.Homeless) != 1 || out.Homeless[0].Pod != "shop/big-1" {
+				t.Errorf("%s: homeless = %+v, want shop/big-1 named", name, out.Homeless)
+			}
+			if len(out.Homeless) == 1 && len(out.Homeless[0].Why) == 0 {
+				t.Errorf("%s: a homeless pod with no why is a verdict without a reason", name)
+			}
+		}
+	}
+
+	// A typo answers 400, not a confident report about the wrong question.
+	srv := testServer(t, whatifRecord(roomy))
+	body, _ := json.Marshal(map[string]any{"removeNodes": []string{"no-such"}})
+	resp, err := http.Post(srv.URL+"/api/v1/whatif", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != 400 {
+		t.Errorf("unknown node: status %d, want 400", resp.StatusCode)
+	}
+}

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -300,3 +300,34 @@ func (c *Client) Drain(ctx context.Context, node string, dryRun bool) (string, e
 	}
 	return out.RunID, nil
 }
+
+// WhatifEnvelope is what POST /api/v1/whatif returns.
+type WhatifEnvelope struct {
+	Removed   []string         `json:"removed"`
+	Displaced int              `json:"displaced"`
+	Fits      bool             `json:"fits"`
+	Homeless  []WhatifHomeless `json:"homeless"`
+	BasedOn   string           `json:"basedOn"`
+	TakenAt   time.Time        `json:"takenAt"`
+}
+
+type WhatifHomeless struct {
+	Pod string   `json:"pod"`
+	Why []string `json:"why"`
+}
+
+// Whatif simulates losing nodes or a zone against the latest snapshot.
+func (c *Client) Whatif(ctx context.Context, nodes []string, zone string) (*WhatifEnvelope, error) {
+	var out WhatifEnvelope
+	body := map[string]any{}
+	if len(nodes) > 0 {
+		body["removeNodes"] = nodes
+	}
+	if zone != "" {
+		body["removeZone"] = zone
+	}
+	if err := c.do(ctx, "POST", "/api/v1/whatif", body, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -551,3 +551,23 @@ func PrintResilience(w io.Writer, env *ResilienceEnvelope) {
 	}
 	fmt.Fprintln(w, "\nEach finding names a pod a node loss would hurt — voluntarily drained or not.")
 }
+
+// PrintWhatif renders a loss simulation. The verdict leads; the homeless
+// pods, when any, are the entire point of asking.
+func PrintWhatif(w io.Writer, env *WhatifEnvelope) {
+	fmt.Fprintf(w, "Simulated losing %d node(s): %s\n", len(env.Removed), strings.Join(env.Removed, ", "))
+	fmt.Fprintf(w, "%d pod(s) displaced.\n\n", env.Displaced)
+	if env.Fits {
+		fmt.Fprintf(w, "%s\n", bold(green("Everything fits.")))
+		fmt.Fprintln(w, "The constraint engine found every displaced pod a legal home on the surviving nodes.")
+		fmt.Fprintln(w, dim("A fit here is the engine's answer, not a promise about the scheduler on the day."))
+		return
+	}
+	fmt.Fprintf(w, "%s\n", bold(red(fmt.Sprintf("%d pod(s) would have nowhere legal to go:", len(env.Homeless)))))
+	for _, h := range env.Homeless {
+		fmt.Fprintf(w, "  %s %s\n", red("■"), h.Pod)
+		for _, why := range h.Why {
+			fmt.Fprintf(w, "      %s\n", why)
+		}
+	}
+}


### PR DESCRIPTION
The second-to-last roadmap item. *"Can we lose zone B?"* — answered by the constraint engine rather than spreadsheet arithmetic that ignores every real constraint:

- latest snapshot **minus** the removed nodes/zone; every displaced movable pod re-homed by the analyzer
- pods with nowhere legal to go **named, with the analyzer's explanations** — a verdict without a reason is a shrug with confidence
- DaemonSet pods fall away with their node (their controller wouldn't re-home them either)
- typo'd node → 400, not a confident report about the wrong question; removing everything → refused
- **a fit is the engine's answer, not a promise about the scheduler on the day** — the report says so in those words
- read grant, not execute: a simulation mutates a copy and touches nothing
- `dencer whatif` exits non-zero on no-fit — "we survive a zone loss" becomes a **CI-checkable claim**

Both verdict paths tested black-box through the real store and router. All 19 packages green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)