### PR TITLE
Reports analyze fresh; the README learns the new verbs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ happens to be able to execute, not an autoscaler with a UI.
   drained is still sitting there.
 - **Answers questions in natural language** through an optional Kagent agent
   that quotes the analyzer rather than re-deriving anything.
+- **Answers the adjacent questions the same engine can.** `dencer preflight`
+  — will a node-pool rotation wedge, and on which pod; `dencer audit` — what
+  cannot survive a node loss; `dencer whatif --without-zone b` — does
+  everything still fit, CI-gateable; `dencer rightsizing` — requests versus
+  *measured* usage; `dencer drain <node>` — kubectl drain with the rails.
 - **Works without the UI.** `dencer` (also a `kubectl` plugin) does everything
   the UI does from a terminal, with `-o json` for pipelines — see
   [docs/cli.md](docs/cli.md).

--- a/internal/api/rest/preflight.go
+++ b/internal/api/rest/preflight.go
@@ -41,7 +41,16 @@ func (s *Server) handlePreflight(w http.ResponseWriter, r *http.Request) {
 		s.fail(w, err)
 		return
 	}
-	snap, analysis := rec.Snapshot, rec.Analysis
+	// Analyzed fresh from the stored snapshot rather than read from the
+	// stored analysis blob. The snapshot refreshes on the dedup path (when
+	// usage collection is on) precisely because stored state ages on steady
+	// clusters — and the analysis blob still ages that way, frozen at the
+	// last plan change. A preflight run "immediately before upgrading", as
+	// its own report advises, must not answer from constraints as they stood
+	// an hour ago. Analyze costs ~16ms at 900 pods and ~300ms at 5k
+	// (docs/benchmarks.md): report-endpoint money.
+	snap := rec.Snapshot
+	analysis := constraints.Analyze(snap)
 
 	// One pass to group constraints by node. Analysis.ForNode scans all pods
 	// per call, which is fine for the planner's occasional question and

--- a/internal/api/rest/resilience.go
+++ b/internal/api/rest/resilience.go
@@ -3,6 +3,8 @@ package rest
 import (
 	"net/http"
 	"sort"
+
+	"github.com/atedgimo/k8s-dencer/internal/constraints"
 )
 
 // The resilience audit: the analyzer's never-evictable list, re-sorted into
@@ -32,8 +34,13 @@ func (s *Server) handleResilience(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Fresh analysis for the same reason preflight computes one: the stored
+	// blob is frozen at the last plan change, and an availability audit that
+	// answers from an hour ago is a false reassurance.
+	analysis := constraints.Analyze(rec.Snapshot)
+
 	findings := []resilienceFinding{}
-	for _, pc := range rec.Analysis.Pods {
+	for _, pc := range analysis.Pods {
 		if pc.Movable {
 			continue
 		}
@@ -69,6 +76,6 @@ func (s *Server) handleResilience(w http.ResponseWriter, r *http.Request) {
 		"takenAt":  rec.Snapshot.TakenAt,
 		"planId":   rec.Plan.ID,
 		"findings": findings,
-		"pods":     len(rec.Analysis.Pods),
+		"pods":     len(analysis.Pods),
 	})
 }


### PR DESCRIPTION
Two follow-ups from yesterday's round.

**Fresh analysis for reports.** The stored analysis blob freezes at the last plan change — the same ageing the snapshot had before the dedup-refresh, one field over. Correct for the plan (the analysis explains *that* plan); wrong for `preflight` (whose own report says *re-run immediately before upgrading*) and the availability `audit`. Both now `Analyze()` the stored snapshot per request — ~16ms at 900 pods, ~300ms at 5k — the pattern `whatif` used from birth.

**README currency.** The five new verbs (preflight, audit, whatif, rightsizing, drain) join the feature list where a first reader looks.

All 19 packages green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)