### PR TITLE
Playground: include the kwok CRDs in the rendered install

### DIFF
--- a/hack/gcp-playground.sh
+++ b/hack/gcp-playground.sh
@@ -156,10 +156,14 @@ kubectl --context "$CTX" create namespace "$KWOK_NS" --dry-run=client -o yaml \
 # apply lands everything in the context's default namespace — found live,
 # the rollout wait then looking for a controller that existed one namespace
 # over. Explicit namespaces in rendered docs still win over -n.
+# --include-crds: the third thing helm install does that helm template does
+# not — the chart's crds/ directory never renders without it, and stage-fast's
+# Stage objects have nothing to land on. Found live, one launch per layer.
 helm template kwok kwok/kwok --version "$KWOK_CHART_VERSION" \
-  --namespace "$KWOK_NS" -f "$REPO/demo/kwok-values.yaml" \
+  --namespace "$KWOK_NS" --include-crds -f "$REPO/demo/kwok-values.yaml" \
   | python3 -c 'import sys; print("\n---".join(d for d in sys.stdin.read().split("\n---") if "kind: FlowSchema" not in d))' \
   | kubectl --context "$CTX" -n "$KWOK_NS" apply -f - >/dev/null
+kubectl --context "$CTX" wait --for=condition=established crd/stages.kwok.x-k8s.io --timeout=60s >/dev/null
 kubectl --context "$CTX" -n "$KWOK_NS" rollout status deployment/kwok-controller --timeout=3m >/dev/null
 helm --kube-context "$CTX" upgrade --install kwok-stage-fast kwok/stage-fast --version "$KWOK_CHART_VERSION" \
   --namespace "$KWOK_NS" --wait --timeout 3m >/dev/null


### PR DESCRIPTION
Third launch, third `helm template` ≠ `helm install` gap: the `crds/` directory only renders with `--include-crds`, so stage-fast's Stage objects had no CRD. Added, plus a `kubectl wait --for=condition=established` on the stages CRD before stage-fast.

**Verified on a genuinely fresh cluster this time** (the prior fixes' dry-runs shared their bugs' blind spots): full fabric block executed against a throwaway k3d — 12 CRDs applied, stages established, controller rolled out, stage-fast in, demo chart up with 26 fake nodes and Running pods, then deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)