### PR TITLE
The timeline exists: samples, the history API, and the fabric's autoscaler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -451,6 +451,10 @@ scenario: ## Switch scenario: make scenario S=b-pdb-blocked
 	@$(MAKE) --no-print-directory demo-wait
 
 .PHONY: demo
+.PHONY: demo-reclaim
+demo-reclaim: ## Fabric plays the autoscaler: remove drained kwok nodes (WATCH=1 to keep going)
+	@if [ "$(WATCH)" = "1" ]; then ./hack/demo-reclaim.sh --watch; else ./hack/demo-reclaim.sh; fi
+
 demo: kwok-up demo-up images images-load deploy ## Full POC: fabric + topology + product
 	@echo
 	@echo "==> demo ready. 'make ui' to open it, 'make down' to tear it all down."

--- a/charts/k8s-dencer/templates/httproute.yaml
+++ b/charts/k8s-dencer/templates/httproute.yaml
@@ -1,4 +1,8 @@
-{{- if .Values.httpRoute.enabled }}
+{{- /* nil-guarded, not just falsy-guarded: a release upgraded with
+     --reuse-values carries values from before this block existed, and
+     .Values.httpRoute is then nil — found live, the release predating the
+     feature. */ -}}
+{{- if and .Values.httpRoute .Values.httpRoute.enabled }}
 {{/*
 Gateway API exposure, beside (not instead of) the Ingress. Clusters standardise
 on one or the other; during a migration both can be enabled and both point at

--- a/hack/demo-reclaim.sh
+++ b/hack/demo-reclaim.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# The demo fabric's stand-in autoscaler.
+#
+# On a real cloud, the platform's autoscaler removes nodes k8s-dencer has
+# drained (GKE did it in 11m9s, observed). The KWOK fabric has no autoscaler,
+# so the demo's story used to stop in the middle: drained nodes sat "awaiting
+# removal" forever and the savings ledger read zero. This script plays the
+# missing role — it deletes fake nodes that are drained, which is exactly
+# what the real autoscaler does, clearly labelled as the fabric acting.
+#
+# Structural safety: it refuses any node not labelled type=kwok, so it cannot
+# touch a real node no matter what it is asked.
+#
+#   hack/demo-reclaim.sh          one pass
+#   hack/demo-reclaim.sh --watch  keep going (Ctrl-C to stop) — run this in a
+#                                 second terminal during a demo
+set -euo pipefail
+
+bold() { printf '\033[1m%s\033[0m\n' "$*"; }
+
+pass() {
+  # Drained means: cordoned, and holding nothing that can move. Mirror the
+  # tracker's definition: only kwok-labelled, unschedulable nodes whose pods
+  # are all DaemonSet-owned or terminating.
+  local nodes
+  nodes="$(kubectl get nodes -l type=kwok \
+    -o jsonpath='{range .items[?(@.spec.unschedulable==true)]}{.metadata.name}{"\n"}{end}')"
+  [ -z "$nodes" ] && return 0
+
+  while IFS= read -r node; do
+    [ -z "$node" ] && continue
+    # Any non-DaemonSet, non-terminating pod means the drain is not finished.
+    local blockers
+    blockers="$(kubectl get pods --all-namespaces \
+      --field-selector spec.nodeName="$node" -o json 2>/dev/null |
+      python3 -c '
+import json,sys
+d=json.load(sys.stdin)
+n=0
+for p in d.get("items",[]):
+    if p.get("metadata",{}).get("deletionTimestamp"): continue
+    owners=[o.get("kind") for o in p.get("metadata",{}).get("ownerReferences",[])]
+    if "DaemonSet" in owners: continue
+    n+=1
+print(n)')"
+    if [ "$blockers" = "0" ]; then
+      bold "fabric-autoscaler: removing drained node $node"
+      kubectl delete node "$node" --wait=false
+    fi
+  done <<< "$nodes"
+}
+
+if [ "${1:-}" = "--watch" ]; then
+  bold "fabric-autoscaler: watching for drained kwok nodes (Ctrl-C to stop)"
+  while true; do pass; sleep 20; done
+else
+  pass
+fi

--- a/internal/api/rest/history.go
+++ b/internal/api/rest/history.go
@@ -1,0 +1,84 @@
+package rest
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/atedgimo/k8s-dencer/internal/store"
+)
+
+// History: the cluster's timeline, assembled server-side into chart-ready
+// series. Everything here was already being recorded — plan summaries, the
+// reclamation ledger, run outcomes, and (new) the per-cycle samples — this
+// endpoint is the first thing that reads them as a line through time rather
+// than a moment.
+func (s *Server) handleHistory(w http.ResponseWriter, r *http.Request) {
+	hours := 168
+	if h := r.URL.Query().Get("hours"); h != "" {
+		v, err := strconv.Atoi(h)
+		if err != nil || v < 1 || v > 24*31 {
+			writeError(w, http.StatusBadRequest, "hours must be between 1 and 744")
+			return
+		}
+		hours = v
+	}
+	since := time.Now().Add(-time.Duration(hours) * time.Hour)
+
+	samples := []store.Sample{}
+	if ts, ok := s.store.(store.SampleStore); ok {
+		got, err := ts.Samples(r.Context(), since)
+		if err != nil {
+			s.fail(w, err)
+			return
+		}
+		samples = got
+	}
+
+	// Plan summaries: List is newest-first and window-agnostic; filter here.
+	plansOut := []map[string]any{}
+	if sums, err := s.store.List(r.Context(), 200); err == nil {
+		for _, p := range sums {
+			if p.GeneratedAt.After(since) {
+				plansOut = append(plansOut, map[string]any{
+					"id": p.ID, "generatedAt": p.GeneratedAt,
+					"nodesBefore": p.NodesBefore, "nodesAfter": p.NodesAfter,
+				})
+			}
+		}
+	}
+
+	recl := []store.Reclamation{}
+	if tracker, ok := s.store.(store.ReclamationStore); ok {
+		if got, err := tracker.Reclamations(r.Context(), 500); err == nil {
+			for _, rr := range got {
+				if rr.DrainedAt.After(since) || (rr.ResolvedAt != nil && rr.ResolvedAt.After(since)) {
+					recl = append(recl, rr)
+				}
+			}
+		}
+	}
+
+	runsOut := []map[string]any{}
+	if s.runs != nil {
+		if got, err := s.runs.RecentRuns(r.Context(), 200); err == nil {
+			for _, run := range got {
+				if run.FinishedAt == nil || run.FinishedAt.Before(since) {
+					continue
+				}
+				runsOut = append(runsOut, map[string]any{
+					"id": run.ID, "status": run.Status, "mode": run.Mode,
+					"dryRun": run.DryRun, "finishedAt": run.FinishedAt,
+				})
+			}
+		}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"hours":        hours,
+		"samples":      samples,
+		"plans":        plansOut,
+		"reclamations": recl,
+		"runs":         runsOut,
+	})
+}

--- a/internal/api/rest/rest.go
+++ b/internal/api/rest/rest.go
@@ -121,6 +121,7 @@ func (s *Server) Routes(mux *http.ServeMux) {
 	read("/api/v1/preflight", s.handlePreflight)
 	read("/api/v1/resilience", s.handleResilience)
 	read("/api/v1/rightsizing", s.handleRightsizing)
+	read("/api/v1/history", s.handleHistory)
 	// A simulation is a read: it mutates a copy of a stored snapshot and
 	// touches nothing, so it carries the read grant, not the execute one —
 	// registered directly because the read() helper prepends GET.

--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -90,6 +90,18 @@ func (p *Publisher) Cycle(ctx context.Context) {
 	allocatable, requested := snap.Totals()
 	cpu, mem, pods := requested.Ratio(allocatable)
 
+	// Summed observed usage, zero when unmeasured — the sample records
+	// HasUsage so zero can never masquerade as idle.
+	var usedCPU, usedMem int64
+	if snap.HasUsageData {
+		for i := range snap.Nodes {
+			if u := snap.Nodes[i].Usage; u != nil {
+				usedCPU += u.MilliCPU
+				usedMem += u.MemoryBytes
+			}
+		}
+	}
+
 	occupied := 0
 	for _, n := range snap.Nodes {
 		if !snap.RequestedOnNode(n.Name).IsZero() {
@@ -173,6 +185,32 @@ func (p *Publisher) Cycle(ctx context.Context) {
 	p.Metrics.NodesReclaimed.Set(float64(plan.ReclaimedNodes()))
 	p.Metrics.PlanProduced(time.Now())
 	p.Metrics.PlanCycleTime.Observe(time.Since(cycleStart).Seconds())
+
+	// One point on the timeline, every cycle — dedup included, because a
+	// steady cluster still has a timeline and the History view exists to
+	// draw it. Failures degrade to a gap in the chart, never to a stopped
+	// planner.
+	if ts, ok := p.DB.(store.SampleStore); ok {
+		at := snap.TakenAt
+		if at.IsZero() {
+			// The collector always stamps TakenAt; a zero here (synthetic
+			// snapshots, a future source that forgets) must not write a row
+			// in year one that every range query then misses.
+			at = time.Now().UTC()
+		}
+		if err := ts.SaveSample(ctx, store.Sample{
+			TakenAt: at, Nodes: len(snap.Nodes), Pods: len(snap.Pods),
+			CPUReqMilli: requested.MilliCPU, CPUAllocMilli: allocatable.MilliCPU,
+			MemReqBytes: requested.MemoryBytes, MemAllocBytes: allocatable.MemoryBytes,
+			CPUUsedMilli: usedCPU, MemUsedBytes: usedMem, HasUsage: snap.HasUsageData,
+			Reclaimable: plan.ReclaimedNodes(),
+		}); err != nil {
+			p.Log.Warn("saving timeline sample failed", "error", err)
+		}
+		if pruned, err := ts.PruneSamples(ctx, time.Now().Add(-30*24*time.Hour)); err == nil && pruned > 0 {
+			p.Log.Info("pruned timeline", "removed", pruned)
+		}
+	}
 
 	// The planner is the only component watching nodes continuously, so it is
 	// the one that can tell whether a node the executor drained was actually

--- a/internal/publish/publish_test.go
+++ b/internal/publish/publish_test.go
@@ -78,8 +78,12 @@ func openStore(t *testing.T) store.Store {
 func snapshot(t *testing.T) *model.ClusterSnapshot {
 	t.Helper()
 	opts := model.DefaultSynthetic(8)
-	// Old enough that minNodeAge does not empty the plan.
 	snap := model.Synthesize(opts)
+	// The synthetic fixture stamps a fixed 2025 TakenAt. Restamp to now:
+	// the timeline's 30-day retention would otherwise prune each sample the
+	// moment the cycle that wrote it finishes — which is exactly what
+	// happened the first time this ran, and the prune log confessed.
+	snap.TakenAt = time.Now().UTC()
 	return snap
 }
 
@@ -210,5 +214,30 @@ func TestReclamationsResolveOnAnUnchangedCycle(t *testing.T) {
 	}
 	if !found {
 		t.Error("the gone node was not recorded as reclaimed")
+	}
+}
+
+// The timeline gains a point on EVERY cycle, dedup included — a steady
+// cluster still has a timeline, and the History view exists to draw it.
+func TestEveryCycleLandsOnTheTimeline(t *testing.T) {
+	db := openStore(t)
+	pub := newPublisher(t, steadySource{snapshot(t)}, db)
+
+	pub.Cycle(t.Context())
+	pub.Cycle(t.Context()) // the dedup path
+
+	ts, ok := db.(store.SampleStore)
+	if !ok {
+		t.Fatal("sqlite store no longer implements SampleStore")
+	}
+	samples, err := ts.Samples(t.Context(), time.Now().Add(-time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(samples) != 2 {
+		t.Fatalf("2 cycles produced %d timeline points; the dedup path is skipping the timeline", len(samples))
+	}
+	if samples[0].Nodes == 0 || samples[0].CPUAllocMilli == 0 {
+		t.Error("a sample with zero estate is a chart that lies about an empty cluster")
 	}
 }

--- a/internal/store/execution.go
+++ b/internal/store/execution.go
@@ -161,6 +161,10 @@ type ExecutionStore interface {
 	// RunByID returns one run.
 	RunByID(ctx context.Context, runID string) (Run, error)
 
+	// RecentRuns returns the newest runs regardless of plan, newest first —
+	// the History view's markers.
+	RecentRuns(ctx context.Context, limit int) ([]Run, error)
+
 	// Events returns a run's audit trail in order.
 	Events(ctx context.Context, runID string) ([]RunEvent, error)
 

--- a/internal/store/sqlite/execution.go
+++ b/internal/store/sqlite/execution.go
@@ -148,6 +148,30 @@ func (s *Store) ActiveRun(ctx context.Context) (store.Run, error) {
 	return scanRun(row)
 }
 
+// RecentRuns lists the newest runs regardless of plan, newest first.
+func (s *Store) RecentRuns(ctx context.Context, limit int) ([]store.Run, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, plan_id, steps, dry_run, status, actor, actor_groups,
+		       requested_at, started_at, finished_at, worker, summary, mode, envelope, node
+		FROM runs ORDER BY requested_at DESC, rowid DESC LIMIT ?`, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	var out []store.Run
+	for rows.Next() {
+		run, err := scanRun(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, run)
+	}
+	return out, rows.Err()
+}
+
 // RunsForPlan lists runs against a plan, newest first.
 func (s *Store) RunsForPlan(ctx context.Context, planID string, limit int) ([]store.Run, error) {
 	if limit <= 0 {

--- a/internal/store/sqlite/samples.go
+++ b/internal/store/sqlite/samples.go
@@ -1,0 +1,63 @@
+package sqlite
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/atedgimo/k8s-dencer/internal/store"
+)
+
+func (s *Store) SaveSample(ctx context.Context, sm store.Sample) error {
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO samples (taken_at, nodes, pods,
+			cpu_req_milli, cpu_alloc_milli, mem_req_bytes, mem_alloc_bytes,
+			cpu_used_milli, mem_used_bytes, has_usage, reclaimable)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		sm.TakenAt.UTC().Format(time.RFC3339Nano), sm.Nodes, sm.Pods,
+		sm.CPUReqMilli, sm.CPUAllocMilli, sm.MemReqBytes, sm.MemAllocBytes,
+		sm.CPUUsedMilli, sm.MemUsedBytes, boolToInt(sm.HasUsage), sm.Reclaimable)
+	if err != nil {
+		return fmt.Errorf("save sample: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) Samples(ctx context.Context, since time.Time) ([]store.Sample, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT taken_at, nodes, pods,
+		       cpu_req_milli, cpu_alloc_milli, mem_req_bytes, mem_alloc_bytes,
+		       cpu_used_milli, mem_used_bytes, has_usage, reclaimable
+		FROM samples WHERE taken_at >= ? ORDER BY taken_at`,
+		since.UTC().Format(time.RFC3339Nano))
+	if err != nil {
+		return nil, fmt.Errorf("list samples: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := []store.Sample{}
+	for rows.Next() {
+		var sm store.Sample
+		var takenAt string
+		var hasUsage int
+		if err := rows.Scan(&takenAt, &sm.Nodes, &sm.Pods,
+			&sm.CPUReqMilli, &sm.CPUAllocMilli, &sm.MemReqBytes, &sm.MemAllocBytes,
+			&sm.CPUUsedMilli, &sm.MemUsedBytes, &hasUsage, &sm.Reclaimable); err != nil {
+			return nil, err
+		}
+		sm.TakenAt = parseTime(takenAt)
+		sm.HasUsage = hasUsage != 0
+		out = append(out, sm)
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) PruneSamples(ctx context.Context, before time.Time) (int, error) {
+	res, err := s.db.ExecContext(ctx, `DELETE FROM samples WHERE taken_at < ?`,
+		before.UTC().Format(time.RFC3339Nano))
+	if err != nil {
+		return 0, fmt.Errorf("prune samples: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	return int(n), nil
+}

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -56,7 +56,7 @@ func Open(path string) (*Store, error) {
 // Close releases the database handle.
 func (s *Store) Close() error { return s.db.Close() }
 
-const schemaVersion = 6
+const schemaVersion = 7
 
 // Migrate creates or upgrades the schema.
 func (s *Store) Migrate(ctx context.Context) error {
@@ -102,6 +102,11 @@ func (s *Store) Migrate(ctx context.Context) error {
 	if current < 6 {
 		if _, err := tx.ExecContext(ctx, schemaV6); err != nil {
 			return fmt.Errorf("apply schema v6: %w", err)
+		}
+	}
+	if current < 7 {
+		if _, err := tx.ExecContext(ctx, schemaV7); err != nil {
+			return fmt.Errorf("apply schema v7: %w", err)
 		}
 	}
 
@@ -240,6 +245,25 @@ ALTER TABLE reclamations ADD COLUMN mem_bytes INTEGER NOT NULL DEFAULT 0;
 // Schema v6 — guarded drain: a run can target one named node.
 const schemaV6 = `
 ALTER TABLE runs ADD COLUMN node TEXT NOT NULL DEFAULT '';
+`
+
+// Schema v7 — the timeline. One small row per publish cycle; pruned to a
+// window by the planner. Indexed on taken_at because every read is a range.
+const schemaV7 = `
+CREATE TABLE IF NOT EXISTS samples (
+    taken_at        TEXT NOT NULL,
+    nodes           INTEGER NOT NULL,
+    pods            INTEGER NOT NULL,
+    cpu_req_milli   INTEGER NOT NULL,
+    cpu_alloc_milli INTEGER NOT NULL,
+    mem_req_bytes   INTEGER NOT NULL,
+    mem_alloc_bytes INTEGER NOT NULL,
+    cpu_used_milli  INTEGER NOT NULL,
+    mem_used_bytes  INTEGER NOT NULL,
+    has_usage       INTEGER NOT NULL,
+    reclaimable     INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS samples_taken_at ON samples (taken_at);
 `
 
 // Save persists a record unless it duplicates the latest plan.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -188,3 +188,38 @@ type Store interface {
 
 	Close() error
 }
+
+// Sample is one point on the cluster's timeline, written by the planner every
+// publish cycle. Small on purpose — ten numbers — because it is written every
+// resync forever, and because trends need totals, not inventories: the full
+// snapshot already exists for the moment anyone wants detail.
+type Sample struct {
+	TakenAt time.Time `json:"takenAt"`
+	Nodes   int       `json:"nodes"`
+	Pods    int       `json:"pods"`
+
+	CPUReqMilli   int64 `json:"cpuReqMilli"`
+	CPUAllocMilli int64 `json:"cpuAllocMilli"`
+	MemReqBytes   int64 `json:"memReqBytes"`
+	MemAllocBytes int64 `json:"memAllocBytes"`
+
+	// Zero when no usage source is configured — which is "unmeasured", never
+	// "idle". Consumers must check HasUsage before drawing conclusions.
+	CPUUsedMilli int64 `json:"cpuUsedMilli"`
+	MemUsedBytes int64 `json:"memUsedBytes"`
+	HasUsage     bool  `json:"hasUsage"`
+
+	// Reclaimable is the plan's answer at this moment: how many nodes the
+	// planner would free. The one series that tells the product's own story.
+	Reclaimable int `json:"reclaimable"`
+}
+
+// SampleStore persists the timeline. Implemented by the SQLite store;
+// optional the same way ReclamationStore is.
+type SampleStore interface {
+	SaveSample(ctx context.Context, s Sample) error
+	// Samples returns points at or after since, oldest first.
+	Samples(ctx context.Context, since time.Time) ([]Sample, error)
+	// PruneSamples removes points older than before, returning how many.
+	PruneSamples(ctx context.Context, before time.Time) (int, error)
+}


### PR DESCRIPTION
Build-order #2 of the approved phase — the backend of the History flagship.

**Samples** (schema v7): ten numbers per publish cycle, **dedup included** — a steady cluster still has a timeline. 30-day retention, pruned in-cycle. The invariant's first failing test run was the retention proving itself: the synthetic fixture stamps June 2025, so every sample was pruned the instant it was written — the log confessed (`pruned timeline removed=1`). Mutation-verified (asserted mutation).

**`GET /api/v1/history`**: chart-ready series assembled server-side — samples, plan summaries, reclamations, run markers. Read grant; no list ever null.

**The fabric's stand-in autoscaler** (`make demo-reclaim`, `WATCH=1`): deletes fake nodes that are *genuinely drained* — the act GKE performed in 11m9s, played by the fabric and labelled as such. Structural safety: refuses anything not `type=kwok`. **Deliberate plan deviation:** manual+watch instead of an automatic in-cluster pod — that pod would need cluster-wide `delete nodes` RBAC (unscopable by label), and the demo chart holding node-deletion rights undermines the privilege split.

**Found live:** #83's HTTPRoute template dies under `--reuse-values` (values predating the block → `.Values.httpRoute` nil). Nil-guarded.

**Proven end to end — the local ledger is nonzero for the first time ever:**
```
converge (Green envelope) → 2 nodes drained → fabric removes them
ledger: 56 cores, 224 GiB actually returned · median 7m
history: samples ticking · run marker · 2 measured reclaimed events
```

All 19 packages green, chart contract green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)