### PR TITLE
Review follow-ups: security headers, RecsPage ARIA, docs currency

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,10 +223,12 @@ stops sending an element per pod and starts sending occupancy per node — an
 individual 6px block conveys nothing at that density anyway. Method, growth
 curves and the known ceiling in **[docs/benchmarks.md](docs/benchmarks.md)**.
 
-The field itself has three renderings and picks one by cluster size: **Rack** to
-120 nodes, where a pod is an object you can point at; **Wells** to 600, a level
-per node, readable without reading numbers; **Panel** above that, one sorted row
-per node. Any of the three can be chosen explicitly and the choice persists.
+The Cluster destination views the same nodes through three lenses, defaulting
+by cluster size: **Rack** to 120 nodes, where a pod is an object you can point
+at; **Wells** to 600, each node a vessel with the planner's real packing
+ceiling drawn on it; **Load** above that, one sorted row per node showing used
+versus reserved-but-idle. Any lens can be chosen explicitly and the choice
+persists.
 
 How full a node is means the **larger of its CPU and memory requests** as a
 fraction of allocatable — the dimension that actually limits packing, and the
@@ -234,11 +236,12 @@ same one the planner ranks on. Requests, not usage: Kubernetes schedules on what
 pods ask for, so a node at 50% requested is half unschedulable however idle its
 cores are.
 
-The field also separates **what is observed from what is predicted**. Facts
+The lenses also separate **what is observed from what is predicted**. Facts
 about the real cluster — a node cordoned, NotReady, drained and awaiting
-removal, or actually reclaimed — are worded on the node itself and hold still
-while the scrubber animates the plan's forecast over them. During a run the
-executor's own event trail marks cordons and drains as they genuinely happen.
+removal, or actually reclaimed — are worded on the node itself, apart from the
+plan's intent colouring. During a run the executor's own event trail marks
+cordons, evictions and drains as they genuinely happen, and evicted pods ghost
+until the next snapshot says where they truly landed.
 
 ## Documentation
 
@@ -251,6 +254,7 @@ executor's own event trail marks cordons and drains as they genuinely happen.
 | [Execution and safety](docs/execution.md) | Per-step behaviour, the guard's rails, maintenance windows, audit |
 | [Observability](docs/observability.md) | Prometheus metrics per component |
 | [Development](docs/development.md) | Local loop, KWOK fabric, CI gates, releases |
+| [The GCP playground](docs/gcp-playground.md) | A timed, self-destructing GKE cluster with real workloads and a random scenario |
 | [Benchmarks](docs/benchmarks.md) | Measured cost, growth curves, the ceiling |
 | [Product roadmap](docs/product-roadmap.md) | Shipped capabilities and what comes next, as features |
 | [Engineering roadmap](docs/roadmap.md) | The milestone history — built, planned, and deliberately dropped |
@@ -262,8 +266,9 @@ executor's own event trail marks cordons and drains as they genuinely happen.
 execution, and maintenance windows. Phase 4 — hardening toward 1000 nodes and
 50,000 pods — is in progress, with metrics, CI and the release pipeline landed.
 
-**v0.1.0 is published** — images and chart on `ghcr.io`, installable by the
-command above.
+**v0.3.0 is published** — images and chart on `ghcr.io`, installable by the
+command above. It carries the redesigned UI, the packing ceiling, and per-node
+measured usage.
 
 **The UI has been rebuilt against a full design handoff** (2026-08-01): twelve
 mockup frames, a dual-theme token system with computed-contrast guards, and

--- a/charts/k8s-dencer/templates/ui-frontend/configmap.yaml
+++ b/charts/k8s-dencer/templates/ui-frontend/configmap.yaml
@@ -29,6 +29,17 @@ data:
         root /usr/share/nginx/html;
         index index.html;
 
+        # Security headers on every response. A console that holds a bearer token
+        # in the tab must not be frameable, and its responses must never be
+        # MIME-sniffed into something executable. The CSP names exactly what the
+        # bundle uses: self-hosted assets, data: for inlined images, and inline
+        # style ATTRIBUTES (React style={}), which style-src cannot allow more
+        # narrowly than 'unsafe-inline'.
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "DENY" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'" always;
+
         location = /config.js {
             add_header Cache-Control "no-store" always;
             try_files $uri =404;

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@
 | **[Execution and safety](execution.md)** | What the executor does per step, the Safety Guard's rails, maintenance windows, and the audit trail |
 | **[Observability](observability.md)** | Prometheus metrics and what each component publishes |
 | **[Running the cloud test on GCP](gcp-setup.md)** | Account, project, billing, quota — everything to do by hand, once |
+| **[The GCP playground](gcp-playground.md)** | A timed, self-destructing GKE cluster with real workloads and a random scenario |
 | **[Development](development.md)** | The local loop, the KWOK fake-node fabric, the CI gates, and cutting a release |
 | **[Benchmarks](benchmarks.md)** | Measured cost per operation, and where each stage stops being usable |
 | **[Findings](findings.md)** | Bugs and gaps found by running it — what hid, and why |

--- a/docs/product-roadmap.md
+++ b/docs/product-roadmap.md
@@ -105,7 +105,7 @@ deciding what to build next and telling users what they get.
 
 ### Interfaces
 - **Web UI** — dark instrument-style design; three field renderings chosen by
-  cluster size (Rack ≤120 nodes, Wells ≤600, Panel above), each switchable and
+  cluster size (Rack ≤120 nodes, Wells ≤600, Load above), each switchable and
   persistent; step scrubber; per-node and per-pod inspector; verified identity
   and cluster label in the chrome
 - **CLI** — `dencer` and `kubectl dencer` plugin; everything the UI does, with
@@ -156,7 +156,7 @@ what it already records and packs. Chosen because they reuse the machinery
 as it stands, and two of them serve audiences far larger than
 consolidation's.
 
-7. **Cost awareness, remaining slices** — pricing and a cost-aware planner
+1. **Cost awareness, remaining slices** — pricing and a cost-aware planner
    objective. The facts shipped first: instance type and capacity type are on
    every node (Inspector), and the plan states how its reclaimable nodes are
    bought — "7 spot, 4 on-demand" — with unpriced nodes omitted rather than

--- a/ui/nginx.conf
+++ b/ui/nginx.conf
@@ -12,6 +12,17 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Security headers on every response. A console that holds a bearer token
+    # in the tab must not be frameable, and its responses must never be
+    # MIME-sniffed into something executable. The CSP names exactly what the
+    # bundle uses: self-hosted assets, data: for inlined images, and inline
+    # style ATTRIBUTES (React style={}), which style-src cannot allow more
+    # narrowly than 'unsafe-inline'.
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'" always;
+
     # Runtime config must never be cached: it is how a redeploy changes the
     # API endpoint without rebuilding the image.
     location = /config.js {

--- a/ui/src/components/recs/RecsPage.tsx
+++ b/ui/src/components/recs/RecsPage.tsx
@@ -74,10 +74,11 @@ export default function RecsPage({ recs, steps, graph, muted, onMute, onUnmute, 
         <span className="recspage-counts mono">
           {all.length} finding{all.length === 1 ? "" : "s"} · {highCount} high
         </span>
-        <div className="recspage-filters">
+        <div className="recspage-filters" role="group" aria-label="Filter findings">
           <button
             type="button"
             className={"steplist-filter" + (!showAll ? " is-on" : "")}
+            aria-pressed={!showAll}
             onClick={() => setShowAll(false)}
           >
             Blocking a step
@@ -85,6 +86,7 @@ export default function RecsPage({ recs, steps, graph, muted, onMute, onUnmute, 
           <button
             type="button"
             className={"steplist-filter" + (showAll ? " is-on" : "")}
+            aria-pressed={showAll}
             onClick={() => setShowAll(true)}
           >
             All findings
@@ -127,7 +129,7 @@ export default function RecsPage({ recs, steps, graph, muted, onMute, onUnmute, 
             <span className="eyebrow mono">Rule</span>
             <span className="eyebrow mono recsqueue-cols-right">Unblocks</span>
           </div>
-          <div className="recsqueue-list">
+          <div className="recsqueue-list" role="list" aria-label="Findings, ranked by nodes unlocked">
             {visible.length === 0 && (
               <p className="recsqueue-empty">
                 {showAll
@@ -146,6 +148,12 @@ export default function RecsPage({ recs, steps, graph, muted, onMute, onUnmute, 
               return (
                 <button
                   type="button"
+                  role="listitem"
+                  aria-current={
+                    current && findingKey(current.kind, current.workload) === key
+                      ? "true"
+                      : undefined
+                  }
                   key={key}
                   className={
                     "recsrow" +
@@ -156,7 +164,10 @@ export default function RecsPage({ recs, steps, graph, muted, onMute, onUnmute, 
                   }
                   onClick={() => setSelected(key)}
                 >
-                  <span className={"recsrow-sev recsrow-sev-" + r.severity}>
+                  <span
+                    className={"recsrow-sev recsrow-sev-" + r.severity}
+                    aria-label={"severity " + r.severity}
+                  >
                     {SEV_LABEL[r.severity]}
                   </span>
                   <span className="recsrow-body">
@@ -230,7 +241,7 @@ function Detail({
   );
 
   return (
-    <aside className="recsdetail">
+    <aside className="recsdetail" aria-label={`Finding detail: ${rec.kind} on ${rec.workload}`}>
       <div className="recsdetail-head">
         <div className="recsdetail-tags">
           <span className={"recsrow-sev recsrow-sev-" + rec.severity}>


### PR DESCRIPTION
The small fixes from today's four-way review:

- **Security headers** on the UI (image nginx.conf + chart ConfigMap overlay): `nosniff`, `X-Frame-Options: DENY`, strict referrer, and a tight CSP (`style-src 'unsafe-inline'` is required by React style attributes; everything else is `'self'`/`data:`).
- **RecsPage ARIA**: filter group + pressed states, list/listitem + `aria-current`, labelled detail pane, severity announced.
- **Docs currency**: README's UI description matches the shipped lenses (Panel→Load, scrubber→observed overlay), Status says **v0.3.0**, the playground doc is linked from both indexes, roadmap numbering fixed.

Chart contract, palette, test/ui, density, typecheck, build: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)