### PR TITLE
Playground: apply rendered kwok manifests into the kwok namespace

### DIFF
--- a/hack/gcp-playground.sh
+++ b/hack/gcp-playground.sh
@@ -151,10 +151,15 @@ helm repo update kwok >/dev/null 2>&1
 # bookkeeping buys nothing here.
 kubectl --context "$CTX" create namespace "$KWOK_NS" --dry-run=client -o yaml \
   | kubectl --context "$CTX" apply -f - >/dev/null
+# apply -n, not just template --namespace: helm template renders manifests
+# WITHOUT namespace metadata (helm install injects it server-side), so a bare
+# apply lands everything in the context's default namespace — found live,
+# the rollout wait then looking for a controller that existed one namespace
+# over. Explicit namespaces in rendered docs still win over -n.
 helm template kwok kwok/kwok --version "$KWOK_CHART_VERSION" \
   --namespace "$KWOK_NS" -f "$REPO/demo/kwok-values.yaml" \
   | python3 -c 'import sys; print("\n---".join(d for d in sys.stdin.read().split("\n---") if "kind: FlowSchema" not in d))' \
-  | kubectl --context "$CTX" apply -f - >/dev/null
+  | kubectl --context "$CTX" -n "$KWOK_NS" apply -f - >/dev/null
 kubectl --context "$CTX" -n "$KWOK_NS" rollout status deployment/kwok-controller --timeout=3m >/dev/null
 helm --kube-context "$CTX" upgrade --install kwok-stage-fast kwok/stage-fast --version "$KWOK_CHART_VERSION" \
   --namespace "$KWOK_NS" --wait --timeout 3m >/dev/null


### PR DESCRIPTION
Second live launch, second half of the FlowSchema fix's bug: `helm template` renders without namespace metadata (that injection is `helm install`'s job), so the filtered apply landed the kwok controller in `default` and the rollout wait searched `kwok`. The apply now carries `-n kwok`; client dry-run shows Deployment and Service placed correctly. Teardown held on both failed launches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)