### PR TITLE
Release 0.3.0

### DIFF
--- a/charts/k8s-dencer/Chart.yaml
+++ b/charts/k8s-dencer/Chart.yaml
@@ -10,8 +10,8 @@ type: application
 
 # Chart version tracks the chart; appVersion tracks the images. Component image
 # tags default to appVersion so a chart release pins a coherent image set.
-version: 0.2.0
-appVersion: "0.2.0"
+version: 0.3.0
+appVersion: "0.3.0"
 
 # controller-runtime and the policy/v1 PDB API used here are stable from 1.21,
 # but the chart relies on 1.27-era defaults for restricted Pod Security


### PR DESCRIPTION
Chart 0.3.0 / appVersion 0.3.0 — the redesigned UI ("The ledger"), the packing ceiling (`planner.packCeiling`, schema v8), per-node usage in the graph, and the GCP playground. Tag `v0.3.0` follows the merge; the release workflow publishes images + chart to ghcr on the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)