### PR TITLE
Playground: usage collection on from install

### DIFF
--- a/hack/gcp-playground.sh
+++ b/hack/gcp-playground.sh
@@ -521,6 +521,7 @@ helm --kube-context "$CTX" upgrade --install "$RELEASE" "$REPO/charts/k8s-dencer
   --set persistence.enabled=true \
   --set-string persistence.storageClass=standard-rwo \
   --set executor.enabled=true \
+  --set planner.usageSource=metrics-server \
   "${READINESS_SET[@]}" \
   "${SAFETY_SET[@]}" \
   --set planner.minNodeAge=30s \


### PR DESCRIPTION
GKE has metrics-server by default; the playground now sets `planner.usageSource=metrics-server` at install so the Load lens draws from launch. Found the hard way: enabling it live mid-window restarted the planner into the volume-affinity squeeze (Pending, no fresh plans, a stale step offering an already-empty cordoned node). The source self-degrades if metrics-server is absent, so the flag is safe everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)