### PR TITLE
Playground: workloads sized to leave slack

### DIFF
--- a/hack/gcp-playground.sh
+++ b/hack/gcp-playground.sh
@@ -215,18 +215,21 @@ restore_context
 green "  up"
 
 # ------------------------------------------------------- real workloads
-# Restricted-PSS-compliant nginx with real readiness probes, sized so six
-# e2-mediums end up fragmented: enough spread that the plan frees a node or
-# two, enough headroom that every eviction has somewhere to land. The
-# scenario adds the constraint that should change the ratings — the same
-# grammar as the demo chart, spoken by real pods.
+# Restricted-PSS-compliant nginx with real readiness probes, sized to leave
+# SLACK: launch six packed the fleet to 92-97% once GKE's own daemons
+# (~300m/node) joined, and above the packing ceiling the planner rightly
+# said there was nothing to improve. A consolidation demo needs a
+# fragmented cluster, not a full one — the spread scheduler scatters these
+# to ~55-65% per node, which the ceiling can then pack into fewer machines.
+# The scenario adds the constraint that should change the ratings — the
+# same grammar as the demo chart, spoken by real pods.
 real_base() {
   cat <<EOF
 apiVersion: apps/v1
 kind: Deployment
 metadata: { name: play-web, namespace: ${DEMO_NS}, labels: { app: play-web } }
 spec:
-  replicas: 8
+  replicas: 4
   selector: { matchLabels: { app: play-web } }
   template:
     metadata: { labels: { app: play-web } }
@@ -244,7 +247,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata: { name: play-cache, namespace: ${DEMO_NS}, labels: { app: play-cache } }
 spec:
-  replicas: 5
+  replicas: 3
   selector: { matchLabels: { app: play-cache } }
   template:
     metadata: { labels: { app: play-cache } }
@@ -262,7 +265,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata: { name: play-filler, namespace: ${DEMO_NS}, labels: { app: play-filler } }
 spec:
-  replicas: 6
+  replicas: 3
   selector: { matchLabels: { app: play-filler } }
   template:
     metadata: { labels: { app: play-filler } }


### PR DESCRIPTION
Launch 6's finding: the UI came up and the plan honestly said *nothing to improve* — the fleet was at 92–97% requests (my sizing + GKE's ~300m/node of system daemons), which is above the packing ceiling, so no destination could absorb anything. Right answer, useless demo.

Base workloads shrink to scatter at ~55–65% per node. **Verified on the live run**: hand-scaling the same deployments took the plan from 0 steps to 2 Green drains within one resync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)