### PR TITLE
UI redesign PR 3/7 — run screens: rehearsal, execution, halted by the guard

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -13,6 +13,7 @@ import Hero from "./components/review/Hero";
 import StepList from "./components/review/StepList";
 import StepDetail from "./components/review/StepDetail";
 import ReviewFooter from "./components/review/ReviewFooter";
+import RunScreen from "./components/run/RunScreen";
 import { FieldView, Surface, VIEW_LABELS, defaultView, rememberView, storedView } from "./view";
 import { authInfo, token as tokenStore } from "./auth";
 import { onRenewed } from "./oidc";
@@ -279,6 +280,16 @@ export default function App() {
         clusterLabel={server?.clusterLabel}
         identity={server?.identity}
         onSignOut={handleSignOut}
+        runNote={
+          run.state.status === "active"
+            ? {
+                label: run.state.run.dryRun ? "Rehearsing" : "Run in progress",
+                value: `${run.state.events.filter((e) => e.action === "Drained").length} of ${run.state.run.steps.length} steps done`,
+              }
+            : run.state.status === "done" && run.state.run.status === "Blocked"
+              ? { label: "Run halted", value: "the guard refused a step" }
+              : undefined
+        }
       />
 
       <div className="frame-main">
@@ -329,7 +340,35 @@ export default function App() {
             />
           )}
 
-          {state.status === "ready" && surface === "review" && (
+          {state.status === "ready" &&
+            surface === "review" &&
+            (run.state.status === "active" || run.state.status === "done") && (
+              // A run exists: the Review destination IS the run — rehearsal
+              // result, execution in progress, or halted by the guard.
+              <RunScreen
+                run={run.state.run}
+                events={run.state.events}
+                active={run.state.status === "active"}
+                graph={state.graph}
+                steps={steps}
+                planMatches={run.state.run.planId === state.plan.plan.id}
+                reclaimed={new Map(reclamations.recent.map((r) => [r.node, r]))}
+                onDismiss={run.dismiss}
+                onRehearse={() => requestRun(true)}
+                onDrain={() => requestRun(false)}
+                onRecompute={() => {
+                  touched.current = false;
+                  run.dismiss();
+                  (state.superseded ? state.showLatest : state.reload)();
+                }}
+                onOpenRecommendations={() => setSurface("recommendations")}
+              />
+            )}
+
+          {state.status === "ready" &&
+            surface === "review" &&
+            run.state.status !== "active" &&
+            run.state.status !== "done" && (
             <>
               <Hero
                 graph={state.graph}

--- a/ui/src/components/Rail.tsx
+++ b/ui/src/components/Rail.tsx
@@ -26,6 +26,8 @@ interface Props {
   /** The identity the API server verified, not one the browser asserted. */
   identity?: string;
   onSignOut?: () => void;
+  /** A run in flight — the one fact worth showing on every destination. */
+  runNote?: { label: string; value: string };
 }
 
 const ICONS: Record<Surface, React.ReactNode> = {
@@ -71,6 +73,7 @@ export default function Rail({
   clusterLabel,
   identity,
   onSignOut,
+  runNote,
 }: Props) {
   return (
     <nav className="rail" aria-label="Destinations">
@@ -114,6 +117,12 @@ export default function Rail({
       </div>
 
       <div className="rail-foot">
+        {runNote && (
+          <div className="rail-run" role="status">
+            <span className="rail-run-label eyebrow mono">{runNote.label}</span>
+            <span className="rail-run-value mono">{runNote.value}</span>
+          </div>
+        )}
         {clusterLabel && (
           <div className="rail-cluster" title="The cluster this view is showing">
             <span className="rail-cluster-label eyebrow mono">Cluster</span>

--- a/ui/src/components/run/RunScreen.tsx
+++ b/ui/src/components/run/RunScreen.tsx
@@ -1,0 +1,645 @@
+/**
+ * The run screens (assets/design/README.md, 2a/2b/2c): when a run exists,
+ * the Review destination becomes the run — rehearsal result, execution in
+ * progress, or halted by the Safety Guard. One component, because the
+ * executor deliberately emits identical events for a rehearsal and a real
+ * run: what an operator previews is what they will see.
+ *
+ * 2b ships without Abort or "Pause after this step" — there is no backend
+ * for either yet, and a control that does nothing would be worse than its
+ * absence (user decision; feasibility discussion parked).
+ *
+ * 2c is the trust screen. It states what drifted, what was kept, that the
+ * cordon was reverted, and offers exactly two ways forward. Deliberately no
+ * force-drain: there is no override in this UI. A refusal is the product
+ * working.
+ */
+
+import { GraphPayload, PlanStep, Reclamation, Run, RunEvent, formatBytes, formatCPU } from "../../api";
+
+export type RunPhase = "pending" | "live" | "done" | "refused";
+
+interface Props {
+  run: Run;
+  events: RunEvent[];
+  active: boolean;
+  graph: GraphPayload;
+  steps: PlanStep[];
+  /** True while the plan on screen is still the run's plan. */
+  planMatches: boolean;
+  /** node → its reclamation record; capacity measured at drain time. */
+  reclaimed: Map<string, Reclamation>;
+  onDismiss: () => void;
+  onDrain: () => void;
+  onRehearse: () => void;
+  onRecompute: () => void;
+  onOpenRecommendations: () => void;
+}
+
+export default function RunScreen(props: Props) {
+  const { run, active } = props;
+  if (active) return <Execution {...props} />;
+  if (run.dryRun) return <RehearsalResult {...props} />;
+  if (run.status === "Blocked" || run.status === "Failed") return <Halted {...props} />;
+  return <Execution {...props} />; // a finished, successful run: 2b at rest
+}
+
+/* ------------------------------------------------------------- shared bits */
+
+/**
+ * The run's own view of its steps. Nodes come from the run's EVENTS first:
+ * a finished run reloads the plan underneath this screen, and joining the
+ * run's sequence numbers against the fresh plan silently renames every row
+ * to some other node — found live, the trail saying himem-1 while the row
+ * said spot-7. The plan is consulted only while it is still the run's plan
+ * (planMatches), and then only for steps the events have not reached.
+ */
+interface StepModel {
+  seq: number;
+  node?: string;
+  /** The plan's step, only while the plan on screen is the run's plan. */
+  planned?: PlanStep;
+}
+
+function runSteps(run: Run, events: RunEvent[], steps: PlanStep[], planMatches: boolean): StepModel[] {
+  return run.steps.map((seq) => {
+    const fromEvents = events.find((e) => e.step === seq && e.node)?.node;
+    const planned = planMatches ? steps.find((s) => s.sequenceNumber === seq) : undefined;
+    return { seq, node: fromEvents ?? planned?.targetNode, planned };
+  });
+}
+
+function stepEvents(events: RunEvent[], seq: number): RunEvent[] {
+  return events.filter((e) => e.step === seq);
+}
+
+function drained(events: RunEvent[], seq: number): boolean {
+  return stepEvents(events, seq).some((e) => e.action === "Drained");
+}
+
+function refused(events: RunEvent[], seq: number): boolean {
+  return stepEvents(events, seq).some((e) => e.level === "Blocked" || e.level === "Error");
+}
+
+/** Pods this step moves: the plan's number while it exists, else the events'. */
+function podsOf(m: StepModel, events: RunEvent[]): number {
+  if (m.planned) return m.planned.moves.length;
+  return stepEvents(events, m.seq).filter((e) => e.action === "Evict").length;
+}
+
+/**
+ * What a drained node was worth. The reclamation ledger's measured capture
+ * wins — a reclaimed node is gone from the live graph, and reading the graph
+ * for it would quietly shrink the total as the run succeeds. The graph is
+ * the fallback for nodes still present.
+ */
+function nodeWorth(
+  graph: GraphPayload,
+  reclaimed: Map<string, Reclamation>,
+  node?: string,
+): { cpu: number; mem: number } {
+  if (node) {
+    const r = reclaimed.get(node);
+    if (r?.cpuMilli) return { cpu: r.cpuMilli, mem: r.memBytes ?? 0 };
+    const n = graph.elements.find((e) => e.data.kind === "node" && e.data.label === node);
+    if (n) return { cpu: n.data.cpuAllocatable ?? 0, mem: n.data.memAllocatable ?? 0 };
+  }
+  return { cpu: 0, mem: 0 };
+}
+
+function fmtTime(iso?: string): string {
+  return iso ? new Date(iso).toLocaleTimeString([], { hour12: false }) : "";
+}
+
+/** The live trail, right-hand column of 2a and 2b. */
+function Trail({ events, streaming }: { events: RunEvent[]; streaming: boolean }) {
+  const download = () => {
+    const text = events
+      .map((e) => `${fmtTime(e.at)}  ${e.level === "Info" ? "" : e.level.toUpperCase() + " "}${e.message}`)
+      .join("\n");
+    const url = URL.createObjectURL(new Blob([text], { type: "text/plain" }));
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `dencer-run-${events[0]?.runId ?? "trail"}.txt`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="trailpane">
+      <div className="trailpane-head">
+        <span className="eyebrow mono">{streaming ? "Live trail" : "Trail"}</span>
+        {streaming ? (
+          <span className="trailpane-streaming">
+            <span className="trailpane-dot" aria-hidden="true" />
+            streaming
+          </span>
+        ) : (
+          <button type="button" className="trailpane-copy" onClick={download}>
+            Download
+          </button>
+        )}
+      </div>
+      <div className="trailpane-lines">
+        {events.map((e) => (
+          <div key={e.sequence} className="trailline">
+            <span className="trailline-t">{fmtTime(e.at)}</span>
+            <span
+              className={
+                "trailline-text" +
+                (e.level === "Blocked"
+                  ? " is-blocked"
+                  : e.level === "Error"
+                    ? " is-error"
+                    : e.action === "Drained" || e.action === "Verify"
+                      ? " is-strong"
+                      : "")
+              }
+            >
+              {e.message}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/* -------------------------------------------------------------- 2a result */
+
+function RehearsalResult({
+  run,
+  events,
+  graph,
+  steps,
+  planMatches,
+  reclaimed,
+  onDismiss,
+  onDrain,
+  onRehearse,
+}: Props) {
+  const mine = runSteps(run, events, steps, planMatches);
+  const clean = mine.filter((m) => drained(events, m.seq));
+  const blockedStep = mine.find((m) => refused(events, m.seq));
+  const allClean = !blockedStep && clean.length === mine.length;
+  const pods = mine.reduce((n, m) => n + podsOf(m, events), 0);
+  let cpu = 0;
+  let mem = 0;
+  for (const m of clean) {
+    const w = nodeWorth(graph, reclaimed, m.node);
+    cpu += w.cpu;
+    mem += w.mem;
+  }
+  const placed = events.filter((e) => e.action === "Evict").length;
+
+  return (
+    <div className="runscreen">
+      <div className="runhead">
+        <button type="button" className="runhead-back" onClick={onDismiss}>
+          ← Back to review
+        </button>
+        <span className="runhead-sep" aria-hidden="true" />
+        <span className="runhead-title">Rehearsal</span>
+        <span className="runhead-meta mono">
+          plan {run.planId.slice(0, 7)} · {mine.length} steps
+        </span>
+        <span className="runhead-when mono">{fmtTime(run.finishedAt)}</span>
+      </div>
+
+      <div className="runhero">
+        <div className="runhero-lead">
+          <div className={"runhero-eyebrow " + (allClean ? "is-safe" : "is-held")}>
+            <span className="runhero-eyedot" aria-hidden="true" />
+            <span className="eyebrow mono">
+              {allClean
+                ? `All ${mine.length} steps would succeed`
+                : `Step ${blockedStep?.seq ?? "?"} would be refused`}
+            </span>
+          </div>
+          <h2 className="runhero-headline">Nothing was cordoned. Nothing was evicted.</h2>
+          <p className="runhero-sub">
+            The Safety Guard ran in full against the live cluster
+            {allClean
+              ? " and every check passed. Placement was simulated against real node capacity — every pod found a home."
+              : ". One step was refused; the trail names the rule, and the step goes back to the ledger as held back."}
+          </p>
+        </div>
+        <div className="runhero-tiles">
+          <div className={"runtile " + (allClean ? "runtile-safe" : "runtile-held")}>
+            <span className="runtile-figure mono">
+              {clean.length} / {mine.length}
+            </span>
+            <span className="runtile-label">steps clean</span>
+          </div>
+          <div className="runtile">
+            <span className="runtile-figure mono">{placed}</span>
+            <span className="runtile-label">pods placed</span>
+          </div>
+          <div className="runtile">
+            <span className="runtile-figure mono">{formatCPU(cpu)} cores</span>
+            <span className="runtile-label">would return</span>
+          </div>
+          <div className="runtile">
+            <span className="runtile-figure mono">{formatBytes(mem)}</span>
+            <span className="runtile-label">would return</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="runbody">
+        <div className="runsteps">
+          <span className="eyebrow mono">Step by step</span>
+          {mine.map((m) => {
+            const ok = drained(events, m.seq);
+            const bad = refused(events, m.seq);
+            const d = stepEvents(events, m.seq).find((e) => e.action === "Drained");
+            const n = podsOf(m, events);
+            return (
+              <div key={m.seq} className="runstep">
+                <span className="runstep-n mono">{String(m.seq).padStart(2, "0")}</span>
+                <div className="runstep-body">
+                  <div className="runstep-line">
+                    <span className="runstep-node mono">{m.node}</span>
+                    <span className="runstep-pods mono">
+                      {n} pod{n === 1 ? "" : "s"}
+                    </span>
+                  </div>
+                  <span className="runstep-detail">{d?.message ?? ""}</span>
+                </div>
+                <span
+                  className={"runstep-outcome " + (bad ? "is-held" : ok ? "is-safe" : "is-muted")}
+                >
+                  {bad ? "Would be refused" : ok ? "Would drain cleanly" : "Not reached"}
+                </span>
+              </div>
+            );
+          })}
+          <div className="runnote">
+            A rehearsal is a snapshot. If the cluster changes before you run, the Safety Guard
+            re-checks each step and halts on the first refusal.
+          </div>
+        </div>
+        <Trail events={events} streaming={false} />
+      </div>
+
+      <footer className="runfooter">
+        <div className="runfooter-summary">
+          <span className="runfooter-line">
+            Rehearsal held for {mine.length} step{mine.length === 1 ? "" : "s"} · {pods} pod
+            {pods === 1 ? "" : "s"}
+          </span>
+          <span className="runfooter-sub">
+            {allClean
+              ? "Approving carries this selection straight into a real run."
+              : "Resolve the refusal, or drop that step from the selection."}
+          </span>
+        </div>
+        <div className="runfooter-actions">
+          <button type="button" className="btn" onClick={onDismiss}>
+            Discard
+          </button>
+          <button type="button" className="btn reviewfooter-rehearse" onClick={onRehearse}>
+            Rehearse again
+          </button>
+          {allClean && planMatches && (
+            <button type="button" className="reviewfooter-drain" onClick={onDrain}>
+              Drain {mine.length} node{mine.length === 1 ? "" : "s"}
+            </button>
+          )}
+        </div>
+      </footer>
+    </div>
+  );
+}
+
+/* ---------------------------------------------------------- 2b execution */
+
+const PHASES = ["cordon", "evict", "verify", "reclaim"] as const;
+
+function phaseStates(
+  events: RunEvent[],
+  seq: number,
+  node: string | undefined,
+  reclaimed: Map<string, Reclamation>,
+  active: boolean,
+): Record<(typeof PHASES)[number], RunPhase> {
+  const mine = stepEvents(events, seq);
+  const has = (action: string) => mine.some((e) => e.action === action && e.level === "Info");
+  const bad = mine.some((e) => e.level === "Blocked" || e.level === "Error");
+  const isDrained = has("Drained");
+  const cordon = has("Cordon");
+  const verify = has("Verify");
+  const gone = node != null && reclaimed.get(node)?.outcome === "reclaimed";
+
+  const started = mine.length > 0;
+  const st = (done: boolean, liveWhen: boolean): RunPhase =>
+    done ? "done" : bad ? "refused" : active && liveWhen ? "live" : "pending";
+
+  return {
+    cordon: st(cordon || isDrained, started && !cordon),
+    evict: st(isDrained, cordon && !isDrained),
+    verify: st(verify, isDrained && !verify),
+    reclaim: st(gone, verify && !gone),
+  };
+}
+
+function Execution({ run, events, active, graph, steps, planMatches, reclaimed, onDismiss }: Props) {
+  const mine = runSteps(run, events, steps, planMatches);
+  const done = mine.filter((m) => drained(events, m.seq));
+  const current = active
+    ? mine.find((m) => !drained(events, m.seq) && !refused(events, m.seq))
+    : undefined;
+  const podsTotal = mine.reduce((n, m) => n + podsOf(m, events), 0);
+  const podsMoved = events.filter((e) => e.action === "Evict").length;
+  let cpu = 0;
+  let mem = 0;
+  for (const m of done) {
+    const w = nodeWorth(graph, reclaimed, m.node);
+    cpu += w.cpu;
+    mem += w.mem;
+  }
+  const phaseOf = current ? phaseStates(events, current.seq, current.node, reclaimed, active) : null;
+  const currentPhase = phaseOf ? (PHASES.find((p) => phaseOf[p] === "live") ?? "cordon") : null;
+
+  return (
+    <div className="runscreen">
+      <div className="runhead">
+        {!active && (
+          <>
+            <button type="button" className="runhead-back" onClick={onDismiss}>
+              ← Back to review
+            </button>
+            <span className="runhead-sep" aria-hidden="true" />
+          </>
+        )}
+        <span className="runhead-title">
+          {active ? `Draining ${mine.length} nodes` : `Run ${run.planId.slice(0, 7)}`}
+        </span>
+        <span className="runhead-meta mono">
+          plan {run.planId.slice(0, 7)} · started {fmtTime(run.startedAt ?? run.requestedAt)} by{" "}
+          {run.actor}
+        </span>
+      </div>
+
+      <div className="runhero runhero-col">
+        <div className="runhero-row">
+          <div className="runhero-lead">
+            <span className="eyebrow mono">
+              {active && current
+                ? `Step ${current.seq} of ${mine.length}${currentPhase ? ` · ${currentPhase === "evict" ? "evicting" : currentPhase}` : ""}`
+                : `Run ${run.status.toLowerCase()}`}
+            </span>
+            <h2 className="runhero-headline">
+              {done.length} node{done.length === 1 ? "" : "s"} reclaimed,{" "}
+              {mine.length - done.length} to go
+            </h2>
+          </div>
+          <div className="runhero-stats">
+            <div className="hero-stat">
+              <span className="hero-stat-figure mono runstat-safe">{formatCPU(cpu)} cores</span>
+              <span className="hero-stat-label">returned so far</span>
+            </div>
+            <span className="hero-stat-sep" aria-hidden="true" />
+            <div className="hero-stat">
+              <span className="hero-stat-figure mono runstat-safe">{formatBytes(mem)}</span>
+              <span className="hero-stat-label">memory freed</span>
+            </div>
+            <span className="hero-stat-sep" aria-hidden="true" />
+            <div className="hero-stat">
+              <span className="hero-stat-figure mono">
+                {podsMoved} of {podsTotal}
+              </span>
+              <span className="hero-stat-label">pods moved</span>
+            </div>
+          </div>
+        </div>
+        <div className="runprogress" aria-hidden="true">
+          {done.length > 0 && <div className="runprogress-done" style={{ flex: done.length }} />}
+          {active && current && <div className="runprogress-live" style={{ flex: 1 }} />}
+          {mine.length - done.length - (active && current ? 1 : 0) > 0 && (
+            <div
+              className="runprogress-rest"
+              style={{ flex: mine.length - done.length - (active && current ? 1 : 0) }}
+            />
+          )}
+        </div>
+      </div>
+
+      <div className="runbody">
+        <div className="runsteps">
+          <span className="eyebrow mono">Steps</span>
+          {mine.map((m) => {
+            const ph = phaseStates(events, m.seq, m.node, reclaimed, active);
+            const isDone = drained(events, m.seq);
+            const isBad = refused(events, m.seq);
+            const isLive = current?.seq === m.seq;
+            const gone = m.node != null && reclaimed.get(m.node)?.outcome === "reclaimed";
+            const n = podsOf(m, events);
+            return (
+              <div key={m.seq} className="runstep runstep-col">
+                <div className="runstep-line">
+                  <span className="runstep-n mono">{String(m.seq).padStart(2, "0")}</span>
+                  <span className="runstep-node mono">{m.node}</span>
+                  <span className="runstep-meta">
+                    {n} pod{n === 1 ? "" : "s"}
+                    {gone && " · node gone from the cluster"}
+                  </span>
+                  <span
+                    className={
+                      "runstep-outcome " +
+                      (isBad ? "is-held" : isDone ? "is-safe" : isLive ? "is-live" : "is-muted")
+                    }
+                  >
+                    {isBad
+                      ? "Refused"
+                      : gone
+                        ? "Reclaimed"
+                        : isDone
+                          ? "Drained"
+                          : isLive
+                            ? "In progress"
+                            : "Queued"}
+                  </span>
+                </div>
+                <div className="runphases">
+                  {PHASES.map((p) => (
+                    <span key={p} className={"runphase runphase-" + ph[p]}>
+                      {p}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+        <Trail events={events} streaming={active} />
+      </div>
+
+      <footer className="runfooter">
+        <div className="runfooter-summary">
+          <span className="runfooter-line">The Safety Guard re-runs before every step</span>
+          <span className="runfooter-sub">
+            If a check fails, the run halts and the cordon on the current node is reverted.
+          </span>
+        </div>
+        <div className="runfooter-actions">
+          {!active && (
+            <button type="button" className="btn" onClick={onDismiss}>
+              Back to review
+            </button>
+          )}
+        </div>
+      </footer>
+    </div>
+  );
+}
+
+/* -------------------------------------------------------------- 2c halted */
+
+function Halted({
+  run,
+  events,
+  graph,
+  steps,
+  planMatches,
+  reclaimed,
+  onDismiss,
+  onRecompute,
+  onOpenRecommendations,
+}: Props) {
+  const mine = runSteps(run, events, steps, planMatches);
+  const done = mine.filter((m) => drained(events, m.seq));
+  const badStep = mine.find((m) => refused(events, m.seq));
+  const guard = events.find((e) => e.level === "Blocked" && e.action === "Guard");
+  const fail = events.find((e) => e.level === "Error");
+  let cpu = 0;
+  let mem = 0;
+  for (const m of done) {
+    const w = nodeWorth(graph, reclaimed, m.node);
+    cpu += w.cpu;
+    mem += w.mem;
+  }
+  const goneCount = done.filter((m) => m.node && reclaimed.get(m.node)?.outcome === "reclaimed").length;
+  const nodesNow = graph.stats.nodesBefore - goneCount;
+
+  return (
+    <div className="runscreen">
+      <div className="runhead">
+        <span className="runhead-title">Run {run.planId.slice(0, 7)}</span>
+        <span className="runhead-meta mono">
+          {fmtTime(run.startedAt ?? run.requestedAt)} → {fmtTime(run.finishedAt)} · {run.actor}
+        </span>
+      </div>
+
+      <div className="runhero">
+        <div className="runhero-lead">
+          <div className="runhero-eyebrow is-held">
+            <span className="runhero-eyedot runhero-eyedot-square" aria-hidden="true" />
+            <span className="eyebrow mono">
+              {guard ? `Halted at step ${badStep?.seq ?? "?"} of ${mine.length}` : "Run failed"}
+            </span>
+          </div>
+          <h2 className="runhero-headline">
+            {done.length} node{done.length === 1 ? "" : "s"} reclaimed.{" "}
+            {guard ? "The next was refused and reverted." : "Then a step failed."}
+          </h2>
+          <p className="runhero-sub runhero-sub-strong">
+            {guard?.message ?? fail?.message ?? run.summary ?? ""}{" "}
+            <strong>No pod was evicted for the refused step</strong> and the cordon was removed.
+          </p>
+        </div>
+        <div className="runhero-cards">
+          <div className="runcard runcard-safe">
+            <span className="eyebrow mono">Kept</span>
+            <span className="runcard-value">
+              {done.length} node{done.length === 1 ? "" : "s"} reclaimed · {formatCPU(cpu)} cores,{" "}
+              {formatBytes(mem)}
+            </span>
+          </div>
+          <div className="runcard">
+            <span className="eyebrow mono">Cluster now</span>
+            <span className="runcard-value">{nodesNow} nodes · no cordons left behind</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="runbody">
+        <div className="runsteps">
+          <span className="eyebrow mono">What ran</span>
+          {mine.map((m) => {
+            const isDone = drained(events, m.seq);
+            const isBad = refused(events, m.seq);
+            const n = podsOf(m, events);
+            return (
+              <div key={m.seq} className="runstep">
+                <span className="runstep-n mono">{String(m.seq).padStart(2, "0")}</span>
+                <span className="runstep-node mono">{m.node}</span>
+                <span className="runstep-meta">
+                  {n} pod{n === 1 ? "" : "s"}
+                </span>
+                <span
+                  className={"runstep-outcome " + (isBad ? "is-held" : isDone ? "is-safe" : "is-muted")}
+                >
+                  {isBad ? "Refused · reverted" : isDone ? "Reclaimed" : "Not reached"}
+                </span>
+              </div>
+            );
+          })}
+
+          {(guard || fail) && (
+            <div className="refusal">
+              <div className="refusal-head">
+                <span className="refusal-tag">{guard ? "REFUSAL" : "FAILURE"}</span>
+                <span className="refusal-rule mono">{guard?.rule ?? fail?.action}</span>
+              </div>
+              <p className="refusal-text mono">{guard?.message ?? fail?.message}</p>
+            </div>
+          )}
+        </div>
+
+        <aside className="waysforward">
+          <div className="waysforward-head">
+            <span className="eyebrow mono">Two ways forward</span>
+            <span className="waysforward-sub">
+              The remaining step is not lost — it goes back to the ledger as held back, with this
+              refusal attached.
+            </span>
+          </div>
+          <div className="waysforward-body">
+            <div className="wayscard wayscard-primary">
+              <span className="wayscard-title">Wait for the cluster to recover</span>
+              <span className="wayscard-text">
+                The refusal names live state. When it heals, the next plan offers this node again —
+                nothing needs to be undone.
+              </span>
+            </div>
+            <div className="wayscard">
+              <span className="wayscard-title">Change the rule</span>
+              <span className="wayscard-text">
+                If the constraint is stricter than the service needs, relaxing it is a real
+                availability trade — make it in Recommendations, where the trade is priced.
+              </span>
+              <button type="button" className="wayscard-link" onClick={onOpenRecommendations}>
+                Open in Recommendations
+              </button>
+            </div>
+            <div className="wayscard wayscard-refused">
+              <span className="wayscard-title">Not offered: force the drain</span>
+              <span className="wayscard-text">
+                There is no override in this UI. A refusal is the product working.
+              </span>
+            </div>
+          </div>
+          <div className="waysforward-foot">
+            <button type="button" className="btn stepdetail-add" onClick={onDismiss}>
+              Back to review
+            </button>
+            <button type="button" className="reviewfooter-drain" onClick={onRecompute}>
+              Recompute
+            </button>
+          </div>
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -8,6 +8,7 @@
 @import "./styles/base.css";
 @import "./styles/frame.css";
 @import "./styles/review.css";
+@import "./styles/runscreens.css";
 @import "./styles/chrome.css";
 @import "./styles/field.css";
 @import "./styles/sidebar.css";

--- a/ui/src/styles/runscreens.css
+++ b/ui/src/styles/runscreens.css
@@ -1,0 +1,683 @@
+/*
+ * Run screens (2a rehearsal result, 2b execution, 2c halted by the guard).
+ * The Review destination becomes the run; measurements from the handoff.
+ */
+
+.runscreen {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+/* ------------------------------------------------------------- run header */
+
+.runhead {
+  height: var(--topbar-h);
+  flex-shrink: 0;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 0 var(--space-6);
+  background: var(--surface);
+}
+
+.runhead-back {
+  border: 0;
+  background: none;
+  padding: 0;
+  font-size: var(--text-sm);
+  color: var(--accent-text);
+}
+
+.runhead-sep {
+  width: 1px;
+  height: 22px;
+  background: var(--border-card);
+}
+
+.runhead-title {
+  font-size: var(--text-md);
+  font-weight: 600;
+}
+
+.runhead-meta {
+  font-size: var(--text-xs);
+  color: var(--text-5);
+}
+
+.runhead-when {
+  margin-left: auto;
+  font-size: var(--text-2xs);
+  color: var(--text-faint);
+}
+
+/* --------------------------------------------------------------- run hero */
+
+.runhero {
+  padding: 26px var(--space-6) 22px;
+  border-bottom: 1px solid var(--border);
+  background: var(--surface);
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-8);
+}
+
+.runhero-col {
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.runhero-row {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: var(--space-6);
+  width: 100%;
+}
+
+.runhero-lead {
+  display: flex;
+  flex-direction: column;
+  gap: 11px;
+  flex: 1;
+  min-width: 0;
+}
+
+.runhero-eyebrow {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+}
+
+.runhero-eyedot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+
+.runhero-eyedot-square {
+  border-radius: 2px;
+}
+
+.runhero-eyebrow.is-safe .runhero-eyedot {
+  background: var(--safe);
+}
+
+.runhero-eyebrow.is-safe .eyebrow {
+  color: var(--safe);
+}
+
+.runhero-eyebrow.is-held .runhero-eyedot {
+  background: var(--held);
+}
+
+.runhero-eyebrow.is-held .eyebrow {
+  color: var(--held);
+}
+
+.runhero-headline {
+  margin: 0;
+  font-size: var(--text-2xl);
+  font-weight: 600;
+  letter-spacing: var(--tracking-display);
+  line-height: 1.1;
+}
+
+.runhero-sub {
+  margin: 0;
+  font-size: var(--text-md);
+  line-height: 1.55;
+  color: var(--text-3);
+  max-width: 700px;
+  text-wrap: pretty;
+}
+
+.runhero-sub-strong {
+  color: var(--text-2);
+}
+
+.runhero-sub-strong strong {
+  font-weight: 600;
+  color: var(--text-1);
+}
+
+.runhero-stats {
+  display: flex;
+  align-items: center;
+  gap: 22px;
+  flex-shrink: 0;
+}
+
+.runstat-safe {
+  color: var(--safe);
+}
+
+/* 2a's four tiles. */
+.runhero-tiles {
+  width: 300px;
+  flex-shrink: 0;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-2);
+}
+
+.runtile {
+  padding: 11px 12px;
+  border-radius: var(--radius);
+  background: var(--inset);
+  border: 1px solid var(--inset-border);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.runtile-safe {
+  background: var(--safe-bg);
+  border-color: var(--safe-border);
+}
+
+.runtile-safe .runtile-figure {
+  color: var(--safe);
+}
+
+.runtile-held {
+  background: var(--held-bg);
+  border-color: var(--held-border);
+}
+
+.runtile-held .runtile-figure {
+  color: var(--held);
+}
+
+.runtile-figure {
+  font-size: 17px;
+  font-weight: 600;
+}
+
+.runtile-label {
+  font-size: var(--text-2xs);
+  color: var(--text-4);
+}
+
+/* 2c's kept/now cards. */
+.runhero-cards {
+  width: 300px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.runcard {
+  padding: 12px 13px;
+  border-radius: var(--radius);
+  background: var(--inset);
+  border: 1px solid var(--inset-border);
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.runcard-safe {
+  background: var(--safe-bg);
+  border-color: var(--safe-border);
+}
+
+.runcard-safe .eyebrow {
+  color: var(--safe-text);
+}
+
+.runcard-value {
+  font-size: var(--text-sm);
+  color: var(--text-1);
+}
+
+/* ------------------------------------------------------------ progress bar */
+
+.runprogress {
+  display: flex;
+  height: 6px;
+  border-radius: 3px;
+  overflow: hidden;
+  gap: 2px;
+  background: var(--hairline);
+  width: 100%;
+}
+
+.runprogress-done {
+  background: var(--safe);
+  border-radius: 3px 0 0 3px;
+}
+
+.runprogress-live {
+  background: var(--accent);
+}
+
+.runprogress-rest {
+  background: var(--hairline);
+  border-radius: 0 3px 3px 0;
+}
+
+/* ---------------------------------------------------------------- run body */
+
+.runbody {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+}
+
+.runsteps {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid var(--border);
+  padding: 18px 20px;
+  gap: 12px;
+  overflow-y: auto;
+}
+
+.runstep {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 14px 15px;
+  border-radius: 9px;
+  background: var(--inset);
+  border: 1px solid var(--inset-border);
+}
+
+.runstep-col {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 11px;
+}
+
+.runstep-line {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+}
+
+.runstep-body {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+  flex: 1;
+}
+
+.runstep-n {
+  font-size: var(--text-2xs);
+  color: var(--text-faint);
+}
+
+.runstep-node {
+  font-size: var(--text-sm);
+  color: var(--text-1);
+}
+
+.runstep-pods {
+  font-size: var(--text-2xs);
+  color: var(--text-4);
+}
+
+.runstep-meta {
+  font-size: var(--text-xs);
+  color: var(--text-4);
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.runstep-detail {
+  font-size: var(--text-xs);
+  color: var(--text-4);
+}
+
+.runstep-outcome {
+  font-size: var(--text-xs);
+  font-weight: 500;
+  flex-shrink: 0;
+  margin-left: auto;
+}
+
+.runstep-outcome.is-safe {
+  color: var(--safe);
+}
+
+.runstep-outcome.is-held {
+  color: var(--held);
+}
+
+.runstep-outcome.is-live {
+  color: var(--accent-text);
+}
+
+.runstep-outcome.is-muted {
+  color: var(--text-5);
+}
+
+/* ------------------------------------------------------------ phase chips */
+
+.runphases {
+  display: flex;
+  gap: 7px;
+}
+
+.runphase {
+  flex: 1;
+  padding: 6px 9px;
+  border-radius: 6px;
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+  text-align: center;
+  background: var(--inset);
+  border: 1px solid var(--border-card);
+  color: var(--text-faint);
+}
+
+.runphase-done {
+  background: var(--safe-bg);
+  border-color: var(--safe-border);
+  color: var(--safe);
+}
+
+.runphase-live {
+  background: var(--nav-active-bg);
+  border-color: var(--border-strong);
+  color: var(--accent-text);
+}
+
+.runphase-refused {
+  background: var(--held-bg);
+  border-color: var(--held-border);
+  color: var(--held-text);
+}
+
+/* --------------------------------------------------------------- the trail */
+
+.trailpane {
+  width: 520px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  background: var(--group-band);
+  min-height: 0;
+  overflow: hidden;
+}
+
+.trailpane-head {
+  padding: 14px 18px 10px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  border-bottom: 1px solid var(--hairline);
+}
+
+.trailpane-streaming {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: var(--text-2xs);
+  color: var(--accent-text);
+}
+
+.trailpane-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+}
+
+.trailpane-copy {
+  margin-left: auto;
+  border: 0;
+  background: none;
+  padding: 0;
+  font-size: var(--text-xs);
+  color: var(--accent-text);
+}
+
+.trailpane-lines {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 12px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.trailline {
+  display: flex;
+  gap: 12px;
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+  line-height: 1.5;
+}
+
+.trailline-t {
+  color: var(--text-faint);
+  flex-shrink: 0;
+}
+
+.trailline-text {
+  color: var(--text-4);
+  white-space: pre-wrap;
+}
+
+.trailline-text.is-strong {
+  color: var(--text-2);
+}
+
+.trailline-text.is-blocked {
+  color: var(--caution-text);
+}
+
+.trailline-text.is-error {
+  color: var(--held-text);
+}
+
+/* --------------------------------------------------------- rehearsal note */
+
+.runnote {
+  margin-top: 6px;
+  padding: 13px 15px;
+  border-radius: 9px;
+  border: 1px dashed var(--border-strong);
+  font-size: var(--text-xs);
+  color: var(--text-3);
+  text-wrap: pretty;
+}
+
+/* --------------------------------------------------------------- refusal */
+
+.refusal {
+  margin-top: 6px;
+  padding: 15px 16px;
+  border-radius: 9px;
+  background: var(--held-bg);
+  border: 1px solid var(--held-border);
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+}
+
+.refusal-head {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+}
+
+.refusal-tag {
+  font-size: var(--text-2xs);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: var(--held-border);
+  color: var(--held);
+}
+
+.refusal-rule {
+  font-size: var(--text-2xs);
+  color: var(--held-text);
+}
+
+.refusal-text {
+  margin: 0;
+  font-size: var(--text-2xs);
+  line-height: 1.55;
+  color: var(--text-2);
+  white-space: pre-wrap;
+}
+
+/* ---------------------------------------------------------- ways forward */
+
+.waysforward {
+  width: 392px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  background: var(--surface);
+  min-height: 0;
+  overflow: hidden;
+}
+
+.waysforward-head {
+  padding: 18px 20px 14px;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+
+.waysforward-sub {
+  font-size: var(--text-sm);
+  color: var(--text-3);
+  text-wrap: pretty;
+}
+
+.waysforward-body {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 16px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.wayscard {
+  padding: 14px 15px;
+  border-radius: 9px;
+  background: var(--inset);
+  border: 1px solid var(--inset-border);
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+
+.wayscard-primary {
+  border-color: var(--border-strong);
+}
+
+.wayscard-refused {
+  background: none;
+  border: 1px dashed var(--border-strong);
+}
+
+.wayscard-title {
+  font-size: var(--text-sm);
+  font-weight: 600;
+}
+
+.wayscard-text {
+  font-size: var(--text-xs);
+  line-height: 1.5;
+  color: var(--text-3);
+  text-wrap: pretty;
+}
+
+.wayscard-link {
+  border: 0;
+  background: none;
+  padding: 0;
+  text-align: left;
+  font-size: var(--text-xs);
+  color: var(--accent-text);
+}
+
+.waysforward-foot {
+  flex: 0 0 auto;
+  padding: 14px 20px 18px;
+  border-top: 1px solid var(--border);
+  display: flex;
+  gap: var(--space-2);
+}
+
+/* -------------------------------------------------------------- run footer */
+
+.runfooter {
+  height: var(--footer-h);
+  flex-shrink: 0;
+  border-top: 1px solid var(--border);
+  background: var(--surface);
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  padding: 0 var(--space-6);
+}
+
+.runfooter-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.runfooter-line {
+  font-size: var(--text-sm);
+  font-weight: 600;
+}
+
+.runfooter-sub {
+  font-size: var(--text-xs);
+  color: var(--text-4);
+}
+
+.runfooter-actions {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+}
+
+/* --------------------------------------------------- rail run-status card */
+
+.rail-run {
+  padding: 10px 11px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius);
+  background: var(--nav-active-bg);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.rail-run-label {
+  letter-spacing: 0.1em;
+  color: var(--accent-text);
+}
+
+.rail-run-value {
+  font-size: var(--text-xs);
+  color: var(--text-2);
+}


### PR DESCRIPTION
Recreation of #93, which was auto-closed when its stacked base branch was deleted on #92's merge. Same content, now against main.

Screens 2a/2b/2c: rehearsal result ("Nothing was cordoned. Nothing was evicted."), execution with cordon→evict→verify→reclaim phase chips from real run events + streaming trail, and the halted-by-guard trust screen with exactly two ways forward ("There is no override in this UI. A refusal is the product working."). No Abort/Pause — no backend exists (user decision, parked).

Bug found live and fixed: a finished run reloads the plan under the screen; rows now source nodes from the run's own events and price drained nodes from the reclamation ledger. Verified with a real rehearsal + two real drains on OrbStack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)