### PR TITLE
Gateway API HTTPRoute, beside the Ingress

### DIFF
--- a/charts/k8s-dencer/templates/httproute.yaml
+++ b/charts/k8s-dencer/templates/httproute.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.httpRoute.enabled }}
+{{/*
+Gateway API exposure, beside (not instead of) the Ingress. Clusters standardise
+on one or the other; during a migration both can be enabled and both point at
+the same place, because the routing story is identical either way: all traffic
+goes to the frontend, which reverse-proxies /api to the backend — one route
+keeps cookies, CORS and WebSocket upgrades same-origin.
+
+The chart deliberately does NOT create a Gateway. A Gateway is cluster
+infrastructure with an owner, an address and a TLS story of its own;
+parentRefs is the operator saying which one this route attaches to, and
+values.schema.json requires at least one so an enabled route cannot dangle.
+
+Requires the Gateway API CRDs (gateway.networking.k8s.io/v1, GA since v1.0).
+*/}}
+{{- $fullName := include "k8s-dencer.fullname" . -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "k8s-dencer.labels" . | nindent 4 }}
+  {{- with (merge (dict) .Values.httpRoute.annotations .Values.commonAnnotations) }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml .Values.httpRoute.parentRefs | nindent 4 }}
+  {{- with .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ $fullName }}-ui-frontend
+          port: {{ .Values.uiFrontend.service.port }}
+{{- end }}

--- a/charts/k8s-dencer/values.schema.json
+++ b/charts/k8s-dencer/values.schema.json
@@ -611,6 +611,50 @@
           }
         }
       }
+    },
+    "httpRoute": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "annotations": {
+          "type": "object"
+        },
+        "parentRefs": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "hostnames": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "enabled": {
+                "const": true
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "parentRefs": {
+                "minItems": 1
+              }
+            },
+            "required": [
+              "parentRefs"
+            ]
+          }
+        }
+      ]
     }
   },
   "allOf": [

--- a/charts/k8s-dencer/values.yaml
+++ b/charts/k8s-dencer/values.yaml
@@ -268,6 +268,22 @@ ingress:
           pathType: Prefix
   tls: []
 
+# Gateway API exposure, beside (not instead of) the Ingress — enable whichever
+# your cluster standardises on, or both during a migration. The chart does NOT
+# create a Gateway: that is cluster infrastructure with its own owner and TLS
+# story. parentRefs names the Gateway this route attaches to, and the schema
+# requires at least one so an enabled route cannot dangle. Needs the Gateway
+# API CRDs (gateway.networking.k8s.io/v1).
+httpRoute:
+  enabled: false
+  annotations: {}
+  # - name: my-gateway
+  #   namespace: infra
+  #   sectionName: https
+  parentRefs: []
+  # - k8s-dencer.example.com
+  hostnames: []
+
 # The executor: the only component that can change your cluster.
 #
 # OFF by default, and an upgrade must never silently turn it on. Enabling it

--- a/docs/install.md
+++ b/docs/install.md
@@ -82,6 +82,31 @@ none — the entire value of this field is being believed when it says `prod`.
 Beside it the header shows the identity the API server verified through
 `TokenReview`, not a claim decoded from whatever token the page is holding.
 
+## Exposing the UI
+
+Two ways, matching what your cluster standardises on — enable either, or both
+during a migration. Each routes **all** traffic to the frontend, which
+reverse-proxies `/api` to the backend, keeping cookies, CORS and WebSocket
+upgrades same-origin.
+
+**Ingress** (the classic):
+
+```bash
+--set ingress.enabled=true --set ingress.className=nginx --set ingress.hosts[0].host=dencer.example.com
+```
+
+**Gateway API HTTPRoute** (`gateway.networking.k8s.io/v1`; needs the Gateway
+API CRDs installed):
+
+```bash
+--set httpRoute.enabled=true --set httpRoute.parentRefs[0].name=my-gateway --set httpRoute.parentRefs[0].namespace=infra --set httpRoute.hostnames[0]=dencer.example.com
+```
+
+The chart deliberately does **not** create a Gateway — that is cluster
+infrastructure with its own owner, address and TLS story. `parentRefs` names
+the Gateway this route attaches to, and the schema refuses an enabled route
+with no parent, so it cannot dangle.
+
 ## Known constraints
 
 - **SQLite is single-writer.** `uiBackend.replicaCount` is pinned to 1 and enforced by the schema; the planner is co-scheduled with ui-backend via a `requiredDuringScheduling` podAffinity, because a ReadWriteOnce claim only permits multiple pods on the same node. Both constraints disappear when the Postgres store lands.


### PR DESCRIPTION
Clusters that adopted Gateway API often run no Ingress controller at all. The chart now speaks both: `httpRoute.enabled` renders a `gateway.networking.k8s.io/v1` HTTPRoute to the same target as the Ingress — the frontend, which reverse-proxies `/api`, keeping everything same-origin either way. Enable either, or both during a migration.

**Two deliberate refusals:**
- the chart does **not** create a Gateway — cluster infrastructure with its own owner, address and TLS story
- an enabled route **cannot dangle**: the schema requires ≥1 `parentRef` when enabled, so it fails at install rather than sitting silently `Accepted=False`

**Verified to the honest limit** without a Gateway implementation: CRDs installed on the live cluster, rendered route **accepted by server-side dry-run validation**. Actual routing needs a Gateway controller; the Ingress path remains what CI exercises end to end — stated, not implied.

Chart contract green, helm lint green, docs cover both paths side by side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)