### PR TITLE
Playground: print the commands, and keep the screenshot script

### DIFF
--- a/hack/gcp-playground.sh
+++ b/hack/gcp-playground.sh
@@ -582,6 +582,44 @@ green  "  UI      http://localhost:${UI_PORT}"
 echo   "  token   (valid ${PLAY_MINUTES}m — paste into the sign-in field)"
 echo   "  ${TOKEN}"
 echo
+# Everything below was learned the hard way during a real session: the CLI is
+# not on anyone's PATH, `make` only works from the repo root, flags come after
+# the subcommand, and a positional argument has to be last or Go's flag package
+# swallows it. Printing the exact lines costs nothing and saves the window.
+bold "==> commands (copy-paste; the cluster is addressed by --context ${CTX})"
+cat <<COMMANDS
+  # what the product is doing
+  kubectl --context ${CTX} -n ${NS} get pods
+  kubectl --context ${CTX} -n ${NS} logs -l app.kubernetes.io/component=planner -f
+
+  # the workloads it is planning against
+  kubectl --context ${CTX} -n ${DEMO_NS} get pods -o wide
+  kubectl --context ${CTX} get nodes -o wide
+
+  # the CLI — build it once, from the repo root
+  make cli-install                       # installs dencer into \$GOBIN
+  go run ./cmd/dencer <command> [flags]  # or run it without installing
+
+  # dencer against this cluster (flags AFTER the subcommand)
+  dencer plan        --context ${CTX}
+  dencer preflight   --context ${CTX}
+  dencer audit       --context ${CTX}
+  dencer recommend   --context ${CTX}
+  dencer rightsizing --context ${CTX}
+  dencer status      --context ${CTX}
+
+  # commands taking an argument want it LAST, after every flag
+  dencer explain --context ${CTX} 1
+  dencer why     --context ${CTX} ${DEMO_NS}/<pod>
+  dencer drain   --context ${CTX} --dry-run <node>
+
+  # the closed loop, inside bounds you set
+  dencer converge --context ${CTX} --max-nodes 2 --max-impact Green --dry-run
+
+  # a fresh UI token whenever this one expires
+  kubectl --context ${CTX} -n ${NS} create token dencer-operator --duration=30m
+COMMANDS
+echo
 if [[ "$PLAY_FABRIC" == "real" ]]; then
   echo "  scenario ${SCENARIO}, on real machines: every drain is a real eviction,"
   echo "  and a node you free is Google's autoscaler's to remove — ~11 minutes,"

--- a/ui/e2e-demo/shots.mjs
+++ b/ui/e2e-demo/shots.mjs
@@ -1,0 +1,77 @@
+/**
+ * Screenshot the real UI at a named phase, for evidence rather than video.
+ *
+ * The walkthrough records a scripted tour; this takes stills of whatever the
+ * product is showing right now, which is what you want when the cluster
+ * underneath is real, costs money, and will not exist in an hour.
+ *
+ *   DENCER_URL=http://localhost:8092 DENCER_TOKEN=... SHOT_DIR=/path/to/phase \
+ *     node ui/e2e-demo/shots.mjs
+ */
+import { chromium } from "playwright";
+import { mkdirSync } from "node:fs";
+
+const URL = process.env.DENCER_URL || "http://localhost:8092";
+const TOKEN = process.env.DENCER_TOKEN || "";
+const OUT = process.env.SHOT_DIR || "shots";
+const pause = (ms) => new Promise((r) => setTimeout(r, ms));
+
+mkdirSync(OUT, { recursive: true });
+const browser = await chromium.launch();
+const ctx = await browser.newContext({ viewport: { width: 1440, height: 900 }, colorScheme: "dark" });
+const page = await ctx.newPage();
+await page.addInitScript(() => localStorage.setItem("dencer.theme", "dark"));
+
+const shot = async (name) => {
+  await page.screenshot({ path: `${OUT}/${name}.png` });
+  console.log(`  ${name}.png`);
+};
+
+await page.goto(URL, { waitUntil: "domcontentloaded" });
+await pause(1500);
+const tokenBox = page.locator("#token");
+if (await tokenBox.isVisible().catch(() => false)) {
+  await tokenBox.fill(TOKEN);
+  await page.getByRole("button", { name: /sign in with token/i }).click();
+}
+
+// Review — the hero and the step list, which is the whole product in one frame.
+await page.waitForSelector(".hero-headline", { timeout: 30000 }).catch(() => {});
+await pause(2500);
+await shot("1-review");
+
+// A step opened, so the Safety Guard reasoning is on the record.
+const rows = page.locator(".steprow");
+if ((await rows.count().catch(() => 0)) > 0) {
+  await rows.nth(0).click();
+  await pause(1800);
+  await shot("2-step-detail");
+}
+
+// The three Cluster lenses — Wells carries the packing ceiling.
+await page.locator('.rail-item:has-text("Cluster")').click().catch(() => {});
+await pause(2000);
+for (const lens of ["Wells", "Load", "Rack"]) {
+  const btn = page.locator(`.clusterpage-lenses .viewswitch-btn:has-text("${lens}")`);
+  if (await btn.isVisible().catch(() => false)) {
+    await btn.click();
+    await pause(1800);
+    await shot(`3-lens-${lens.toLowerCase()}`);
+  }
+}
+
+await page.locator('.rail-item:has-text("Recommendations")').click().catch(() => {});
+await pause(2000);
+await shot("4-recommendations");
+
+// History — the savings ledger, which only means anything on real machines.
+await page.locator('.rail-item:has-text("History")').click().catch(() => {});
+await pause(2500);
+await shot("5-history");
+
+await page.locator('.rail-item:has-text("Review")').click().catch(() => {});
+await pause(1200);
+
+await ctx.close();
+await browser.close();
+console.log(`shots in ${OUT}`);


### PR DESCRIPTION
A real session against a real GKE cluster spent its first minutes on questions the script already knew the answers to:

- `dencer` is not on anyone's PATH.
- `make cli-install` only works from the repo root.
- Flags come **after** the subcommand — `dencer --context x plan` fails with `unknown command "--context"`.
- Go's `flag` package stops at the first non-flag argument, so `dencer drain node-3 --yes` reports `which node? e.g. dencer drain worker-3`. The argument has to come **last**, which is the opposite of what that error's own example implies.

None of that is worth discovering on a 45-minute clock that costs money.

The ready banner now prints copy-pasteable lines: kubectl for both the product and workload namespaces, how to get the CLI, every `dencer` verb already carrying `--context gke-play`, the argument-taking forms spelled out in the order that actually parses, and how to mint a fresh UI token when the first expires.

Also promotes `ui/e2e-demo/shots.mjs` from a scratch file to a committed one. It sits beside `walkthrough.mjs` and borrows its selectors — the walkthrough records a scripted tour, this takes stills of whatever the product is showing right now, which is what you want when the cluster underneath is real, costs money, and will not exist in an hour. It produced the UI evidence behind the findings from that session.

## Verification

`bash -n` clean; heredoc expansion checked (`$GOBIN` stays literal, `${CTX}`/`${DEMO_NS}` interpolate). The command list is not invented — every line was run successfully against the live cluster during the session that prompted this.

Note the flag-ordering awkwardness is being papered over here, not fixed; it's filed separately as a CLI usability issue.