### PR TITLE
Release v0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,9 +274,12 @@ until the next snapshot says where they truly landed.
 execution, and maintenance windows. Phase 4 — hardening toward 1000 nodes and
 50,000 pods — is in progress, with metrics, CI and the release pipeline landed.
 
-**v0.3.0 is published** — images and chart on `ghcr.io`, installable by the
-command above. It carries the redesigned UI, the packing ceiling, and per-node
-measured usage.
+**v0.4.0 is published** — images, chart and CLI binaries on `ghcr.io` and the
+[releases page](https://github.com/atedgimo/k8s-dencer/releases), installable by
+the command above. It carries the redesigned UI, the packing ceiling, per-node
+measured usage, a CLI that authenticates against cloud kubeconfigs without being
+handed a token, and an install that can leave the web UI out entirely
+(`uiFrontend.enabled=false`).
 
 **The UI has been rebuilt against a full design handoff** (2026-08-01): twelve
 mockup frames, a dual-theme token system with computed-contrast guards, and

--- a/charts/k8s-dencer/Chart.yaml
+++ b/charts/k8s-dencer/Chart.yaml
@@ -10,8 +10,8 @@ type: application
 
 # Chart version tracks the chart; appVersion tracks the images. Component image
 # tags default to appVersion so a chart release pins a coherent image set.
-version: 0.3.0
-appVersion: "0.3.0"
+version: 0.4.0
+appVersion: "0.4.0"
 
 # controller-runtime and the policy/v1 PDB API used here are stable from 1.21,
 # but the chart relies on 1.27-era defaults for restricted Pod Security


### PR DESCRIPTION
Cuts v0.4.0. Nineteen merges have been sitting in main since v0.3.0 was tagged on 1 August, and tags here are manual, so none of that work has reached anyone.

**Why a minor and not a patch:** two of those merges add capability rather than fix behaviour — `uiFrontend.enabled` is a new chart value, and the CLI gained automatic credential-plugin auth. New backwards-compatible functionality is a minor bump, even in 0.x.

**What ships:**

| Change | PR |
|---|---|
| CLI resolves bearer tokens from cloud kubeconfigs automatically (GKE/EKS/AKS/OIDC), with a stderr notice naming the plugin | #121 by @jainpratik163 |
| `uiFrontend.enabled=false` — install the product without the web UI | #122 |
| CRDs and CLI-only install documented | #122 |
| Security headers on the UI (CSP, nosniff, frame-ancestors, referrer policy) and accessibility fixes | #114 |
| README hero animation | #115 |

The playground work (#101–#113) is developer tooling and ships to nobody, so it doesn't figure in the number.

**The reason not to leave this sitting:** the CLI binaries attached to the v0.3.0 release still carry the auth bug a user reported. Anyone downloading `dencer` today hits it, and the fix currently exists only for people who build from source.

Chart `version` and `appVersion` both move to 0.4.0 — the release workflow hard-fails the publish if they disagree with the tag. README status updated in the same commit.

Tag goes up once this merges.