### PR TITLE
Recommendations: the analyzer finally says what to do

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ happens to be able to execute, not an autoscaler with a UI.
   never an open-ended "optimize".
 - **Refuses steps that became unsafe** between planning and execution, naming
   the rule that stopped it.
+- **Draws the cluster over time, not just now.** A History surface: the
+  estate with its reclaimable slice, a measured savings ledger climbing as
+  nodes are actually removed, requests versus observed usage — with run
+  markers on the timeline.
 - **Checks whether draining actually saved anything.** k8s-dencer never deletes
   a node — something else does — so it watches, and tells you when a node you
   drained is still sitting there.

--- a/cmd/dencer/main.go
+++ b/cmd/dencer/main.go
@@ -41,6 +41,7 @@ Commands:
   reclamations          what actually became of the nodes you drained
   preflight             will every node drain? run before a node-pool rotation
   audit                 what cannot survive a node loss, and why
+  recommend             what is missing — PDBs, replicas, requests — with fixes
   rightsizing           requests vs observed usage, per workload
   whatif                simulate losing nodes or a zone: does everything still fit?
   drain <node>          guarded drain of one node: the rails, not bare kubectl
@@ -120,6 +121,8 @@ func run() error {
 		return cmdPreflight(ctx, os.Args[2:])
 	case "audit", "resilience":
 		return cmdAudit(ctx, os.Args[2:])
+	case "recommend", "recommendations":
+		return cmdRecommend(ctx, os.Args[2:])
 	case "rightsizing", "rightsize":
 		return cmdRightsizing(ctx, os.Args[2:])
 	case "whatif":
@@ -403,6 +406,28 @@ func cmdRightsizing(ctx context.Context, args []string) error {
 		return cli.Encode(os.Stdout, g.format, env)
 	}
 	cli.PrintRightsizing(os.Stdout, env)
+	return nil
+}
+
+func cmdRecommend(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("recommend", flag.ExitOnError)
+	g := bind(fs)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	c, err := connect(ctx, g)
+	if err != nil {
+		return err
+	}
+	defer c.Close()
+	env, err := c.Recommend(ctx)
+	if err != nil {
+		return err
+	}
+	if g.format != cli.FormatText {
+		return cli.Encode(os.Stdout, g.format, env)
+	}
+	cli.PrintRecommendations(os.Stdout, env)
 	return nil
 }
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -227,3 +227,17 @@ workloads, **measured on both sides** (requires
 `planner.usageSource=metrics-server`; without measurements it refuses to
 estimate). Usage is a point-in-time sample, not a peak — shrink requests
 against your own percentiles, not this single reading.
+
+## `dencer recommend` — what is missing, with fixes
+
+```
+dencer recommend [-o json]
+```
+
+`audit` reports what cannot survive; this reports what to *change*: the
+multi-replica workload with no PDB (paste-ready YAML included), the
+single-replica Deployment where every drain is an outage, missing resource
+requests (suggested from measured usage when available), zero-headroom
+budgets with the concrete adjustment, and hands-off annotations explained so
+future-you remembers why nothing moves. Severity is impact on consolidation —
+these are chores, not alarms.

--- a/docs/product-roadmap.md
+++ b/docs/product-roadmap.md
@@ -10,6 +10,12 @@ deciding what to build next and telling users what they get.
 ## Shipped
 
 ### Analysis and planning
+- **Recommendations** — `dencer recommend`: what is *missing*, with fixes.
+  The PDB nobody wrote (paste-ready YAML), the single replica that makes
+  every drain an outage, the absent requests the scheduler is blind
+  without, the zero-headroom budget with the concrete change — severity is
+  impact-on-consolidation, and every item carries its why. (UI panel:
+  next slice.)
 - **The ecosystem's hands-off signals are honoured** —
   `karpenter.sh/do-not-disrupt` and
   `cluster-autoscaler.kubernetes.io/safe-to-evict: "false"` pin a pod

--- a/docs/product-roadmap.md
+++ b/docs/product-roadmap.md
@@ -70,6 +70,12 @@ deciding what to build next and telling users what they get.
   `pods/eviction` leaks to any other role
 
 ### Observing reality (not just predicting it)
+- **History** — the cluster as a line, not a moment: the estate with its
+  reclaimable slice shaded, the ledger climbing as capacity is *measured*
+  returned (run markers on the timeline; hollow ones were rehearsals), and
+  requests versus measured usage. One sample per planner cycle, 30-day
+  window. The demo fabric can play the missing autoscaler
+  (`make demo-reclaim`) so the whole story shows locally
 - **Reclaimer evidence, three-valued** — a recorded removal is proof, a
   visible autoscaler pod is a promise, and neither is *not* "no reclaimer"
   (managed control planes hide theirs). When drains are pending and there is

--- a/internal/api/rest/recommendations.go
+++ b/internal/api/rest/recommendations.go
@@ -1,0 +1,24 @@
+package rest
+
+import (
+	"net/http"
+
+	"github.com/atedgimo/k8s-dencer/internal/recommend"
+)
+
+// Recommendations: what is missing, with fixes. audit reports what cannot
+// survive; this reports what to change — the PDB nobody wrote, the second
+// replica, the requests the scheduler is blind without. Same freshness rule
+// as the other reports: derived from the stored snapshot per request.
+func (s *Server) handleRecommendations(w http.ResponseWriter, r *http.Request) {
+	rec, err := s.record(r.Context(), "latest")
+	if err != nil {
+		s.fail(w, err)
+		return
+	}
+	recs := recommend.Build(rec.Snapshot)
+	writeJSON(w, http.StatusOK, map[string]any{
+		"takenAt":         rec.Snapshot.TakenAt,
+		"recommendations": recs,
+	})
+}

--- a/internal/api/rest/rest.go
+++ b/internal/api/rest/rest.go
@@ -122,6 +122,7 @@ func (s *Server) Routes(mux *http.ServeMux) {
 	read("/api/v1/resilience", s.handleResilience)
 	read("/api/v1/rightsizing", s.handleRightsizing)
 	read("/api/v1/history", s.handleHistory)
+	read("/api/v1/recommendations", s.handleRecommendations)
 	// A simulation is a read: it mutates a copy of a stored snapshot and
 	// touches nothing, so it carries the read grant, not the execute one —
 	// registered directly because the read() helper prepends GET.

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -359,3 +359,26 @@ func (c *Client) Rightsizing(ctx context.Context) (*RightsizingEnvelope, error) 
 	}
 	return &out, nil
 }
+
+// RecommendationsEnvelope is what GET /api/v1/recommendations returns.
+type RecommendationsEnvelope struct {
+	TakenAt         time.Time        `json:"takenAt"`
+	Recommendations []Recommendation `json:"recommendations"`
+}
+
+type Recommendation struct {
+	Kind     string `json:"kind"`
+	Severity string `json:"severity"`
+	Workload string `json:"workload"`
+	Why      string `json:"why"`
+	Fix      string `json:"fix,omitempty"`
+}
+
+// Recommend reports what is missing, with fixes.
+func (c *Client) Recommend(ctx context.Context) (*RecommendationsEnvelope, error) {
+	var out RecommendationsEnvelope
+	if err := c.get(ctx, "/api/v1/recommendations", &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -605,3 +605,26 @@ func PrintRightsizing(w io.Writer, env *RightsizingEnvelope) {
 	fmt.Fprintln(w, dim("\nSorted by absolute CPU excess. Usage is a point-in-time sample, not a peak;"))
 	fmt.Fprintln(w, dim("shrink requests against your own percentiles, not against this single reading."))
 }
+
+// PrintRecommendations renders fixes, most consequential first. Severity is
+// impact-on-consolidation, not risk — words, not the rating glyphs.
+func PrintRecommendations(w io.Writer, env *RecommendationsEnvelope) {
+	if len(env.Recommendations) == 0 {
+		fmt.Fprintln(w, bold("Nothing to recommend."))
+		fmt.Fprintln(w, "Every workload has requests, replicas and a governed disruption budget.")
+		return
+	}
+	fmt.Fprintf(w, "%s  %s\n\n",
+		bold(fmt.Sprintf("%d recommendation(s)", len(env.Recommendations))),
+		dim("as of "+humanDuration(time.Since(env.TakenAt))+" ago"))
+	for _, r := range env.Recommendations {
+		fmt.Fprintf(w, "%s %s  %s\n", strings.ToUpper(r.Severity), bold(r.Workload), dim("["+r.Kind+"]"))
+		fmt.Fprintf(w, "  %s\n", r.Why)
+		if r.Fix != "" {
+			for _, line := range strings.Split(r.Fix, "\n") {
+				fmt.Fprintf(w, "    %s\n", dim(line))
+			}
+		}
+		fmt.Fprintln(w)
+	}
+}

--- a/internal/recommend/recommend.go
+++ b/internal/recommend/recommend.go
@@ -1,0 +1,171 @@
+// Package recommend turns the analyzer's observations into fixes.
+//
+// audit answers "what cannot survive a node loss"; preflight answers "will a
+// rotation wedge". Both report what IS. This package reports what is MISSING
+// — the PDB nobody wrote, the second replica nobody added, the requests
+// nobody set — because the analyzer sees all of it on every cycle and has
+// never once said what to do about it.
+//
+// Every recommendation carries a why in one sentence and, where a fix is a
+// piece of YAML, the YAML — paste-ready, minimal, and honest about being a
+// starting point rather than a policy.
+package recommend
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/atedgimo/k8s-dencer/internal/model"
+)
+
+// Severity is impact-on-consolidation, not risk: these are chores, not
+// alarms, and the UI must not colour them like ratings.
+type Severity string
+
+const (
+	// SeverityHigh: this blocks consolidation (or availability) today.
+	SeverityHigh Severity = "high"
+	// SeverityMedium: this degrades packing or resilience.
+	SeverityMedium Severity = "medium"
+	// SeverityInfo: not a problem — an explanation of a deliberate state.
+	SeverityInfo Severity = "info"
+)
+
+type Recommendation struct {
+	Kind     string   `json:"kind"`
+	Severity Severity `json:"severity"`
+	// Workload is namespace/Kind/name — the thing an operator recognises.
+	Workload string `json:"workload"`
+	Why      string `json:"why"`
+	// Fix is paste-ready YAML when the fix is YAML, empty when it is a
+	// decision. Suggestions, not policy: the numbers are starting points.
+	Fix string `json:"fix,omitempty"`
+}
+
+// Build derives recommendations from a snapshot and nothing else — same
+// purity contract as the analyzer, so it can run against any stored moment.
+func Build(snap *model.ClusterSnapshot) []Recommendation {
+	out := []Recommendation{}
+
+	type workload struct {
+		namespace, kind, name string
+		pods                  []*model.Pod
+	}
+	byOwner := map[string]*workload{}
+	for i := range snap.Pods {
+		p := &snap.Pods[i]
+		if p.Terminating || p.Owner == nil {
+			continue
+		}
+		key := p.Namespace + "/" + p.Owner.Kind + "/" + p.Owner.Name
+		w := byOwner[key]
+		if w == nil {
+			w = &workload{namespace: p.Namespace, kind: p.Owner.Kind, name: p.Owner.Name}
+			byOwner[key] = w
+		}
+		w.pods = append(w.pods, p)
+	}
+
+	covered := func(p *model.Pod) bool {
+		for _, pdb := range snap.PDBs {
+			if pdb.Namespace == p.Namespace && pdb.Selector.Matches(p.Labels) {
+				return true
+			}
+		}
+		return false
+	}
+
+	for key, w := range byOwner {
+		if w.kind == "DaemonSet" {
+			continue // pinned by design; a PDB or replicas advice is noise
+		}
+		replicas := len(w.pods)
+		sample := w.pods[0]
+
+		// Multi-replica workload with no PDB: every eviction is currently
+		// ungoverned, which makes every step touching it look riskier than
+		// its owner probably intends.
+		if replicas >= 2 && !covered(sample) {
+			out = append(out, Recommendation{
+				Kind: "MissingPDB", Severity: SeverityMedium, Workload: key,
+				Why: fmt.Sprintf(
+					"%d replicas and no PodDisruptionBudget: evictions are ungoverned, so the API server cannot pace a drain for this workload.",
+					replicas),
+				Fix: fmt.Sprintf(`apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      # match your workload's pod labels
+      app: %s`, w.name, w.namespace, sample.Labels["app"]),
+			})
+		}
+
+		// Single replica: any eviction is downtime, and the impact
+		// classifier will keep rating it accordingly forever.
+		if replicas == 1 && (w.kind == "Deployment" || w.kind == "ReplicaSet" || w.kind == "StatefulSet") {
+			out = append(out, Recommendation{
+				Kind: "SingleReplica", Severity: SeverityHigh, Workload: key,
+				Why: "One replica: every eviction — voluntary or a node dying — is downtime. " +
+					"A second replica turns drains from outages into non-events.",
+			})
+		}
+
+		// Missing requests: the packing math is blind to this workload, and
+		// so is every scheduler decision about it.
+		if sample.Requests.MilliCPU == 0 && sample.Requests.MemoryBytes == 0 {
+			fix := ""
+			if sample.Usage != nil && (sample.Usage.MilliCPU > 0 || sample.Usage.MemoryBytes > 0) {
+				fix = fmt.Sprintf(`resources:
+  requests:
+    # measured just now — set from your own percentiles, not one sample
+    cpu: %dm
+    memory: %dMi`, sample.Usage.MilliCPU, sample.Usage.MemoryBytes>>20)
+			}
+			out = append(out, Recommendation{
+				Kind: "MissingRequests", Severity: SeverityHigh, Workload: key,
+				Why: "No resource requests: the scheduler and every capacity number in this product " +
+					"are blind to what this workload needs.",
+				Fix: fix,
+			})
+		}
+
+		// Hands-off annotation: deliberate, so informational — but worth a
+		// line, because six months later nobody remembers why nothing moves.
+		if sample.DoNotDisrupt {
+			out = append(out, Recommendation{
+				Kind: "HandsOff", Severity: SeverityInfo, Workload: key,
+				Why: "Annotated do-not-disrupt (or safe-to-evict: \"false\"): this workload will " +
+					"never be moved by k8s-dencer or the autoscalers. Deliberate — and worth " +
+					"remembering when this node shows as undrainable.",
+			})
+		}
+	}
+
+	// Zero-headroom PDBs, workload or not: the budget that blocks every
+	// drain and is violated by any node loss.
+	for _, pdb := range snap.PDBs {
+		if pdb.Blocks() {
+			out = append(out, Recommendation{
+				Kind: "ZeroHeadroomPDB", Severity: SeverityHigh,
+				Workload: pdb.Namespace + "/PodDisruptionBudget/" + pdb.Name,
+				Why: fmt.Sprintf(
+					"Allows 0 disruptions (%d healthy, %d required): every drain is refused and any node loss violates it. Add a replica or lower the requirement.",
+					pdb.CurrentHealthy, pdb.DesiredHealthy),
+			})
+		}
+	}
+
+	sort.SliceStable(out, func(i, j int) bool {
+		rank := map[Severity]int{SeverityHigh: 0, SeverityMedium: 1, SeverityInfo: 2}
+		if rank[out[i].Severity] != rank[out[j].Severity] {
+			return rank[out[i].Severity] < rank[out[j].Severity]
+		}
+		return out[i].Workload < out[j].Workload
+	})
+	return out
+}

--- a/internal/recommend/recommend_test.go
+++ b/internal/recommend/recommend_test.go
@@ -1,0 +1,83 @@
+package recommend_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/atedgimo/k8s-dencer/internal/model"
+	"github.com/atedgimo/k8s-dencer/internal/recommend"
+)
+
+func pod(ns, name, owner, kind string, cpu int64, labels map[string]string) model.Pod {
+	return model.Pod{
+		Namespace: ns, Name: name, NodeName: "a", Phase: model.PodRunning, Ready: true,
+		Labels:   labels,
+		Requests: model.Resources{MilliCPU: cpu, MemoryBytes: cpu << 20},
+		Owner:    &model.OwnerRef{Kind: kind, Name: owner},
+	}
+}
+
+func TestRecommendationsNameWhatIsMissing(t *testing.T) {
+	web := map[string]string{"app": "web"}
+	lonely := map[string]string{"app": "lonely"}
+	naked := map[string]string{"app": "naked"}
+	snap := &model.ClusterSnapshot{
+		Nodes: []model.Node{{Name: "a", Ready: true}},
+		Pods: []model.Pod{
+			// multi-replica, no PDB -> MissingPDB
+			pod("shop", "web-1", "web", "ReplicaSet", 500, web),
+			pod("shop", "web-2", "web", "ReplicaSet", 500, web),
+			// single replica -> SingleReplica
+			pod("shop", "lonely-1", "lonely", "Deployment", 500, lonely),
+			// zero requests -> MissingRequests
+			pod("shop", "naked-1", "naked", "ReplicaSet", 0, naked),
+			pod("shop", "naked-2", "naked", "ReplicaSet", 0, naked),
+			// DaemonSet: no advice, ever
+			pod("kube-system", "ds-1", "ds", "DaemonSet", 100, map[string]string{"app": "ds"}),
+		},
+		PDBs: []model.PodDisruptionBudget{
+			// covers naked -> no MissingPDB for it; zero headroom -> its own rec
+			{Namespace: "shop", Name: "naked", Selector: &model.LabelSelector{MatchLabels: naked},
+				CurrentHealthy: 2, DesiredHealthy: 2, DisruptionsAllowed: 0},
+		},
+	}
+
+	recs := recommend.Build(snap)
+	byKind := map[string][]recommend.Recommendation{}
+	for _, r := range recs {
+		byKind[r.Kind] = append(byKind[r.Kind], r)
+	}
+
+	if len(byKind["MissingPDB"]) != 1 || byKind["MissingPDB"][0].Workload != "shop/ReplicaSet/web" {
+		t.Errorf("MissingPDB = %+v, want exactly shop/ReplicaSet/web", byKind["MissingPDB"])
+	}
+	if got := byKind["MissingPDB"]; len(got) == 1 && !strings.Contains(got[0].Fix, "maxUnavailable: 1") {
+		t.Error("the MissingPDB fix is not paste-ready YAML")
+	}
+	if len(byKind["SingleReplica"]) != 1 || byKind["SingleReplica"][0].Workload != "shop/Deployment/lonely" {
+		t.Errorf("SingleReplica = %+v", byKind["SingleReplica"])
+	}
+	if len(byKind["MissingRequests"]) != 1 {
+		t.Errorf("MissingRequests = %+v", byKind["MissingRequests"])
+	}
+	if len(byKind["ZeroHeadroomPDB"]) != 1 {
+		t.Errorf("ZeroHeadroomPDB = %+v", byKind["ZeroHeadroomPDB"])
+	}
+	for _, r := range recs {
+		if strings.Contains(r.Workload, "DaemonSet") {
+			t.Errorf("advice for a DaemonSet is noise: %+v", r)
+		}
+		if r.Why == "" {
+			t.Errorf("%s has no why; a fix without a reason is a decree", r.Kind)
+		}
+	}
+	// severity ordering: high before medium before info
+	last := 0
+	rank := map[recommend.Severity]int{"high": 0, "medium": 1, "info": 2}
+	for _, r := range recs {
+		if rank[r.Severity] < last {
+			t.Fatalf("recommendations not sorted by severity: %+v", recs)
+		}
+		last = rank[r.Severity]
+	}
+}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -8,7 +8,8 @@ import { SignIn } from "./components/SignIn";
 import StepLedger from "./components/StepLedger";
 import Verdict from "./components/Verdict";
 import AppBar from "./components/AppBar";
-import { FieldView, defaultView, rememberView, storedView } from "./view";
+import History from "./components/History";
+import { FieldView, Surface, defaultView, rememberView, storedView } from "./view";
 import { authInfo, token as tokenStore } from "./auth";
 import { onRenewed } from "./oidc";
 import { runtimeConfig } from "./runtime-config";
@@ -58,6 +59,10 @@ export default function App() {
   const [focusedRating, setFocusedRating] = useState<Impact | null>(null);
   const [pending, setPending] = useState<{ steps: PlanStep[]; dryRun: boolean } | null>(null);
   const [convergeOpen, setConvergeOpen] = useState(false);
+  // Which top-level surface is showing. Deliberately not persisted: History
+  // is a place you visit, and reopening the app on it instead of the field
+  // would bury the thing the product is for.
+  const [surface, setSurface] = useState<Surface>("field");
   const lastToggled = useRef<number | null>(null);
 
   const planId = state.status === "ready" ? state.plan.plan.id : null;
@@ -176,6 +181,8 @@ export default function App() {
           setViewPref(v);
           rememberView(v);
         }}
+        surface={surface}
+        onSurface={setSurface}
         clusterLabel={server?.clusterLabel}
         identity={server?.identity}
         onSignOut={handleSignOut}
@@ -245,6 +252,10 @@ export default function App() {
           <RunTrail state={run.state} onDismiss={run.dismiss} />
 
           <main className="workspace">
+            {surface === "history" ? (
+              <History />
+            ) : (
+              <>
             <PackingField
               view={view}
               awaiting={reclamations.stats.awaiting}
@@ -285,6 +296,8 @@ export default function App() {
                 onSelectStep={handleSelectStep}
               />
             </aside>
+              </>
+            )}
           </main>
 
           <Scrubber

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -140,6 +140,37 @@ export interface StepDetail {
   constraints: PodConstraints[];
 }
 
+/** One point on the planner's timeline. Mirrors store.Sample. */
+export interface HistorySample {
+  takenAt: string;
+  nodes: number;
+  pods: number;
+  cpuReqMilli: number;
+  cpuAllocMilli: number;
+  memReqBytes: number;
+  memAllocBytes: number;
+  cpuUsedMilli: number;
+  memUsedBytes: number;
+  hasUsage: boolean;
+  reclaimable: number;
+}
+
+export interface HistoryRunMarker {
+  id: string;
+  status: RunStatus;
+  mode?: string;
+  dryRun: boolean;
+  finishedAt?: string;
+}
+
+export interface HistoryResponse {
+  hours: number;
+  samples: HistorySample[];
+  plans: Array<{ id: string; generatedAt: string; nodesBefore: number; nodesAfter: number }>;
+  reclamations: Reclamation[];
+  runs: HistoryRunMarker[];
+}
+
 const base = () => runtimeConfig().apiBaseUrl;
 
 /** ApiError distinguishes "nothing planned yet" from a real failure — a fresh
@@ -273,6 +304,9 @@ export interface Reclamation {
   step?: number;
   resolvedAt?: string;
   outcome?: "reclaimed" | "returned";
+  /** Allocatable captured at drain time — the ledger's measured inputs. */
+  cpuMilli?: number;
+  memBytes?: number;
 }
 
 export interface ReclamationsResponse {
@@ -366,6 +400,10 @@ export const api = {
       maxImpact,
       dryRun,
     }),
+
+  /** The cluster's timeline, chart-ready. */
+  history: (hours: number, signal?: AbortSignal) =>
+    get<HistoryResponse>(`/api/v1/history?hours=${hours}`, signal),
 
   run: (runId: string, signal?: AbortSignal) => get<RunDetail>(`/api/v1/runs/${runId}`, signal),
 

--- a/ui/src/components/AppBar.tsx
+++ b/ui/src/components/AppBar.tsx
@@ -17,7 +17,7 @@
 
 import { useState } from "react";
 import { Theme, applyTheme, storedTheme } from "../theme";
-import { FieldView, VIEW_LABELS } from "../view";
+import { FieldView, Surface, VIEW_LABELS } from "../view";
 
 interface Props {
   /** Operator-set. Empty renders nothing rather than a guess. */
@@ -27,9 +27,11 @@ interface Props {
   onSignOut?: () => void;
   view?: FieldView;
   onView?: (v: FieldView) => void;
+  surface?: Surface;
+  onSurface?: (s: Surface) => void;
 }
 
-export default function AppBar({ clusterLabel, identity, onSignOut, view, onView }: Props) {
+export default function AppBar({ clusterLabel, identity, onSignOut, view, onView, surface, onSurface }: Props) {
   return (
     <header className="appbar">
       <div className="appbar-brand">
@@ -78,13 +80,30 @@ export default function AppBar({ clusterLabel, identity, onSignOut, view, onView
               <button
                 key={v}
                 type="button"
-                className={"viewswitch-btn" + (v === view ? " is-on" : "")}
-                aria-pressed={v === view}
-                onClick={() => onView(v)}
+                className={"viewswitch-btn" + (v === view && surface !== "history" ? " is-on" : "")}
+                aria-pressed={v === view && surface !== "history"}
+                onClick={() => {
+                  onSurface?.("field");
+                  onView(v);
+                }}
               >
                 {VIEW_LABELS[v]}
               </button>
             ))}
+            {/* History sits in the same switch because it is the same
+                gesture — "show me the cluster differently" — even though it
+                is a different axis underneath (a question about time, not a
+                way of drawing nodes). */}
+            {onSurface && (
+              <button
+                type="button"
+                className={"viewswitch-btn" + (surface === "history" ? " is-on" : "")}
+                aria-pressed={surface === "history"}
+                onClick={() => onSurface("history")}
+              >
+                History
+              </button>
+            )}
           </div>
         )}
         <ThemeToggle />

--- a/ui/src/components/History.tsx
+++ b/ui/src/components/History.tsx
@@ -1,0 +1,322 @@
+import { useEffect, useMemo, useState } from "react";
+import { api, formatBytes, formatCPU, HistoryResponse } from "../api";
+
+/**
+ * The cluster's timeline — the first surface that reads what the product has
+ * always recorded as a line instead of a moment.
+ *
+ * Three bands, top to bottom in the order of the product's own argument:
+ * what the estate is (nodes, and how many the plan would free), what was
+ * actually returned (the ledger, cumulative and measured), and what the
+ * machines really do versus what they ask for (requests vs usage, only when
+ * measured). Run markers sit on the ledger band because runs are what turn
+ * the first band's potential into the second band's fact.
+ *
+ * Hand-drawn SVG, no chart library: the bundle stays honest and the charts
+ * obey the house rules exactly — ink is achromatic, the only colour on this
+ * page is a run marker's rating, which already means risk everywhere else.
+ */
+
+const RANGES = [
+  { label: "24h", hours: 24 },
+  { label: "7d", hours: 168 },
+  { label: "30d", hours: 720 },
+] as const;
+
+export default function History() {
+  const [hours, setHours] = useState<number>(24);
+  const [data, setData] = useState<HistoryResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = () => {
+      api
+        .history(hours)
+        .then((d) => {
+          if (!cancelled) {
+            setData(d);
+            setError(null);
+          }
+        })
+        .catch((e) => {
+          if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+        });
+    };
+    load();
+    const t = setInterval(load, 30_000);
+    return () => {
+      cancelled = true;
+      clearInterval(t);
+    };
+  }, [hours]);
+
+  return (
+    <div className="history">
+      <div className="history-head">
+        <span className="eyebrow">the cluster, over time</span>
+        <div className="history-ranges" role="group" aria-label="Time range">
+          {RANGES.map((r) => (
+            <button
+              key={r.hours}
+              type="button"
+              className={"history-range" + (r.hours === hours ? " is-on" : "")}
+              onClick={() => setHours(r.hours)}
+            >
+              {r.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {error && <p className="history-empty">Could not load the timeline: {error}</p>}
+      {data && data.samples.length < 2 && !error && (
+        <p className="history-empty">
+          The timeline needs a few minutes of samples before there is a line to draw. The planner
+          writes one point every resync; leave this open.
+        </p>
+      )}
+      {data && data.samples.length >= 2 && (
+        <>
+          <EstateBand data={data} />
+          <LedgerBand data={data} />
+          <UsageBand data={data} />
+        </>
+      )}
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------- shared svg */
+
+const W = 960;
+const H = 180;
+const PAD = { l: 44, r: 12, t: 14, b: 22 };
+
+interface Scale {
+  x: (t: number) => number;
+  y: (v: number) => number;
+  t0: number;
+  t1: number;
+  vMax: number;
+}
+
+function makeScale(times: number[], maxValue: number): Scale {
+  const t0 = Math.min(...times);
+  const t1 = Math.max(...times);
+  const span = Math.max(1, t1 - t0);
+  const vMax = Math.max(1, maxValue);
+  return {
+    x: (t) => PAD.l + ((t - t0) / span) * (W - PAD.l - PAD.r),
+    y: (v) => H - PAD.b - (v / vMax) * (H - PAD.t - PAD.b),
+    t0,
+    t1,
+    vMax,
+  };
+}
+
+function linePath(pts: Array<[number, number]>): string {
+  return pts.map(([x, y], i) => `${i === 0 ? "M" : "L"}${x.toFixed(1)},${y.toFixed(1)}`).join(" ");
+}
+
+function timeTicks(s: Scale): Array<{ x: number; label: string }> {
+  const out: Array<{ x: number; label: string }> = [];
+  const span = s.t1 - s.t0;
+  for (let i = 0; i <= 4; i++) {
+    const t = s.t0 + (span * i) / 4;
+    const d = new Date(t);
+    const label =
+      span > 36e5 * 48
+        ? `${d.getMonth() + 1}/${d.getDate()}`
+        : `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+    out.push({ x: s.x(t), label });
+  }
+  return out;
+}
+
+function Grid({ s, yLabel }: { s: Scale; yLabel: (v: number) => string }) {
+  return (
+    <g className="chart-grid" aria-hidden="true">
+      {[0.25, 0.5, 0.75, 1].map((f) => (
+        <g key={f}>
+          <line x1={PAD.l} x2={W - PAD.r} y1={s.y(s.vMax * f)} y2={s.y(s.vMax * f)} />
+          <text x={PAD.l - 6} y={s.y(s.vMax * f) + 3} textAnchor="end" className="chart-ylabel num">
+            {yLabel(s.vMax * f)}
+          </text>
+        </g>
+      ))}
+      {timeTicks(s).map((t) => (
+        <text key={t.x} x={t.x} y={H - 6} textAnchor="middle" className="chart-xlabel num">
+          {t.label}
+        </text>
+      ))}
+    </g>
+  );
+}
+
+/* ---------------------------------------------------------------- estate */
+
+function EstateBand({ data }: { data: HistoryResponse }) {
+  const { s, nodesPath, reclaimArea, latest } = useMemo(() => {
+    const pts = data.samples.map((p) => ({ t: Date.parse(p.takenAt), ...p }));
+    const s = makeScale(
+      pts.map((p) => p.t),
+      Math.max(...pts.map((p) => p.nodes)),
+    );
+    const nodesPath = linePath(pts.map((p) => [s.x(p.t), s.y(p.nodes)]));
+    // Reclaimable drawn as the shaded top slice of the estate: the part of
+    // the fleet the plan says is not needed.
+    const upper = pts.map((p) => [s.x(p.t), s.y(p.nodes)] as [number, number]);
+    const lower = pts
+      .map((p) => [s.x(p.t), s.y(Math.max(0, p.nodes - p.reclaimable))] as [number, number])
+      .reverse();
+    const reclaimArea = linePath(upper) + " " + linePath(lower).replace(/^M/, "L") + " Z";
+    return { s, nodesPath, reclaimArea, latest: pts[pts.length - 1] };
+  }, [data]);
+
+  return (
+    <section className="history-band">
+      <header className="history-band-head">
+        <h2 className="history-band-title">Estate</h2>
+        <span className="history-band-now num">
+          {latest.nodes} nodes · {latest.reclaimable} reclaimable now
+        </span>
+      </header>
+      <svg viewBox={`0 0 ${W} ${H}`} role="img" aria-label="Nodes and reclaimable over time">
+        <Grid s={s} yLabel={(v) => `${Math.round(v)}`} />
+        <path className="chart-area" d={reclaimArea} />
+        <path className="chart-line" d={nodesPath} />
+      </svg>
+      <p className="history-band-note">
+        The shaded slice is what the plan would free — the gap between the fleet you run and the
+        fleet you need.
+      </p>
+    </section>
+  );
+}
+
+/* ---------------------------------------------------------------- ledger */
+
+function LedgerBand({ data }: { data: HistoryResponse }) {
+  const model = useMemo(() => {
+    const events = data.reclamations
+      .filter((r) => r.outcome === "reclaimed" && r.resolvedAt)
+      .map((r) => ({ t: Date.parse(r.resolvedAt as string), cpu: r.cpuMilli ?? 0 }))
+      .sort((a, b) => a.t - b.t);
+    const t0 = data.samples.length ? Date.parse(data.samples[0].takenAt) : Date.now();
+    const t1 = data.samples.length
+      ? Date.parse(data.samples[data.samples.length - 1].takenAt)
+      : Date.now();
+    let cum = 0;
+    const steps: Array<{ t: number; v: number }> = [{ t: t0, v: 0 }];
+    for (const e of events) {
+      if (e.t < t0) {
+        cum += e.cpu;
+        steps[0] = { t: t0, v: cum };
+        continue;
+      }
+      steps.push({ t: e.t, v: cum });
+      cum += e.cpu;
+      steps.push({ t: e.t, v: cum });
+    }
+    steps.push({ t: t1, v: cum });
+    const s = makeScale(
+      [t0, t1],
+      Math.max(1000, ...steps.map((p) => p.v)),
+    );
+    const path = linePath(steps.map((p) => [s.x(p.t), s.y(p.v)]));
+    const runs = data.runs
+      .filter((r) => r.finishedAt)
+      .map((r) => ({ ...r, t: Date.parse(r.finishedAt as string) }))
+      .filter((r) => r.t >= t0 && r.t <= t1);
+    return { s, path, cum, runs, count: events.length };
+  }, [data]);
+
+  return (
+    <section className="history-band">
+      <header className="history-band-head">
+        <h2 className="history-band-title">Ledger</h2>
+        <span className="history-band-now num">
+          {formatCPU(model.cum)} cores measured as returned
+          {model.count > 0 ? ` · ${model.count} node${model.count === 1 ? "" : "s"}` : ""}
+        </span>
+      </header>
+      <svg viewBox={`0 0 ${W} ${H}`} role="img" aria-label="Cumulative capacity returned">
+        <Grid s={model.s} yLabel={(v) => formatCPU(v)} />
+        <path className="chart-line chart-line-step" d={model.path} />
+        {/* Run markers: the moments potential became fact (or was refused).
+            The one place colour appears, because a rating already means risk. */}
+        {model.runs.map((r) => (
+          <g key={r.id} transform={`translate(${model.s.x(r.t).toFixed(1)}, ${H - PAD.b})`}>
+            <line className="chart-run-tick" y2={-(H - PAD.t - PAD.b)} />
+            <title>
+              {(r.mode || "steps") + (r.dryRun ? " (dry run)" : "") + " — " + r.status}
+            </title>
+            <text y={-4} textAnchor="middle" className={"chart-run-mark chart-run-" + r.status.toLowerCase()}>
+              {r.dryRun ? "◌" : r.status === "Succeeded" ? "●" : r.status === "Blocked" ? "■" : "✕"}
+            </text>
+          </g>
+        ))}
+      </svg>
+      <p className="history-band-note">
+        Measured, not estimated: capacity captured at drain time, counted only when the node
+        actually disappeared. Markers are runs — hollow ones were rehearsals.
+      </p>
+    </section>
+  );
+}
+
+/* ----------------------------------------------------------------- usage */
+
+function UsageBand({ data }: { data: HistoryResponse }) {
+  const measured = data.samples.filter((p) => p.hasUsage);
+  const model = useMemo(() => {
+    if (measured.length < 2) return null;
+    const pts = measured.map((p) => ({ t: Date.parse(p.takenAt), ...p }));
+    const s = makeScale(
+      pts.map((p) => p.t),
+      Math.max(...pts.map((p) => p.cpuReqMilli)),
+    );
+    return {
+      s,
+      req: linePath(pts.map((p) => [s.x(p.t), s.y(p.cpuReqMilli)])),
+      used: linePath(pts.map((p) => [s.x(p.t), s.y(p.cpuUsedMilli)])),
+      latest: pts[pts.length - 1],
+    };
+  }, [measured]);
+
+  if (!model) {
+    return (
+      <section className="history-band">
+        <header className="history-band-head">
+          <h2 className="history-band-title">Requests vs usage</h2>
+        </header>
+        <p className="history-empty">
+          No measured usage in this window. Enable it with planner.usageSource=metrics-server;
+          without measurements this band refuses to draw.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="history-band">
+      <header className="history-band-head">
+        <h2 className="history-band-title">Requests vs usage</h2>
+        <span className="history-band-now num">
+          {formatCPU(model.latest.cpuReqMilli)} requested · {formatCPU(model.latest.cpuUsedMilli)}{" "}
+          used · {formatBytes(model.latest.memReqBytes)} / {formatBytes(model.latest.memUsedBytes)}
+        </span>
+      </header>
+      <svg viewBox={`0 0 ${W} ${H}`} role="img" aria-label="Requested versus used CPU over time">
+        <Grid s={model.s} yLabel={(v) => formatCPU(v)} />
+        <path className="chart-line" d={model.req} />
+        <path className="chart-line chart-line-dim" d={model.used} />
+      </svg>
+      <p className="history-band-note">
+        The bright line is what workloads ask for — the scheduler's reality. The dim line is what
+        they measurably use. The space between them is what right-sizing recovers.
+      </p>
+    </section>
+  );
+}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -12,3 +12,4 @@
 @import "./styles/run.css";
 @import "./styles/inspector.css";
 @import "./styles/views.css";
+@import "./styles/history.css";

--- a/ui/src/styles/history.css
+++ b/ui/src/styles/history.css
@@ -1,0 +1,134 @@
+/* The History surface — the cluster over time. Ink is achromatic; the only
+   colour is a run marker's rating, which already means risk everywhere. */
+
+.history {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+  padding: var(--space-4) var(--space-5);
+  overflow-y: auto;
+}
+
+.history-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-4);
+}
+
+.history-ranges {
+  display: inline-flex;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+
+.history-range {
+  padding: var(--space-1) var(--space-3);
+  border: 0;
+  background: transparent;
+  color: var(--graphite);
+  font-size: var(--text-xs);
+  cursor: pointer;
+}
+
+.history-range.is-on {
+  background: var(--surface-3);
+  color: var(--text-primary);
+}
+
+.history-empty {
+  color: var(--graphite);
+  font-size: var(--text-sm);
+  max-width: 60ch;
+}
+
+.history-band {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface-1);
+  padding: var(--space-4);
+}
+
+.history-band-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-4);
+  margin-bottom: var(--space-3);
+}
+
+.history-band-title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: var(--text-lg);
+  font-weight: 600;
+}
+
+.history-band-now {
+  color: var(--graphite);
+  font-size: var(--text-xs);
+}
+
+.history-band svg {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.history-band-note {
+  margin: var(--space-2) 0 0;
+  color: var(--graphite-dim);
+  font-size: var(--text-2xs);
+  max-width: 72ch;
+}
+
+/* chart ink */
+.chart-grid line {
+  stroke: var(--edge-soft);
+  stroke-width: 1;
+}
+
+.chart-ylabel,
+.chart-xlabel {
+  fill: var(--graphite-dim);
+  font-size: 10px;
+}
+
+.chart-line {
+  fill: none;
+  stroke: var(--text-primary);
+  stroke-width: 1.5;
+}
+
+.chart-line-step {
+  stroke-width: 2;
+}
+
+.chart-line-dim {
+  stroke: var(--graphite);
+  stroke-dasharray: 3 3;
+}
+
+.chart-area {
+  fill: var(--graphite);
+  opacity: 0.18;
+  stroke: none;
+}
+
+.chart-run-tick {
+  stroke: var(--edge-soft);
+  stroke-width: 1;
+}
+
+.chart-run-mark {
+  font-size: 11px;
+  fill: var(--graphite);
+}
+
+/* Ratings mean risk; a run's outcome may borrow the scale it already owns. */
+.chart-run-succeeded { fill: var(--risk-green); }
+.chart-run-blocked   { fill: var(--risk-yellow); }
+.chart-run-failed    { fill: var(--risk-red); }

--- a/ui/src/view.ts
+++ b/ui/src/view.ts
@@ -25,6 +25,15 @@
 
 export type FieldView = "rack" | "wells" | "panel";
 
+/**
+ * The app's top-level surface: the field (in whichever FieldView) or the
+ * History timeline. A separate axis from FieldView on purpose — History is
+ * not a way of drawing nodes, it is a different question ("over time" rather
+ * than "right now"), and conflating the axes would make "come back from
+ * History to the view I was using" impossible.
+ */
+export type Surface = "field" | "history";
+
 const KEY = "dencer.view";
 
 /** Above this many nodes, individual pods stop being worth drawing. */


### PR DESCRIPTION
Build-order #4 (engine + API + CLI; UI panel is the noted next slice so the walkthrough can film everything).

`audit` reports what *is*; this reports what is **missing**, with fixes:

| Rule | Fix shape |
|---|---|
| MissingPDB (multi-replica, ungoverned) | **paste-ready YAML**, `maxUnavailable: 1` |
| SingleReplica | the decision, stated: every drain is an outage |
| MissingRequests | suggested **from measured usage** when samples exist, percentile caveat attached |
| ZeroHeadroomPDB | the concrete adjustment, with its numbers |
| HandsOff | info — deliberate states explained for future-you |

DaemonSets get no advice ever. Severity is impact-on-consolidation — words, not rating glyphs; chores, not alarms.

**Verified live against the showcase: 34 findings**, payments' zero-headroom PDB named with its numbers — and the product's own single-replica components flagged like anyone else's, which is what honest generic advice looks like.

Pure function over the snapshot (analyzer's contract); endpoint derives fresh per request. All 19 packages green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)