### PR TITLE
User-reported doc gaps: CRDs section + CLI-only install (with the uiFrontend.enabled flag to back it)

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,10 @@ helm install k8s-dencer oci://ghcr.io/atedgimo/charts/k8s-dencer \
   --set auth.enabled=true
 ```
 
+The chart installs one CRD (`maintenancewindows.dencer.io`); the `dencer.io`
+resources in its RBAC are SubjectAccessReview permission names, not CRDs — see
+[docs/install.md](docs/install.md#crds).
+
 Execution stays off unless you ask for it, and the chart refuses to enable it
 without authentication and persistence:
 

--- a/charts/k8s-dencer/templates/pdb.yaml
+++ b/charts/k8s-dencer/templates/pdb.yaml
@@ -7,12 +7,15 @@ k8s-dencer exists to detect — shipping one would be indefensible. maxUnavailab
 always leaves a node drain a way through.
 */}}
 {{- $components := list
-  (dict "name" "planner"     "cfg" .Values.planner)
-  (dict "name" "ui-backend"  "cfg" .Values.uiBackend)
-  (dict "name" "ui-frontend" "cfg" .Values.uiFrontend)
+  (dict "name" "planner"     "cfg" .Values.planner "on" true)
+  (dict "name" "ui-backend"  "cfg" .Values.uiBackend "on" true)
+  (dict "name" "ui-frontend" "cfg" .Values.uiFrontend "on" .Values.uiFrontend.enabled)
 -}}
 {{- range $c := $components }}
-{{- if $c.cfg.podDisruptionBudget.enabled }}
+{{/* A PDB whose selector matches nothing is noise — and this product's own
+     audit would flag it, which would be embarrassing. Skip disabled
+     components entirely. */}}
+{{- if and $c.on $c.cfg.podDisruptionBudget.enabled }}
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget

--- a/charts/k8s-dencer/templates/ui-frontend/configmap.yaml
+++ b/charts/k8s-dencer/templates/ui-frontend/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.uiFrontend.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -71,3 +72,4 @@ data:
             try_files $uri $uri/ /index.html;
         }
     }
+{{- end }}

--- a/charts/k8s-dencer/templates/ui-frontend/deployment.yaml
+++ b/charts/k8s-dencer/templates/ui-frontend/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.uiFrontend.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -120,3 +121,4 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/charts/k8s-dencer/templates/ui-frontend/service.yaml
+++ b/charts/k8s-dencer/templates/ui-frontend/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.uiFrontend.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -18,3 +19,4 @@ spec:
       protocol: TCP
   selector:
     {{- include "k8s-dencer.componentSelectorLabels" (dict "ctx" . "component" "ui-frontend") | nindent 4 }}
+{{- end }}

--- a/charts/k8s-dencer/values.schema.json
+++ b/charts/k8s-dencer/values.schema.json
@@ -270,6 +270,7 @@
         {
           "type": "object",
           "properties": {
+            "enabled": { "type": "boolean" },
             "replicaCount": {
               "type": "integer",
               "minimum": 1

--- a/charts/k8s-dencer/values.yaml
+++ b/charts/k8s-dencer/values.yaml
@@ -206,6 +206,10 @@ uiBackend:
     maxUnavailable: 1
 
 uiFrontend:
+  # The web UI is optional: a CLI-only install sets this false and keeps
+  # planner + ui-backend (the API the CLI talks to). Ingress and httpRoute
+  # both point at the frontend, so leave them disabled when this is off.
+  enabled: true
   replicaCount: 2
   image:
     registry: ghcr.io

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -23,6 +23,24 @@ The symlink is what makes `kubectl dencer plan` work — kubectl treats any
 `kubectl-*` binary on PATH as a plugin. Every global flag is spelled the way
 kubectl spells it, so muscle memory carries over.
 
+## CLI-only install (no web UI)
+
+The CLI needs two of the release's components: the **planner** (produces the
+plans) and the **ui-backend** (the API the CLI talks to — the name is
+historical; it serves the CLI equally). The web frontend is optional:
+
+```bash
+helm install k8s-dencer oci://ghcr.io/atedgimo/charts/k8s-dencer \
+  --namespace k8s-dencer --create-namespace \
+  --set uiFrontend.enabled=false
+```
+
+Add `--set executor.enabled=true` only if this install should be able to
+`run`, `converge` or `drain` — analysis commands need no executor. Leave
+`ingress`/`httpRoute` disabled (their target is the frontend). Everything
+else — authentication, RBAC, the plan store — is identical to a full
+install.
+
 ## Connecting
 
 With no flags, `dencer` finds the `ui-backend` Service through your kubeconfig

--- a/docs/install.md
+++ b/docs/install.md
@@ -107,6 +107,42 @@ infrastructure with its own owner, address and TLS story. `parentRefs` names
 the Gateway this route attaches to, and the schema refuses an enabled route
 with no parent, so it cannot dangle.
 
+## Installing without the web UI
+
+`--set uiFrontend.enabled=false` keeps planner + API and drops the frontend —
+the install for teams using only the [`dencer` CLI](cli.md#cli-only-install-no-web-ui).
+
+## CRDs
+
+The chart ships **exactly one** CRD: `maintenancewindows.dencer.io` — the
+object that says *when* execution is allowed (see
+[execution.md](execution.md)). Helm installs it automatically on first
+install; nothing else to do.
+
+Two things users reasonably look for and should not:
+
+- **Helm never touches CRDs on upgrade.** That is Helm's design, kept
+  deliberately: a bad CRD change can orphan existing objects. If a chart
+  upgrade changes the CRD, apply it yourself:
+
+  ```bash
+  kubectl apply -f https://raw.githubusercontent.com/atedgimo/k8s-dencer/main/charts/k8s-dencer/crds/dencer.io_maintenancewindows.yaml
+  ```
+
+  (From a repo checkout, `make crd-upgrade` does the same.)
+
+- **`dencer.io/plans` and `dencer.io/consolidations` are not CRDs and never
+  will be.** They appear in the chart's RBAC because the API authorizes with
+  SubjectAccessReview, and SAR permissions do not require the resource to
+  exist as an API type — they are named permissions, nothing more. Plans
+  live in the product's own store, not in etcd (the reasoning is in
+  [architecture.md](architecture.md)), so `kubectl get plans.dencer.io`
+  will never work: the UI, the `dencer` CLI, or `GET /api/v1/plans` is how
+  plans are read.
+
+The demo fabric additionally needs KWOK's `Stage` CRDs, but only for the
+demo — `make demo` installs them; a product install does not.
+
 ## Known constraints
 
 - **SQLite is single-writer.** `uiBackend.replicaCount` is pinned to 1 and enforced by the schema; the planner is co-scheduled with ui-backend via a `requiredDuringScheduling` podAffinity, because a ReadWriteOnce claim only permits multiple pods on the same node. Both constraints disappear when the Postgres store lands.


### PR DESCRIPTION
Two gaps from real users:

**CRDs** — install.md now covers: the one CRD that ships (`maintenancewindows.dencer.io`), Helm's never-on-upgrade behaviour with the apply command, and the actual confusion source: the `dencer.io` RBAC resources are SAR permission names, **not** CRDs — `kubectl get plans.dencer.io` will never work by design. README pointer added.

**CLI-only install** — previously unsupported: the frontend rendered unconditionally. New `uiFrontend.enabled` (default `true`) guards deployment/service/configmap and skips the frontend PDB when off (first cut hit the Sprig `false | default true` falsy trap — caught by rendering both ways: 3 Deployments on, 2 off). `docs/cli.md` documents the minimal footprint: planner + ui-backend; executor only for mutating commands.

Chart contract, palette, test/ui green; both render paths verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)