### PR TITLE
History: the cluster becomes a line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -451,6 +451,10 @@ scenario: ## Switch scenario: make scenario S=b-pdb-blocked
 	@$(MAKE) --no-print-directory demo-wait
 
 .PHONY: demo
+.PHONY: demo-reclaim
+demo-reclaim: ## Fabric plays the autoscaler: remove drained kwok nodes (WATCH=1 to keep going)
+	@if [ "$(WATCH)" = "1" ]; then ./hack/demo-reclaim.sh --watch; else ./hack/demo-reclaim.sh; fi
+
 demo: kwok-up demo-up images images-load deploy ## Full POC: fabric + topology + product
 	@echo
 	@echo "==> demo ready. 'make ui' to open it, 'make down' to tear it all down."

--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ happens to be able to execute, not an autoscaler with a UI.
   never an open-ended "optimize".
 - **Refuses steps that became unsafe** between planning and execution, naming
   the rule that stopped it.
+- **Draws the cluster over time, not just now.** A History surface: the
+  estate with its reclaimable slice, a measured savings ledger climbing as
+  nodes are actually removed, requests versus observed usage — with run
+  markers on the timeline.
 - **Checks whether draining actually saved anything.** k8s-dencer never deletes
   a node — something else does — so it watches, and tells you when a node you
   drained is still sitting there.

--- a/charts/k8s-dencer/templates/httproute.yaml
+++ b/charts/k8s-dencer/templates/httproute.yaml
@@ -1,4 +1,8 @@
-{{- if .Values.httpRoute.enabled }}
+{{- /* nil-guarded, not just falsy-guarded: a release upgraded with
+     --reuse-values carries values from before this block existed, and
+     .Values.httpRoute is then nil — found live, the release predating the
+     feature. */ -}}
+{{- if and .Values.httpRoute .Values.httpRoute.enabled }}
 {{/*
 Gateway API exposure, beside (not instead of) the Ingress. Clusters standardise
 on one or the other; during a migration both can be enabled and both point at

--- a/docs/product-roadmap.md
+++ b/docs/product-roadmap.md
@@ -70,6 +70,12 @@ deciding what to build next and telling users what they get.
   `pods/eviction` leaks to any other role
 
 ### Observing reality (not just predicting it)
+- **History** — the cluster as a line, not a moment: the estate with its
+  reclaimable slice shaded, the ledger climbing as capacity is *measured*
+  returned (run markers on the timeline; hollow ones were rehearsals), and
+  requests versus measured usage. One sample per planner cycle, 30-day
+  window. The demo fabric can play the missing autoscaler
+  (`make demo-reclaim`) so the whole story shows locally
 - **Reclaimer evidence, three-valued** — a recorded removal is proof, a
   visible autoscaler pod is a promise, and neither is *not* "no reclaimer"
   (managed control planes hide theirs). When drains are pending and there is

--- a/hack/demo-reclaim.sh
+++ b/hack/demo-reclaim.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# The demo fabric's stand-in autoscaler.
+#
+# On a real cloud, the platform's autoscaler removes nodes k8s-dencer has
+# drained (GKE did it in 11m9s, observed). The KWOK fabric has no autoscaler,
+# so the demo's story used to stop in the middle: drained nodes sat "awaiting
+# removal" forever and the savings ledger read zero. This script plays the
+# missing role — it deletes fake nodes that are drained, which is exactly
+# what the real autoscaler does, clearly labelled as the fabric acting.
+#
+# Structural safety: it refuses any node not labelled type=kwok, so it cannot
+# touch a real node no matter what it is asked.
+#
+#   hack/demo-reclaim.sh          one pass
+#   hack/demo-reclaim.sh --watch  keep going (Ctrl-C to stop) — run this in a
+#                                 second terminal during a demo
+set -euo pipefail
+
+bold() { printf '\033[1m%s\033[0m\n' "$*"; }
+
+pass() {
+  # Drained means: cordoned, and holding nothing that can move. Mirror the
+  # tracker's definition: only kwok-labelled, unschedulable nodes whose pods
+  # are all DaemonSet-owned or terminating.
+  local nodes
+  nodes="$(kubectl get nodes -l type=kwok \
+    -o jsonpath='{range .items[?(@.spec.unschedulable==true)]}{.metadata.name}{"\n"}{end}')"
+  [ -z "$nodes" ] && return 0
+
+  while IFS= read -r node; do
+    [ -z "$node" ] && continue
+    # Any non-DaemonSet, non-terminating pod means the drain is not finished.
+    local blockers
+    blockers="$(kubectl get pods --all-namespaces \
+      --field-selector spec.nodeName="$node" -o json 2>/dev/null |
+      python3 -c '
+import json,sys
+d=json.load(sys.stdin)
+n=0
+for p in d.get("items",[]):
+    if p.get("metadata",{}).get("deletionTimestamp"): continue
+    owners=[o.get("kind") for o in p.get("metadata",{}).get("ownerReferences",[])]
+    if "DaemonSet" in owners: continue
+    n+=1
+print(n)')"
+    if [ "$blockers" = "0" ]; then
+      bold "fabric-autoscaler: removing drained node $node"
+      kubectl delete node "$node" --wait=false
+    fi
+  done <<< "$nodes"
+}
+
+if [ "${1:-}" = "--watch" ]; then
+  bold "fabric-autoscaler: watching for drained kwok nodes (Ctrl-C to stop)"
+  while true; do pass; sleep 20; done
+else
+  pass
+fi

--- a/internal/api/rest/history.go
+++ b/internal/api/rest/history.go
@@ -1,0 +1,84 @@
+package rest
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/atedgimo/k8s-dencer/internal/store"
+)
+
+// History: the cluster's timeline, assembled server-side into chart-ready
+// series. Everything here was already being recorded — plan summaries, the
+// reclamation ledger, run outcomes, and (new) the per-cycle samples — this
+// endpoint is the first thing that reads them as a line through time rather
+// than a moment.
+func (s *Server) handleHistory(w http.ResponseWriter, r *http.Request) {
+	hours := 168
+	if h := r.URL.Query().Get("hours"); h != "" {
+		v, err := strconv.Atoi(h)
+		if err != nil || v < 1 || v > 24*31 {
+			writeError(w, http.StatusBadRequest, "hours must be between 1 and 744")
+			return
+		}
+		hours = v
+	}
+	since := time.Now().Add(-time.Duration(hours) * time.Hour)
+
+	samples := []store.Sample{}
+	if ts, ok := s.store.(store.SampleStore); ok {
+		got, err := ts.Samples(r.Context(), since)
+		if err != nil {
+			s.fail(w, err)
+			return
+		}
+		samples = got
+	}
+
+	// Plan summaries: List is newest-first and window-agnostic; filter here.
+	plansOut := []map[string]any{}
+	if sums, err := s.store.List(r.Context(), 200); err == nil {
+		for _, p := range sums {
+			if p.GeneratedAt.After(since) {
+				plansOut = append(plansOut, map[string]any{
+					"id": p.ID, "generatedAt": p.GeneratedAt,
+					"nodesBefore": p.NodesBefore, "nodesAfter": p.NodesAfter,
+				})
+			}
+		}
+	}
+
+	recl := []store.Reclamation{}
+	if tracker, ok := s.store.(store.ReclamationStore); ok {
+		if got, err := tracker.Reclamations(r.Context(), 500); err == nil {
+			for _, rr := range got {
+				if rr.DrainedAt.After(since) || (rr.ResolvedAt != nil && rr.ResolvedAt.After(since)) {
+					recl = append(recl, rr)
+				}
+			}
+		}
+	}
+
+	runsOut := []map[string]any{}
+	if s.runs != nil {
+		if got, err := s.runs.RecentRuns(r.Context(), 200); err == nil {
+			for _, run := range got {
+				if run.FinishedAt == nil || run.FinishedAt.Before(since) {
+					continue
+				}
+				runsOut = append(runsOut, map[string]any{
+					"id": run.ID, "status": run.Status, "mode": run.Mode,
+					"dryRun": run.DryRun, "finishedAt": run.FinishedAt,
+				})
+			}
+		}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"hours":        hours,
+		"samples":      samples,
+		"plans":        plansOut,
+		"reclamations": recl,
+		"runs":         runsOut,
+	})
+}

--- a/internal/api/rest/rest.go
+++ b/internal/api/rest/rest.go
@@ -121,6 +121,7 @@ func (s *Server) Routes(mux *http.ServeMux) {
 	read("/api/v1/preflight", s.handlePreflight)
 	read("/api/v1/resilience", s.handleResilience)
 	read("/api/v1/rightsizing", s.handleRightsizing)
+	read("/api/v1/history", s.handleHistory)
 	// A simulation is a read: it mutates a copy of a stored snapshot and
 	// touches nothing, so it carries the read grant, not the execute one —
 	// registered directly because the read() helper prepends GET.

--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -90,6 +90,18 @@ func (p *Publisher) Cycle(ctx context.Context) {
 	allocatable, requested := snap.Totals()
 	cpu, mem, pods := requested.Ratio(allocatable)
 
+	// Summed observed usage, zero when unmeasured — the sample records
+	// HasUsage so zero can never masquerade as idle.
+	var usedCPU, usedMem int64
+	if snap.HasUsageData {
+		for i := range snap.Nodes {
+			if u := snap.Nodes[i].Usage; u != nil {
+				usedCPU += u.MilliCPU
+				usedMem += u.MemoryBytes
+			}
+		}
+	}
+
 	occupied := 0
 	for _, n := range snap.Nodes {
 		if !snap.RequestedOnNode(n.Name).IsZero() {
@@ -173,6 +185,32 @@ func (p *Publisher) Cycle(ctx context.Context) {
 	p.Metrics.NodesReclaimed.Set(float64(plan.ReclaimedNodes()))
 	p.Metrics.PlanProduced(time.Now())
 	p.Metrics.PlanCycleTime.Observe(time.Since(cycleStart).Seconds())
+
+	// One point on the timeline, every cycle — dedup included, because a
+	// steady cluster still has a timeline and the History view exists to
+	// draw it. Failures degrade to a gap in the chart, never to a stopped
+	// planner.
+	if ts, ok := p.DB.(store.SampleStore); ok {
+		at := snap.TakenAt
+		if at.IsZero() {
+			// The collector always stamps TakenAt; a zero here (synthetic
+			// snapshots, a future source that forgets) must not write a row
+			// in year one that every range query then misses.
+			at = time.Now().UTC()
+		}
+		if err := ts.SaveSample(ctx, store.Sample{
+			TakenAt: at, Nodes: len(snap.Nodes), Pods: len(snap.Pods),
+			CPUReqMilli: requested.MilliCPU, CPUAllocMilli: allocatable.MilliCPU,
+			MemReqBytes: requested.MemoryBytes, MemAllocBytes: allocatable.MemoryBytes,
+			CPUUsedMilli: usedCPU, MemUsedBytes: usedMem, HasUsage: snap.HasUsageData,
+			Reclaimable: plan.ReclaimedNodes(),
+		}); err != nil {
+			p.Log.Warn("saving timeline sample failed", "error", err)
+		}
+		if pruned, err := ts.PruneSamples(ctx, time.Now().Add(-30*24*time.Hour)); err == nil && pruned > 0 {
+			p.Log.Info("pruned timeline", "removed", pruned)
+		}
+	}
 
 	// The planner is the only component watching nodes continuously, so it is
 	// the one that can tell whether a node the executor drained was actually

--- a/internal/publish/publish_test.go
+++ b/internal/publish/publish_test.go
@@ -78,8 +78,12 @@ func openStore(t *testing.T) store.Store {
 func snapshot(t *testing.T) *model.ClusterSnapshot {
 	t.Helper()
 	opts := model.DefaultSynthetic(8)
-	// Old enough that minNodeAge does not empty the plan.
 	snap := model.Synthesize(opts)
+	// The synthetic fixture stamps a fixed 2025 TakenAt. Restamp to now:
+	// the timeline's 30-day retention would otherwise prune each sample the
+	// moment the cycle that wrote it finishes — which is exactly what
+	// happened the first time this ran, and the prune log confessed.
+	snap.TakenAt = time.Now().UTC()
 	return snap
 }
 
@@ -210,5 +214,30 @@ func TestReclamationsResolveOnAnUnchangedCycle(t *testing.T) {
 	}
 	if !found {
 		t.Error("the gone node was not recorded as reclaimed")
+	}
+}
+
+// The timeline gains a point on EVERY cycle, dedup included — a steady
+// cluster still has a timeline, and the History view exists to draw it.
+func TestEveryCycleLandsOnTheTimeline(t *testing.T) {
+	db := openStore(t)
+	pub := newPublisher(t, steadySource{snapshot(t)}, db)
+
+	pub.Cycle(t.Context())
+	pub.Cycle(t.Context()) // the dedup path
+
+	ts, ok := db.(store.SampleStore)
+	if !ok {
+		t.Fatal("sqlite store no longer implements SampleStore")
+	}
+	samples, err := ts.Samples(t.Context(), time.Now().Add(-time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(samples) != 2 {
+		t.Fatalf("2 cycles produced %d timeline points; the dedup path is skipping the timeline", len(samples))
+	}
+	if samples[0].Nodes == 0 || samples[0].CPUAllocMilli == 0 {
+		t.Error("a sample with zero estate is a chart that lies about an empty cluster")
 	}
 }

--- a/internal/store/execution.go
+++ b/internal/store/execution.go
@@ -161,6 +161,10 @@ type ExecutionStore interface {
 	// RunByID returns one run.
 	RunByID(ctx context.Context, runID string) (Run, error)
 
+	// RecentRuns returns the newest runs regardless of plan, newest first —
+	// the History view's markers.
+	RecentRuns(ctx context.Context, limit int) ([]Run, error)
+
 	// Events returns a run's audit trail in order.
 	Events(ctx context.Context, runID string) ([]RunEvent, error)
 

--- a/internal/store/sqlite/execution.go
+++ b/internal/store/sqlite/execution.go
@@ -148,6 +148,30 @@ func (s *Store) ActiveRun(ctx context.Context) (store.Run, error) {
 	return scanRun(row)
 }
 
+// RecentRuns lists the newest runs regardless of plan, newest first.
+func (s *Store) RecentRuns(ctx context.Context, limit int) ([]store.Run, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, plan_id, steps, dry_run, status, actor, actor_groups,
+		       requested_at, started_at, finished_at, worker, summary, mode, envelope, node
+		FROM runs ORDER BY requested_at DESC, rowid DESC LIMIT ?`, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	var out []store.Run
+	for rows.Next() {
+		run, err := scanRun(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, run)
+	}
+	return out, rows.Err()
+}
+
 // RunsForPlan lists runs against a plan, newest first.
 func (s *Store) RunsForPlan(ctx context.Context, planID string, limit int) ([]store.Run, error) {
 	if limit <= 0 {

--- a/internal/store/sqlite/samples.go
+++ b/internal/store/sqlite/samples.go
@@ -1,0 +1,63 @@
+package sqlite
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/atedgimo/k8s-dencer/internal/store"
+)
+
+func (s *Store) SaveSample(ctx context.Context, sm store.Sample) error {
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO samples (taken_at, nodes, pods,
+			cpu_req_milli, cpu_alloc_milli, mem_req_bytes, mem_alloc_bytes,
+			cpu_used_milli, mem_used_bytes, has_usage, reclaimable)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		sm.TakenAt.UTC().Format(time.RFC3339Nano), sm.Nodes, sm.Pods,
+		sm.CPUReqMilli, sm.CPUAllocMilli, sm.MemReqBytes, sm.MemAllocBytes,
+		sm.CPUUsedMilli, sm.MemUsedBytes, boolToInt(sm.HasUsage), sm.Reclaimable)
+	if err != nil {
+		return fmt.Errorf("save sample: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) Samples(ctx context.Context, since time.Time) ([]store.Sample, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT taken_at, nodes, pods,
+		       cpu_req_milli, cpu_alloc_milli, mem_req_bytes, mem_alloc_bytes,
+		       cpu_used_milli, mem_used_bytes, has_usage, reclaimable
+		FROM samples WHERE taken_at >= ? ORDER BY taken_at`,
+		since.UTC().Format(time.RFC3339Nano))
+	if err != nil {
+		return nil, fmt.Errorf("list samples: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := []store.Sample{}
+	for rows.Next() {
+		var sm store.Sample
+		var takenAt string
+		var hasUsage int
+		if err := rows.Scan(&takenAt, &sm.Nodes, &sm.Pods,
+			&sm.CPUReqMilli, &sm.CPUAllocMilli, &sm.MemReqBytes, &sm.MemAllocBytes,
+			&sm.CPUUsedMilli, &sm.MemUsedBytes, &hasUsage, &sm.Reclaimable); err != nil {
+			return nil, err
+		}
+		sm.TakenAt = parseTime(takenAt)
+		sm.HasUsage = hasUsage != 0
+		out = append(out, sm)
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) PruneSamples(ctx context.Context, before time.Time) (int, error) {
+	res, err := s.db.ExecContext(ctx, `DELETE FROM samples WHERE taken_at < ?`,
+		before.UTC().Format(time.RFC3339Nano))
+	if err != nil {
+		return 0, fmt.Errorf("prune samples: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	return int(n), nil
+}

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -56,7 +56,7 @@ func Open(path string) (*Store, error) {
 // Close releases the database handle.
 func (s *Store) Close() error { return s.db.Close() }
 
-const schemaVersion = 6
+const schemaVersion = 7
 
 // Migrate creates or upgrades the schema.
 func (s *Store) Migrate(ctx context.Context) error {
@@ -102,6 +102,11 @@ func (s *Store) Migrate(ctx context.Context) error {
 	if current < 6 {
 		if _, err := tx.ExecContext(ctx, schemaV6); err != nil {
 			return fmt.Errorf("apply schema v6: %w", err)
+		}
+	}
+	if current < 7 {
+		if _, err := tx.ExecContext(ctx, schemaV7); err != nil {
+			return fmt.Errorf("apply schema v7: %w", err)
 		}
 	}
 
@@ -240,6 +245,25 @@ ALTER TABLE reclamations ADD COLUMN mem_bytes INTEGER NOT NULL DEFAULT 0;
 // Schema v6 — guarded drain: a run can target one named node.
 const schemaV6 = `
 ALTER TABLE runs ADD COLUMN node TEXT NOT NULL DEFAULT '';
+`
+
+// Schema v7 — the timeline. One small row per publish cycle; pruned to a
+// window by the planner. Indexed on taken_at because every read is a range.
+const schemaV7 = `
+CREATE TABLE IF NOT EXISTS samples (
+    taken_at        TEXT NOT NULL,
+    nodes           INTEGER NOT NULL,
+    pods            INTEGER NOT NULL,
+    cpu_req_milli   INTEGER NOT NULL,
+    cpu_alloc_milli INTEGER NOT NULL,
+    mem_req_bytes   INTEGER NOT NULL,
+    mem_alloc_bytes INTEGER NOT NULL,
+    cpu_used_milli  INTEGER NOT NULL,
+    mem_used_bytes  INTEGER NOT NULL,
+    has_usage       INTEGER NOT NULL,
+    reclaimable     INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS samples_taken_at ON samples (taken_at);
 `
 
 // Save persists a record unless it duplicates the latest plan.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -188,3 +188,38 @@ type Store interface {
 
 	Close() error
 }
+
+// Sample is one point on the cluster's timeline, written by the planner every
+// publish cycle. Small on purpose — ten numbers — because it is written every
+// resync forever, and because trends need totals, not inventories: the full
+// snapshot already exists for the moment anyone wants detail.
+type Sample struct {
+	TakenAt time.Time `json:"takenAt"`
+	Nodes   int       `json:"nodes"`
+	Pods    int       `json:"pods"`
+
+	CPUReqMilli   int64 `json:"cpuReqMilli"`
+	CPUAllocMilli int64 `json:"cpuAllocMilli"`
+	MemReqBytes   int64 `json:"memReqBytes"`
+	MemAllocBytes int64 `json:"memAllocBytes"`
+
+	// Zero when no usage source is configured — which is "unmeasured", never
+	// "idle". Consumers must check HasUsage before drawing conclusions.
+	CPUUsedMilli int64 `json:"cpuUsedMilli"`
+	MemUsedBytes int64 `json:"memUsedBytes"`
+	HasUsage     bool  `json:"hasUsage"`
+
+	// Reclaimable is the plan's answer at this moment: how many nodes the
+	// planner would free. The one series that tells the product's own story.
+	Reclaimable int `json:"reclaimable"`
+}
+
+// SampleStore persists the timeline. Implemented by the SQLite store;
+// optional the same way ReclamationStore is.
+type SampleStore interface {
+	SaveSample(ctx context.Context, s Sample) error
+	// Samples returns points at or after since, oldest first.
+	Samples(ctx context.Context, since time.Time) ([]Sample, error)
+	// PruneSamples removes points older than before, returning how many.
+	PruneSamples(ctx context.Context, before time.Time) (int, error)
+}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -8,7 +8,8 @@ import { SignIn } from "./components/SignIn";
 import StepLedger from "./components/StepLedger";
 import Verdict from "./components/Verdict";
 import AppBar from "./components/AppBar";
-import { FieldView, defaultView, rememberView, storedView } from "./view";
+import History from "./components/History";
+import { FieldView, Surface, defaultView, rememberView, storedView } from "./view";
 import { authInfo, token as tokenStore } from "./auth";
 import { onRenewed } from "./oidc";
 import { runtimeConfig } from "./runtime-config";
@@ -58,6 +59,10 @@ export default function App() {
   const [focusedRating, setFocusedRating] = useState<Impact | null>(null);
   const [pending, setPending] = useState<{ steps: PlanStep[]; dryRun: boolean } | null>(null);
   const [convergeOpen, setConvergeOpen] = useState(false);
+  // Which top-level surface is showing. Deliberately not persisted: History
+  // is a place you visit, and reopening the app on it instead of the field
+  // would bury the thing the product is for.
+  const [surface, setSurface] = useState<Surface>("field");
   const lastToggled = useRef<number | null>(null);
 
   const planId = state.status === "ready" ? state.plan.plan.id : null;
@@ -176,6 +181,8 @@ export default function App() {
           setViewPref(v);
           rememberView(v);
         }}
+        surface={surface}
+        onSurface={setSurface}
         clusterLabel={server?.clusterLabel}
         identity={server?.identity}
         onSignOut={handleSignOut}
@@ -245,6 +252,10 @@ export default function App() {
           <RunTrail state={run.state} onDismiss={run.dismiss} />
 
           <main className="workspace">
+            {surface === "history" ? (
+              <History />
+            ) : (
+              <>
             <PackingField
               view={view}
               awaiting={reclamations.stats.awaiting}
@@ -285,6 +296,8 @@ export default function App() {
                 onSelectStep={handleSelectStep}
               />
             </aside>
+              </>
+            )}
           </main>
 
           <Scrubber

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -140,6 +140,37 @@ export interface StepDetail {
   constraints: PodConstraints[];
 }
 
+/** One point on the planner's timeline. Mirrors store.Sample. */
+export interface HistorySample {
+  takenAt: string;
+  nodes: number;
+  pods: number;
+  cpuReqMilli: number;
+  cpuAllocMilli: number;
+  memReqBytes: number;
+  memAllocBytes: number;
+  cpuUsedMilli: number;
+  memUsedBytes: number;
+  hasUsage: boolean;
+  reclaimable: number;
+}
+
+export interface HistoryRunMarker {
+  id: string;
+  status: RunStatus;
+  mode?: string;
+  dryRun: boolean;
+  finishedAt?: string;
+}
+
+export interface HistoryResponse {
+  hours: number;
+  samples: HistorySample[];
+  plans: Array<{ id: string; generatedAt: string; nodesBefore: number; nodesAfter: number }>;
+  reclamations: Reclamation[];
+  runs: HistoryRunMarker[];
+}
+
 const base = () => runtimeConfig().apiBaseUrl;
 
 /** ApiError distinguishes "nothing planned yet" from a real failure — a fresh
@@ -273,6 +304,9 @@ export interface Reclamation {
   step?: number;
   resolvedAt?: string;
   outcome?: "reclaimed" | "returned";
+  /** Allocatable captured at drain time — the ledger's measured inputs. */
+  cpuMilli?: number;
+  memBytes?: number;
 }
 
 export interface ReclamationsResponse {
@@ -366,6 +400,10 @@ export const api = {
       maxImpact,
       dryRun,
     }),
+
+  /** The cluster's timeline, chart-ready. */
+  history: (hours: number, signal?: AbortSignal) =>
+    get<HistoryResponse>(`/api/v1/history?hours=${hours}`, signal),
 
   run: (runId: string, signal?: AbortSignal) => get<RunDetail>(`/api/v1/runs/${runId}`, signal),
 

--- a/ui/src/components/AppBar.tsx
+++ b/ui/src/components/AppBar.tsx
@@ -17,7 +17,7 @@
 
 import { useState } from "react";
 import { Theme, applyTheme, storedTheme } from "../theme";
-import { FieldView, VIEW_LABELS } from "../view";
+import { FieldView, Surface, VIEW_LABELS } from "../view";
 
 interface Props {
   /** Operator-set. Empty renders nothing rather than a guess. */
@@ -27,9 +27,11 @@ interface Props {
   onSignOut?: () => void;
   view?: FieldView;
   onView?: (v: FieldView) => void;
+  surface?: Surface;
+  onSurface?: (s: Surface) => void;
 }
 
-export default function AppBar({ clusterLabel, identity, onSignOut, view, onView }: Props) {
+export default function AppBar({ clusterLabel, identity, onSignOut, view, onView, surface, onSurface }: Props) {
   return (
     <header className="appbar">
       <div className="appbar-brand">
@@ -78,13 +80,30 @@ export default function AppBar({ clusterLabel, identity, onSignOut, view, onView
               <button
                 key={v}
                 type="button"
-                className={"viewswitch-btn" + (v === view ? " is-on" : "")}
-                aria-pressed={v === view}
-                onClick={() => onView(v)}
+                className={"viewswitch-btn" + (v === view && surface !== "history" ? " is-on" : "")}
+                aria-pressed={v === view && surface !== "history"}
+                onClick={() => {
+                  onSurface?.("field");
+                  onView(v);
+                }}
               >
                 {VIEW_LABELS[v]}
               </button>
             ))}
+            {/* History sits in the same switch because it is the same
+                gesture — "show me the cluster differently" — even though it
+                is a different axis underneath (a question about time, not a
+                way of drawing nodes). */}
+            {onSurface && (
+              <button
+                type="button"
+                className={"viewswitch-btn" + (surface === "history" ? " is-on" : "")}
+                aria-pressed={surface === "history"}
+                onClick={() => onSurface("history")}
+              >
+                History
+              </button>
+            )}
           </div>
         )}
         <ThemeToggle />

--- a/ui/src/components/History.tsx
+++ b/ui/src/components/History.tsx
@@ -1,0 +1,322 @@
+import { useEffect, useMemo, useState } from "react";
+import { api, formatBytes, formatCPU, HistoryResponse } from "../api";
+
+/**
+ * The cluster's timeline — the first surface that reads what the product has
+ * always recorded as a line instead of a moment.
+ *
+ * Three bands, top to bottom in the order of the product's own argument:
+ * what the estate is (nodes, and how many the plan would free), what was
+ * actually returned (the ledger, cumulative and measured), and what the
+ * machines really do versus what they ask for (requests vs usage, only when
+ * measured). Run markers sit on the ledger band because runs are what turn
+ * the first band's potential into the second band's fact.
+ *
+ * Hand-drawn SVG, no chart library: the bundle stays honest and the charts
+ * obey the house rules exactly — ink is achromatic, the only colour on this
+ * page is a run marker's rating, which already means risk everywhere else.
+ */
+
+const RANGES = [
+  { label: "24h", hours: 24 },
+  { label: "7d", hours: 168 },
+  { label: "30d", hours: 720 },
+] as const;
+
+export default function History() {
+  const [hours, setHours] = useState<number>(24);
+  const [data, setData] = useState<HistoryResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = () => {
+      api
+        .history(hours)
+        .then((d) => {
+          if (!cancelled) {
+            setData(d);
+            setError(null);
+          }
+        })
+        .catch((e) => {
+          if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+        });
+    };
+    load();
+    const t = setInterval(load, 30_000);
+    return () => {
+      cancelled = true;
+      clearInterval(t);
+    };
+  }, [hours]);
+
+  return (
+    <div className="history">
+      <div className="history-head">
+        <span className="eyebrow">the cluster, over time</span>
+        <div className="history-ranges" role="group" aria-label="Time range">
+          {RANGES.map((r) => (
+            <button
+              key={r.hours}
+              type="button"
+              className={"history-range" + (r.hours === hours ? " is-on" : "")}
+              onClick={() => setHours(r.hours)}
+            >
+              {r.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {error && <p className="history-empty">Could not load the timeline: {error}</p>}
+      {data && data.samples.length < 2 && !error && (
+        <p className="history-empty">
+          The timeline needs a few minutes of samples before there is a line to draw. The planner
+          writes one point every resync; leave this open.
+        </p>
+      )}
+      {data && data.samples.length >= 2 && (
+        <>
+          <EstateBand data={data} />
+          <LedgerBand data={data} />
+          <UsageBand data={data} />
+        </>
+      )}
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------- shared svg */
+
+const W = 960;
+const H = 180;
+const PAD = { l: 44, r: 12, t: 14, b: 22 };
+
+interface Scale {
+  x: (t: number) => number;
+  y: (v: number) => number;
+  t0: number;
+  t1: number;
+  vMax: number;
+}
+
+function makeScale(times: number[], maxValue: number): Scale {
+  const t0 = Math.min(...times);
+  const t1 = Math.max(...times);
+  const span = Math.max(1, t1 - t0);
+  const vMax = Math.max(1, maxValue);
+  return {
+    x: (t) => PAD.l + ((t - t0) / span) * (W - PAD.l - PAD.r),
+    y: (v) => H - PAD.b - (v / vMax) * (H - PAD.t - PAD.b),
+    t0,
+    t1,
+    vMax,
+  };
+}
+
+function linePath(pts: Array<[number, number]>): string {
+  return pts.map(([x, y], i) => `${i === 0 ? "M" : "L"}${x.toFixed(1)},${y.toFixed(1)}`).join(" ");
+}
+
+function timeTicks(s: Scale): Array<{ x: number; label: string }> {
+  const out: Array<{ x: number; label: string }> = [];
+  const span = s.t1 - s.t0;
+  for (let i = 0; i <= 4; i++) {
+    const t = s.t0 + (span * i) / 4;
+    const d = new Date(t);
+    const label =
+      span > 36e5 * 48
+        ? `${d.getMonth() + 1}/${d.getDate()}`
+        : `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+    out.push({ x: s.x(t), label });
+  }
+  return out;
+}
+
+function Grid({ s, yLabel }: { s: Scale; yLabel: (v: number) => string }) {
+  return (
+    <g className="chart-grid" aria-hidden="true">
+      {[0.25, 0.5, 0.75, 1].map((f) => (
+        <g key={f}>
+          <line x1={PAD.l} x2={W - PAD.r} y1={s.y(s.vMax * f)} y2={s.y(s.vMax * f)} />
+          <text x={PAD.l - 6} y={s.y(s.vMax * f) + 3} textAnchor="end" className="chart-ylabel num">
+            {yLabel(s.vMax * f)}
+          </text>
+        </g>
+      ))}
+      {timeTicks(s).map((t) => (
+        <text key={t.x} x={t.x} y={H - 6} textAnchor="middle" className="chart-xlabel num">
+          {t.label}
+        </text>
+      ))}
+    </g>
+  );
+}
+
+/* ---------------------------------------------------------------- estate */
+
+function EstateBand({ data }: { data: HistoryResponse }) {
+  const { s, nodesPath, reclaimArea, latest } = useMemo(() => {
+    const pts = data.samples.map((p) => ({ t: Date.parse(p.takenAt), ...p }));
+    const s = makeScale(
+      pts.map((p) => p.t),
+      Math.max(...pts.map((p) => p.nodes)),
+    );
+    const nodesPath = linePath(pts.map((p) => [s.x(p.t), s.y(p.nodes)]));
+    // Reclaimable drawn as the shaded top slice of the estate: the part of
+    // the fleet the plan says is not needed.
+    const upper = pts.map((p) => [s.x(p.t), s.y(p.nodes)] as [number, number]);
+    const lower = pts
+      .map((p) => [s.x(p.t), s.y(Math.max(0, p.nodes - p.reclaimable))] as [number, number])
+      .reverse();
+    const reclaimArea = linePath(upper) + " " + linePath(lower).replace(/^M/, "L") + " Z";
+    return { s, nodesPath, reclaimArea, latest: pts[pts.length - 1] };
+  }, [data]);
+
+  return (
+    <section className="history-band">
+      <header className="history-band-head">
+        <h2 className="history-band-title">Estate</h2>
+        <span className="history-band-now num">
+          {latest.nodes} nodes · {latest.reclaimable} reclaimable now
+        </span>
+      </header>
+      <svg viewBox={`0 0 ${W} ${H}`} role="img" aria-label="Nodes and reclaimable over time">
+        <Grid s={s} yLabel={(v) => `${Math.round(v)}`} />
+        <path className="chart-area" d={reclaimArea} />
+        <path className="chart-line" d={nodesPath} />
+      </svg>
+      <p className="history-band-note">
+        The shaded slice is what the plan would free — the gap between the fleet you run and the
+        fleet you need.
+      </p>
+    </section>
+  );
+}
+
+/* ---------------------------------------------------------------- ledger */
+
+function LedgerBand({ data }: { data: HistoryResponse }) {
+  const model = useMemo(() => {
+    const events = data.reclamations
+      .filter((r) => r.outcome === "reclaimed" && r.resolvedAt)
+      .map((r) => ({ t: Date.parse(r.resolvedAt as string), cpu: r.cpuMilli ?? 0 }))
+      .sort((a, b) => a.t - b.t);
+    const t0 = data.samples.length ? Date.parse(data.samples[0].takenAt) : Date.now();
+    const t1 = data.samples.length
+      ? Date.parse(data.samples[data.samples.length - 1].takenAt)
+      : Date.now();
+    let cum = 0;
+    const steps: Array<{ t: number; v: number }> = [{ t: t0, v: 0 }];
+    for (const e of events) {
+      if (e.t < t0) {
+        cum += e.cpu;
+        steps[0] = { t: t0, v: cum };
+        continue;
+      }
+      steps.push({ t: e.t, v: cum });
+      cum += e.cpu;
+      steps.push({ t: e.t, v: cum });
+    }
+    steps.push({ t: t1, v: cum });
+    const s = makeScale(
+      [t0, t1],
+      Math.max(1000, ...steps.map((p) => p.v)),
+    );
+    const path = linePath(steps.map((p) => [s.x(p.t), s.y(p.v)]));
+    const runs = data.runs
+      .filter((r) => r.finishedAt)
+      .map((r) => ({ ...r, t: Date.parse(r.finishedAt as string) }))
+      .filter((r) => r.t >= t0 && r.t <= t1);
+    return { s, path, cum, runs, count: events.length };
+  }, [data]);
+
+  return (
+    <section className="history-band">
+      <header className="history-band-head">
+        <h2 className="history-band-title">Ledger</h2>
+        <span className="history-band-now num">
+          {formatCPU(model.cum)} cores measured as returned
+          {model.count > 0 ? ` · ${model.count} node${model.count === 1 ? "" : "s"}` : ""}
+        </span>
+      </header>
+      <svg viewBox={`0 0 ${W} ${H}`} role="img" aria-label="Cumulative capacity returned">
+        <Grid s={model.s} yLabel={(v) => formatCPU(v)} />
+        <path className="chart-line chart-line-step" d={model.path} />
+        {/* Run markers: the moments potential became fact (or was refused).
+            The one place colour appears, because a rating already means risk. */}
+        {model.runs.map((r) => (
+          <g key={r.id} transform={`translate(${model.s.x(r.t).toFixed(1)}, ${H - PAD.b})`}>
+            <line className="chart-run-tick" y2={-(H - PAD.t - PAD.b)} />
+            <title>
+              {(r.mode || "steps") + (r.dryRun ? " (dry run)" : "") + " — " + r.status}
+            </title>
+            <text y={-4} textAnchor="middle" className={"chart-run-mark chart-run-" + r.status.toLowerCase()}>
+              {r.dryRun ? "◌" : r.status === "Succeeded" ? "●" : r.status === "Blocked" ? "■" : "✕"}
+            </text>
+          </g>
+        ))}
+      </svg>
+      <p className="history-band-note">
+        Measured, not estimated: capacity captured at drain time, counted only when the node
+        actually disappeared. Markers are runs — hollow ones were rehearsals.
+      </p>
+    </section>
+  );
+}
+
+/* ----------------------------------------------------------------- usage */
+
+function UsageBand({ data }: { data: HistoryResponse }) {
+  const measured = data.samples.filter((p) => p.hasUsage);
+  const model = useMemo(() => {
+    if (measured.length < 2) return null;
+    const pts = measured.map((p) => ({ t: Date.parse(p.takenAt), ...p }));
+    const s = makeScale(
+      pts.map((p) => p.t),
+      Math.max(...pts.map((p) => p.cpuReqMilli)),
+    );
+    return {
+      s,
+      req: linePath(pts.map((p) => [s.x(p.t), s.y(p.cpuReqMilli)])),
+      used: linePath(pts.map((p) => [s.x(p.t), s.y(p.cpuUsedMilli)])),
+      latest: pts[pts.length - 1],
+    };
+  }, [measured]);
+
+  if (!model) {
+    return (
+      <section className="history-band">
+        <header className="history-band-head">
+          <h2 className="history-band-title">Requests vs usage</h2>
+        </header>
+        <p className="history-empty">
+          No measured usage in this window. Enable it with planner.usageSource=metrics-server;
+          without measurements this band refuses to draw.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="history-band">
+      <header className="history-band-head">
+        <h2 className="history-band-title">Requests vs usage</h2>
+        <span className="history-band-now num">
+          {formatCPU(model.latest.cpuReqMilli)} requested · {formatCPU(model.latest.cpuUsedMilli)}{" "}
+          used · {formatBytes(model.latest.memReqBytes)} / {formatBytes(model.latest.memUsedBytes)}
+        </span>
+      </header>
+      <svg viewBox={`0 0 ${W} ${H}`} role="img" aria-label="Requested versus used CPU over time">
+        <Grid s={model.s} yLabel={(v) => formatCPU(v)} />
+        <path className="chart-line" d={model.req} />
+        <path className="chart-line chart-line-dim" d={model.used} />
+      </svg>
+      <p className="history-band-note">
+        The bright line is what workloads ask for — the scheduler's reality. The dim line is what
+        they measurably use. The space between them is what right-sizing recovers.
+      </p>
+    </section>
+  );
+}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -12,3 +12,4 @@
 @import "./styles/run.css";
 @import "./styles/inspector.css";
 @import "./styles/views.css";
+@import "./styles/history.css";

--- a/ui/src/styles/history.css
+++ b/ui/src/styles/history.css
@@ -1,0 +1,134 @@
+/* The History surface — the cluster over time. Ink is achromatic; the only
+   colour is a run marker's rating, which already means risk everywhere. */
+
+.history {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+  padding: var(--space-4) var(--space-5);
+  overflow-y: auto;
+}
+
+.history-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-4);
+}
+
+.history-ranges {
+  display: inline-flex;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+
+.history-range {
+  padding: var(--space-1) var(--space-3);
+  border: 0;
+  background: transparent;
+  color: var(--graphite);
+  font-size: var(--text-xs);
+  cursor: pointer;
+}
+
+.history-range.is-on {
+  background: var(--surface-3);
+  color: var(--text-primary);
+}
+
+.history-empty {
+  color: var(--graphite);
+  font-size: var(--text-sm);
+  max-width: 60ch;
+}
+
+.history-band {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface-1);
+  padding: var(--space-4);
+}
+
+.history-band-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-4);
+  margin-bottom: var(--space-3);
+}
+
+.history-band-title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: var(--text-lg);
+  font-weight: 600;
+}
+
+.history-band-now {
+  color: var(--graphite);
+  font-size: var(--text-xs);
+}
+
+.history-band svg {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.history-band-note {
+  margin: var(--space-2) 0 0;
+  color: var(--graphite-dim);
+  font-size: var(--text-2xs);
+  max-width: 72ch;
+}
+
+/* chart ink */
+.chart-grid line {
+  stroke: var(--edge-soft);
+  stroke-width: 1;
+}
+
+.chart-ylabel,
+.chart-xlabel {
+  fill: var(--graphite-dim);
+  font-size: 10px;
+}
+
+.chart-line {
+  fill: none;
+  stroke: var(--text-primary);
+  stroke-width: 1.5;
+}
+
+.chart-line-step {
+  stroke-width: 2;
+}
+
+.chart-line-dim {
+  stroke: var(--graphite);
+  stroke-dasharray: 3 3;
+}
+
+.chart-area {
+  fill: var(--graphite);
+  opacity: 0.18;
+  stroke: none;
+}
+
+.chart-run-tick {
+  stroke: var(--edge-soft);
+  stroke-width: 1;
+}
+
+.chart-run-mark {
+  font-size: 11px;
+  fill: var(--graphite);
+}
+
+/* Ratings mean risk; a run's outcome may borrow the scale it already owns. */
+.chart-run-succeeded { fill: var(--risk-green); }
+.chart-run-blocked   { fill: var(--risk-yellow); }
+.chart-run-failed    { fill: var(--risk-red); }

--- a/ui/src/view.ts
+++ b/ui/src/view.ts
@@ -25,6 +25,15 @@
 
 export type FieldView = "rack" | "wells" | "panel";
 
+/**
+ * The app's top-level surface: the field (in whichever FieldView) or the
+ * History timeline. A separate axis from FieldView on purpose — History is
+ * not a way of drawing nodes, it is a different question ("over time" rather
+ * than "right now"), and conflating the axes would make "come back from
+ * History to the view I was using" impossible.
+ */
+export type Surface = "field" | "history";
+
 const KEY = "dencer.view";
 
 /** Above this many nodes, individual pods stop being worth drawing. */


### PR DESCRIPTION
Build-order #3 — the flagship. (Stacks on #85; merge that first.)

Three bands, in the order of the product's own argument:

| Band | Shows | The honest detail |
|---|---|---|
| **Estate** | nodes over time, reclaimable slice shaded | the gap between the fleet you run and the fleet you need, as a *shape* |
| **Ledger** | cumulative capacity **measured** returned (step chart) + run markers | only moves when a node actually disappeared; rehearsal markers are hollow; Succeeded/Blocked/Failed borrow the risk scale they already own |
| **Requests vs usage** | bright = asked-for, dim = measured | refuses to draw without measurements, and says why |

Hand-drawn SVG, zero chart deps — **+2.4 kB gzipped** for the whole surface. Joins the view switch as the same gesture while staying a separate axis (`Surface`, deliberately unpersisted — reopening on History would bury the product).

Verified live: 16 samples, 8 run markers, 10 measured reclaimed events on the deployed cluster's own charts. All gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)