### PR TITLE
Strays out, and the GCP bill stated in numbers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ ui/dist/
 # Stray binaries from `go build ./cmd/<x>` without -o.
 /planner
 /executor
+/dencer
+*.test
 /ui-backend
 bin/
 .e2e-images.log

--- a/Makefile
+++ b/Makefile
@@ -216,6 +216,10 @@ guard-context:
 gke-setup: ## One-time GCP bootstrap for the cloud test (APIs, quota, budget alert)
 	./hack/gke-setup.sh
 
+.PHONY: gke-leftovers
+gke-leftovers: ## Read-only audit: anything billable left in the GCP project?
+	./hack/gke-leftovers.sh
+
 .PHONY: cloud-e2e
 cloud-e2e: ## The same e2e on a real GKE cluster, so a real autoscaler reclaims the node
 	@echo "This creates a billable GKE cluster (~2-3 cents) and destroys it afterwards."

--- a/docs/gcp-setup.md
+++ b/docs/gcp-setup.md
@@ -197,6 +197,29 @@ anywhere in it.
 
 [← Documentation index](README.md) · [Project README](../README.md)
 
+## What a run costs, exactly
+
+Stated so nobody has to guess, using list prices as of mid-2026 — verify
+against [GCP's pricing page](https://cloud.google.com/compute/all-pricing)
+before relying on them:
+
+| Item | Rate | A full run (~45 min) |
+|---|---|---|
+| 5 × `e2-small` **Spot** nodes | ≈ $0.007/h each | **≈ $0.03** |
+| 5 × `e2-small` on-demand (the quota fallback) | ≈ $0.017/h each | ≈ $0.07 |
+| GKE control plane, one **zonal** cluster | covered by GKE's free tier credit for one cluster | $0 |
+| Egress, images, API calls | pennies at this scale | ≈ $0 |
+
+So a complete cloud test is **a few cents on Spot, under ten on-demand** —
+provided teardown ran. The one real cost risk is not the run; it is a
+leftover: a cluster that never tore down bills ~$3.50/day on-demand, and a
+forgotten load balancer ~$0.60/day.
+
+That is what `make gke-leftovers` is for: a **read-only** audit (every
+command is a `list`) of clusters, instances, disks, load balancers, static
+IPs and snapshots. Run it after any cloud session; an empty report is the
+receipt. It deletes nothing, ever.
+
 ## The second run
 
 The first cloud test (M23) proved one thing: a reclaimer nobody here wrote

--- a/hack/gke-leftovers.sh
+++ b/hack/gke-leftovers.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Read-only audit of billable GKE/GCE leftovers in the current project.
+#
+# The cloud test tears itself down, but "the script said so" is not the same
+# as "nothing is billing". This lists every resource class a k8s-dencer cloud
+# run could leave behind — clusters, disks, load balancers, static IPs — with
+# zero mutations: every command here is a list. Run it after any cloud
+# session; an empty report is the receipt.
+set -euo pipefail
+
+bold() { printf '\033[1m%s\033[0m\n' "$*"; }
+
+PROJECT="$(gcloud config get-value project 2>/dev/null)"
+[ -n "$PROJECT" ] || { echo "no gcloud project configured"; exit 1; }
+bold "==> billable leftovers audit for project: $PROJECT (read-only)"
+
+found=0
+check() {
+  local what="$1"; shift
+  local out
+  out="$("$@" 2>/dev/null || true)"
+  if [ -n "$out" ]; then
+    found=1
+    printf '\033[33m▲ %s\033[0m\n%s\n\n' "$what" "$out"
+  else
+    printf '\033[32m  none: %s\033[0m\n' "$what"
+  fi
+}
+
+check "GKE clusters"        gcloud container clusters list --format="table(name,location,currentNodeCount)" 2>/dev/null
+check "Compute instances"   gcloud compute instances list --format="table(name,zone,status)"
+check "Persistent disks"    gcloud compute disks list --format="table(name,zone,sizeGb,users.basename())"
+check "Forwarding rules"    gcloud compute forwarding-rules list --format="table(name,region,IPAddress)"
+check "Target pools"        gcloud compute target-pools list --format="table(name,region)"
+check "Static addresses"    gcloud compute addresses list --filter="status=RESERVED" --format="table(name,region,address)"
+check "Disk snapshots"      gcloud compute snapshots list --format="table(name,diskSizeGb)"
+
+echo
+if [ "$found" = 0 ]; then
+  bold "Nothing billable found. This is the receipt."
+else
+  bold "Leftovers above are billing. Delete what you recognise; nothing here deletes anything."
+fi


### PR DESCRIPTION
Two of the three POC-polish asks.

**Cleanup:** a 35 MB compiled `dencer` binary was committed by a broad `git add` during M25 — shipping in every clone since. Removed; `.gitignore` now blocks the class (`/dencer`, `*.test`). Working tree strays (`planner`, `executor`, `planner.test`) deleted.

**GCP clarity, zero added cost:**
- `docs/gcp-setup.md` states the bill in numbers: **a few cents on Spot, under ten on-demand**, zonal control plane covered by free tier — and names the real risk: a leftover cluster bills ~$3.50/day
- `make gke-leftovers` — a **read-only** audit (every command a `list`) of clusters, instances, disks, LBs, static IPs, snapshots. *An empty report is the receipt.* Deletes nothing, ever. Not run by me — it's yours to run after any cloud session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)