### PR TITLE
Honour the ecosystem's hands-off annotations

### DIFF
--- a/docs/product-roadmap.md
+++ b/docs/product-roadmap.md
@@ -10,6 +10,11 @@ deciding what to build next and telling users what they get.
 ## Shipped
 
 ### Analysis and planning
+- **The ecosystem's hands-off signals are honoured** —
+  `karpenter.sh/do-not-disrupt` and
+  `cluster-autoscaler.kubernetes.io/safe-to-evict: "false"` pin a pod
+  (named constraint, quoted in every explanation) and exclude a node from
+  candidacy, exactly as the autoscalers themselves behave
 - **Right-sizing report** — `dencer rightsizing`: requests versus *measured*
   usage per workload (metrics-server, opt-in via `planner.usageSource`),
   sorted by absolute CPU excess. Refuses to estimate without measurements,

--- a/internal/cluster/collector.go
+++ b/internal/cluster/collector.go
@@ -246,7 +246,20 @@ func applyTransform(opts *cache.Options) {
 			return obj, nil
 		}
 		p.ManagedFields = nil
-		p.Annotations = nil
+		// Annotations are stripped for heap discipline (M17) — except the two
+		// the ecosystem uses to say "hands off", which are load-bearing for
+		// movability and cost nothing to keep.
+		var keep map[string]string
+		if v, ok := p.Annotations["karpenter.sh/do-not-disrupt"]; ok {
+			keep = map[string]string{"karpenter.sh/do-not-disrupt": v}
+		}
+		if v, ok := p.Annotations["cluster-autoscaler.kubernetes.io/safe-to-evict"]; ok {
+			if keep == nil {
+				keep = map[string]string{}
+			}
+			keep["cluster-autoscaler.kubernetes.io/safe-to-evict"] = v
+		}
+		p.Annotations = keep
 		p.Status.ContainerStatuses = nil
 		p.Status.InitContainerStatuses = nil
 		p.Status.EphemeralContainerStatuses = nil

--- a/internal/cluster/convert.go
+++ b/internal/cluster/convert.go
@@ -52,6 +52,8 @@ func convertPod(p *corev1.Pod, ownerOf ownerResolver) model.Pod {
 		NodeSelector: p.Spec.NodeSelector,
 		Terminating:  p.DeletionTimestamp != nil,
 		Ready:        podReady(p),
+		DoNotDisrupt: p.Annotations["karpenter.sh/do-not-disrupt"] == "true" ||
+			p.Annotations["cluster-autoscaler.kubernetes.io/safe-to-evict"] == "false",
 	}
 
 	if p.Spec.Priority != nil {

--- a/internal/constraints/analyzer.go
+++ b/internal/constraints/analyzer.go
@@ -48,6 +48,21 @@ func analyzePod(pod model.Pod, snap *model.ClusterSnapshot, placement *Placement
 		Movable:   pod.IsMovable(),
 	}
 
+	// The explicit hands-off signal outranks everything: it is the owner
+	// saying "do not touch this", in the vocabulary Karpenter and the
+	// cluster autoscaler both honour, and this product honours it too.
+	if pod.DoNotDisrupt {
+		pc.Constraints = append(pc.Constraints, Constraint{
+			Kind:     KindDoNotDisrupt,
+			Hard:     true,
+			Blocking: true,
+			Explanation: "Annotated hands-off (karpenter.sh/do-not-disrupt or " +
+				"cluster-autoscaler.kubernetes.io/safe-to-evict: \"false\"). " +
+				"The owner has explicitly opted this pod out of voluntary disruption, " +
+				"and k8s-dencer honours the same convention the autoscalers do.",
+		})
+	}
+
 	// Controller pinning comes first: if the pod cannot move at all, the rest
 	// of the constraint set is context rather than explanation.
 	if pod.Owner != nil && pod.Owner.Kind == "DaemonSet" {

--- a/internal/constraints/analyzer_test.go
+++ b/internal/constraints/analyzer_test.go
@@ -194,3 +194,44 @@ func TestAnalysisIsDeterministic(t *testing.T) {
 		t.Error("analysis is not deterministic across runs on identical input")
 	}
 }
+
+// The ecosystem's hands-off annotations must make a pod immovable, with the
+// convention named in the explanation. Until this landed, the informer
+// transform stripped ALL annotations, so the analyzer was structurally blind
+// to the one signal Karpenter and the cluster autoscaler both honour.
+func TestHandsOffAnnotationsPinThePod(t *testing.T) {
+	snap := &model.ClusterSnapshot{
+		Nodes: []model.Node{
+			{Name: "a", Ready: true, Allocatable: model.Resources{MilliCPU: 8000, MemoryBytes: 32 << 30, Pods: 110}},
+			{Name: "b", Ready: true, Allocatable: model.Resources{MilliCPU: 8000, MemoryBytes: 32 << 30, Pods: 110}},
+		},
+		Pods: []model.Pod{{
+			Namespace: "shop", Name: "pinned-1", NodeName: "a",
+			Phase: model.PodRunning, Ready: true, DoNotDisrupt: true,
+			Requests: model.Resources{MilliCPU: 500, MemoryBytes: 1 << 28},
+			Owner:    &model.OwnerRef{Kind: "ReplicaSet", Name: "shop"},
+		}},
+	}
+
+	analysis := constraints.Analyze(snap)
+	pc, ok := analysis.ForPod("shop/pinned-1")
+	if !ok {
+		t.Fatal("pod not analysed")
+	}
+	if pc.Movable {
+		t.Error("a do-not-disrupt pod is Movable; the owner's explicit opt-out is being ignored")
+	}
+	found := false
+	for _, c := range pc.Of(constraints.KindDoNotDisrupt) {
+		found = true
+		if !c.Blocking || !c.Hard {
+			t.Error("the hands-off constraint must be hard and blocking")
+		}
+	}
+	if !found {
+		t.Error("no DoNotDisrupt constraint; the pod is pinned without its reason being explainable")
+	}
+	if drainable, _ := analysis.NodeDrainable("a"); drainable {
+		t.Error("a node holding a hands-off pod reports drainable")
+	}
+}

--- a/internal/constraints/constraints.go
+++ b/internal/constraints/constraints.go
@@ -24,6 +24,9 @@ const (
 	KindPDB              Kind = "PodDisruptionBudget"
 	KindTaint            Kind = "Taint"
 	KindControllerPinned Kind = "ControllerPinned"
+	// KindDoNotDisrupt is the ecosystem's explicit hands-off annotation,
+	// honoured here exactly as Karpenter and the cluster autoscaler honour it.
+	KindDoNotDisrupt     Kind = "DoNotDisrupt"
 	KindPersistentVolume Kind = "PersistentVolume"
 )
 

--- a/internal/model/cluster.go
+++ b/internal/model/cluster.go
@@ -56,6 +56,14 @@ func (n Node) InstanceType() string { return n.Labels["node.kubernetes.io/instan
 // said. Three-valued for the usual reason — a KWOK node is not "on-demand",
 // it is unpriced, and pretending otherwise would put a made-up word in a
 // cost report.
+
+// DoNotDisrupt reports the node-level hands-off marker
+// (karpenter.sh/do-not-disrupt: "true"). Such a node is not a drain
+// candidate, whatever its utilisation says.
+func (n Node) DoNotDisrupt() bool {
+	return n.Annotations["karpenter.sh/do-not-disrupt"] == "true"
+}
+
 func (n Node) CapacityType() string {
 	switch {
 	case n.Labels["karpenter.sh/capacity-type"] == "spot",
@@ -126,6 +134,14 @@ type Pod struct {
 	Terminating      bool      `json:"terminating,omitempty"`
 	HasPersistentVol bool      `json:"hasPersistentVolume,omitempty"`
 
+	// DoNotDisrupt is the ecosystem's own "hands off" signal, captured from
+	// either karpenter.sh/do-not-disrupt: "true" or
+	// cluster-autoscaler.kubernetes.io/safe-to-evict: "false". The owner has
+	// explicitly opted out of voluntary disruption, and a consolidation tool
+	// that ignores the conventions its neighbours honour is not safe to run
+	// beside them.
+	DoNotDisrupt bool `json:"doNotDisrupt,omitempty"`
+
 	Usage *Resources `json:"usage,omitempty"`
 }
 
@@ -142,6 +158,10 @@ func (p Pod) IsMovable() bool {
 		return false
 	}
 	if p.Owner != nil && p.Owner.Kind == "DaemonSet" {
+		return false
+	}
+	if p.DoNotDisrupt {
+		// The owner said hands off, in the ecosystem's own vocabulary.
 		return false
 	}
 	return true

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -294,3 +294,14 @@ func TestCapacityTypeIsThreeValued(t *testing.T) {
 		}
 	}
 }
+
+// The hands-off flag must make IsMovable false on its own. The analyzer's
+// blocking constraint already stops the planner; this rail is what stops the
+// EXECUTOR from evicting such a pod during a named drain, where the moves
+// list comes from IsMovable rather than from an analysis.
+func TestDoNotDisruptPodIsNotMovable(t *testing.T) {
+	p := model.Pod{Phase: model.PodRunning, Owner: &model.OwnerRef{Kind: "ReplicaSet", Name: "x"}, DoNotDisrupt: true}
+	if p.IsMovable() {
+		t.Fatal("a do-not-disrupt pod reports movable; a guarded drain would evict it")
+	}
+}

--- a/internal/planner/greedy.go
+++ b/internal/planner/greedy.go
@@ -206,6 +206,11 @@ func drainCandidates(snap *model.ClusterSnapshot, opts Options, now time.Time) [
 		if excluded, _ := opts.nodeExcluded(n, now); excluded {
 			continue
 		}
+		if n.DoNotDisrupt() {
+			// The node-level hands-off marker. Karpenter will not consolidate
+			// this node; neither will we.
+			continue
+		}
 		out = append(out, n)
 	}
 	return out

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -330,3 +330,41 @@ func findPod(p *constraints.Placement, nodeName, namespace, name string) (model.
 	}
 	return model.Pod{}, false
 }
+
+// A node carrying karpenter.sh/do-not-disrupt must never be a drain
+// candidate — Karpenter will not consolidate it, and neither may we.
+func TestHandsOffNodeIsNeverACandidate(t *testing.T) {
+	mk := func(name string, annotations map[string]string) model.Node {
+		return model.Node{
+			Name: name, Ready: true, Annotations: annotations,
+			Allocatable: model.Resources{MilliCPU: 8000, MemoryBytes: 32 << 30, Pods: 110},
+		}
+	}
+	pod := func(name, on string) model.Pod {
+		return model.Pod{
+			Namespace: "shop", Name: name, NodeName: on, Phase: model.PodRunning, Ready: true,
+			Requests: model.Resources{MilliCPU: 500, MemoryBytes: 1 << 28},
+			Owner:    &model.OwnerRef{Kind: "ReplicaSet", Name: "web"},
+		}
+	}
+	snap := &model.ClusterSnapshot{
+		Nodes: []model.Node{
+			mk("protected", map[string]string{"karpenter.sh/do-not-disrupt": "true"}),
+			mk("ordinary", nil),
+			mk("receiver", nil),
+		},
+		Pods: []model.Pod{pod("w1", "protected"), pod("w2", "ordinary"), pod("w3", "receiver")},
+	}
+
+	opts := planner.DefaultOptions()
+	opts.MinNodeAge = 0
+	plan, err := planner.Greedy{}.Plan(snap, constraints.Analyze(snap), opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, s := range plan.Steps {
+		if s.TargetNode == "protected" {
+			t.Fatal("the plan drains a node annotated do-not-disrupt")
+		}
+	}
+}


### PR DESCRIPTION
Build-order #1 of the approved phase — a correctness gap wearing a feature's clothes.

`karpenter.sh/do-not-disrupt` and `safe-to-evict: "false"` are the vocabulary the autoscalers themselves honour — and this product was **structurally deaf** to them: the M17 transform strips pod annotations wholesale, so the collector never saw the signal. The transform now keeps **exactly those two keys** (heap discipline intact).

Three consumers, each enforcing in its own layer because they reach eviction by different roads:

| Layer | Enforcement |
|---|---|
| analyzer | named, hard, blocking `DoNotDisrupt` constraint — every explaining surface (ratings, preflight, audit, whatif) explains this too |
| planner | a hands-off **node** is never a candidate |
| `IsMovable` | the rail the **executor** reads — a named drain builds evictions from `IsMovable`, not an analysis |

The third one earned its own test the honest way: mutation showed the analyzer test stays green without it (the blocking constraint masks it) — only a direct `IsMovable` test can fail, so one exists now. All three rails mutation-verified with *asserted* mutations.

All 19 packages green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)