### PR TITLE
Answer --version, and stop building the CLI twice

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,18 +101,15 @@ jobs:
       # Static, cross-compiled, no cgo — the same properties the server images
       # rely on, for the same reason: a CLI that can drain nodes should not
       # depend on the libc of whatever machine it lands on.
+      #
+      # This calls the same target a contributor runs locally rather than
+      # keeping a second copy of the build here. The two had already drifted
+      # apart on the checksum filename once.
       - name: build
-        env:
-          VERSION: ${{ steps.v.outputs.version }}
-        run: |
-          mkdir -p dist
-          for target in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64; do
-            os="${target%/*}"; arch="${target#*/}"
-            CGO_ENABLED=0 GOOS="$os" GOARCH="$arch" go build \
-              -trimpath -ldflags="-s -w -X main.version=${VERSION}" \
-              -o "dist/dencer-${os}-${arch}" ./cmd/dencer
-          done
-          cd dist && sha256sum dencer-* > checksums.txt && cat checksums.txt
+        run: make cli-release CLI_VERSION=${{ steps.v.outputs.version }}
+
+      - name: checksums
+        run: cat dist/checksums.txt
 
       - name: attach to the release
         env:

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,13 @@ IMAGE_PREFIX ?= k8s-dencer
 PLATFORMS      ?= linux/amd64,linux/arm64
 CLI_PLATFORMS  ?= linux/amd64 linux/arm64 darwin/amd64 darwin/arm64
 CLI_DIST       ?= dist
+# The release workflow overrides this with the tag, so a published binary
+# reports the release it came from rather than the commit it was built at.
+CLI_VERSION    ?= $(IMAGE_TAG)
+# The release runs on Linux and development runs on macOS; only one of these
+# two exists on either. Both emit the same "<hash>  <file>" format.
+SHA256         := $(shell command -v sha256sum >/dev/null 2>&1 \
+                    && echo sha256sum || echo "shasum -a 256")
 
 # Pinned tool versions, installed into ./bin so a workstation without brew
 # still gets a reproducible lint.
@@ -195,11 +202,11 @@ cli-release: ## Build static dencer binaries for linux and darwin (amd64, arm64)
 	  echo "==> $$out"; \
 	  CGO_ENABLED=0 GOOS=$$os GOARCH=$$arch go build \
 	    -trimpath \
-	    -ldflags="-s -w -X main.version=$(IMAGE_TAG)" \
+	    -ldflags="-s -w -X main.version=$(CLI_VERSION)" \
 	    -o $$out ./cmd/dencer; \
 	done
-	@cd $(CLI_DIST) && shasum -a 256 dencer-* > SHA256SUMS
-	@echo "==> $(CLI_DIST)/ (binaries + SHA256SUMS)"
+	@cd $(CLI_DIST) && $(SHA256) dencer-* > checksums.txt
+	@echo "==> $(CLI_DIST)/ (binaries + checksums.txt)"
 
 .PHONY: e2e
 e2e: ## Install on a throwaway multi-node k3d cluster and drain a real node

--- a/cmd/dencer/main.go
+++ b/cmd/dencer/main.go
@@ -45,7 +45,7 @@ Commands:
   rightsizing           requests vs observed usage, per workload
   whatif                simulate losing nodes or a zone: does everything still fit?
   drain <node>          guarded drain of one node: the rails, not bare kubectl
-  version
+  version               the version of this binary (also --version)
 
 Global flags:
   --server URL          backend base URL. Default: port-forward via kubeconfig
@@ -94,7 +94,10 @@ func run() error {
 	case "-h", "--help", "help":
 		fmt.Print(usage)
 		return nil
-	case "version":
+	// --version is not kubectl's spelling, but it is the reflex of everyone
+	// who has ever met another CLI, and answering "unknown command" to it is
+	// a poor first impression from a tool that drains nodes.
+	case "version", "--version":
 		fmt.Printf("dencer %s\n", version)
 		return nil
 	}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -11,13 +11,26 @@ step is Red.
 
 ## Install
 
+Prebuilt binaries are attached to every release from v0.3.0 onward, static and
+cgo-free, for linux and darwin on amd64 and arm64:
+
 ```bash
-make cli-install    # installs dencer and kubectl-dencer into $GOBIN
+# pick your platform: dencer-{linux,darwin}-{amd64,arm64}
+curl -fsSLO https://github.com/atedgimo/k8s-dencer/releases/latest/download/dencer-darwin-arm64
+curl -fsSLO https://github.com/atedgimo/k8s-dencer/releases/latest/download/checksums.txt
+shasum -a 256 -c checksums.txt --ignore-missing
+chmod +x dencer-darwin-arm64 && sudo mv dencer-darwin-arm64 /usr/local/bin/dencer
 ```
 
-Prebuilt binaries are attached to GitHub releases from the first tag after
-v0.1.0 — that release published the images and the chart but predates the CLI,
-so building from a checkout is the only route until then.
+`dencer version` prints what you installed. Verify the checksum before you make
+it executable — this is a binary that can drain nodes.
+
+From a checkout instead:
+
+```bash
+make cli-install    # installs dencer and kubectl-dencer into $GOBIN
+make cli-release    # cross-compiles all four platforms into dist/, as CI does
+```
 
 The symlink is what makes `kubectl dencer plan` work — kubectl treats any
 `kubectl-*` binary on PATH as a plugin. Every global flag is spelled the way


### PR DESCRIPTION
Three small things the v0.4.0 release surfaced, all in the same corner of the project.

### `dencer --version` said "unknown command"

Only the bare `version` subcommand worked. `--version` is the reflex everyone arrives with, and answering it with an error is a poor first impression from a tool that can drain nodes. Now an alias — both spellings print the same line.

### The CLI was built twice, by two copies that had already drifted

`release.yml` carried its own cross-compile loop instead of calling `make cli-release`. The two disagreed: CI wrote `checksums.txt` via `sha256sum`, the Makefile wrote `SHA256SUMS` via `shasum -a 256`. Two builds claiming to be the same build is how a release quietly stops matching what a contributor can reproduce locally.

The workflow now calls the target. The published filename stays `checksums.txt` — v0.3.0 and v0.4.0 already shipped under it, and renaming would break anyone scripting against those releases.

Two changes made the target usable from CI:

- `CLI_VERSION` (defaults to `IMAGE_TAG`) so the release can stamp the tag, and a published binary reports the release it came from rather than the commit it was built at.
- The checksum tool is resolved at runtime, because the release runs on Linux (`sha256sum`) and development happens on macOS (`shasum -a 256`). Both emit the same `<hash>  <file>` format.

### The install docs said binaries didn't exist yet

They said prebuilt binaries would arrive "from the first tag after v0.1.0" — which stopped being true at v0.3.0. Replaced with actual download-and-verify instructions, including the checksum step, because this is a binary that drains nodes.

## Verification

- `make cli-release CLI_VERSION=0.4.1-test` produces all four binaries plus `checksums.txt`; `shasum -c` verifies them.
- Both `dencer --version` and `dencer version` print `dencer 0.4.1-test`, so the version override reaches the binary.
- The documented download commands were run **verbatim against the live v0.4.0 release** — downloads, and the checksum verifies `OK`.
- `go vet` and `go test ./internal/cli/...` clean.

The workflow path itself only executes on a tag push, so it gets its real proof at v0.5.0.