### PR TITLE
Recognise static pods, and stop counting pinned pods as drain blockers

### DIFF
--- a/internal/constraints/analyzer.go
+++ b/internal/constraints/analyzer.go
@@ -66,6 +66,7 @@ func analyzePod(pod model.Pod, snap *model.ClusterSnapshot, placement *Placement
 	// Controller pinning comes first: if the pod cannot move at all, the rest
 	// of the constraint set is context rather than explanation.
 	if pod.Owner != nil && pod.Owner.Kind == "DaemonSet" {
+		pc.PinnedToNode = true
 		pc.Constraints = append(pc.Constraints, Constraint{
 			Kind:     KindControllerPinned,
 			Subject:  pod.Owner.Kind + "/" + pod.Owner.Name,
@@ -74,6 +75,21 @@ func analyzePod(pod model.Pod, snap *model.ClusterSnapshot, placement *Placement
 			Explanation: fmt.Sprintf(
 				"Managed by DaemonSet %s, so it is pinned to node %s. Draining the node does not free this pod's capacity — it is recreated there.",
 				pod.Owner.Name, pod.NodeName),
+		})
+	}
+	// A static pod: defined by a file on the node, mirrored into the API with
+	// the Node as its controller. There is no controller that could place it
+	// anywhere else, which is exactly why an owner-kind allowlist misses it.
+	if pod.IsMirrorPod() {
+		pc.PinnedToNode = true
+		pc.Constraints = append(pc.Constraints, Constraint{
+			Kind:     KindControllerPinned,
+			Subject:  pod.Owner.Kind + "/" + pod.Owner.Name,
+			Hard:     true,
+			Blocking: true,
+			Explanation: fmt.Sprintf(
+				"A static pod, owned by node %s itself rather than by a controller. The kubelet recreates it here from a file on disk; nothing can move it, and draining the node does not free its capacity.",
+				pod.NodeName),
 		})
 	}
 	if pod.Terminating {

--- a/internal/constraints/constraints.go
+++ b/internal/constraints/constraints.go
@@ -62,6 +62,15 @@ type PodConstraints struct {
 	Movable     bool         `json:"movable"`
 	Constraints []Constraint `json:"constraints"`
 
+	// PinnedToNode separates "cannot move" from "stops the node draining".
+	//
+	// A DaemonSet or static pod can never be relocated, but it does not hold a
+	// drain up: the eviction API and `kubectl drain --ignore-daemonsets` both
+	// pass straight over it, and it is recreated on the node afterwards.
+	// Conflating the two is why a managed cluster — five or more such pods on
+	// every node — reported that not one node could drain cleanly.
+	PinnedToNode bool `json:"pinnedToNode,omitempty"`
+
 	// CandidateNodes are the other nodes this pod could legally occupy given
 	// current cluster state. An empty list on a movable pod means the pod is
 	// effectively stuck: there is nowhere for it to go.
@@ -148,6 +157,13 @@ func (a *Analysis) NodeDrainable(nodeName string) (bool, []Constraint) {
 	var blockers []Constraint
 	drainable := true
 	for _, pc := range a.ForNode(nodeName) {
+		// Pinned to the node by design, and therefore not in the way: the
+		// drain evicts around it and the kubelet or its DaemonSet puts it
+		// back. Counting these is how every node on a managed cluster came
+		// to be reported undrainable.
+		if pc.PinnedToNode {
+			continue
+		}
 		if !pc.Movable {
 			drainable = false
 			blockers = append(blockers, pc.Blockers()...)

--- a/internal/constraints/gke_managed_test.go
+++ b/internal/constraints/gke_managed_test.go
@@ -1,0 +1,145 @@
+package constraints_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/atedgimo/k8s-dencer/internal/constraints"
+)
+
+// The gke-managed fixture reproduces a real managed cluster: four e2-medium
+// nodes with 940m allocatable, the system DaemonSets every GKE node carries,
+// and — the reason it exists — kube-proxy as a static pod mirrored into the
+// API with the Node as its controller.
+//
+// Nothing in the kwok fixtures has a system pod at all, which is why the bugs
+// these tests pin down survived a full CI suite and were found by paying for a
+// cluster.
+
+const kubeProxy = "kube-system/kube-proxy-gke-dencer-play-default-pool-4ddb9382-0xk4"
+
+// A mirror pod cannot be rescheduled: delete it and the kubelet recreates it
+// on the same node. Nothing else can place it anywhere.
+func TestGKEManagedMirrorPodIsPinned(t *testing.T) {
+	snap := loadFixture(t, "gke-managed")
+	a := constraints.Analyze(snap)
+
+	pc, ok := a.ForPod(kubeProxy)
+	if !ok {
+		t.Fatalf("fixture does not contain %s", kubeProxy)
+	}
+	if pc.Movable {
+		t.Errorf("kube-proxy is a Node-owned mirror pod and must not be movable")
+	}
+	if len(pc.Blockers()) == 0 {
+		t.Errorf("a pinned pod should say why it cannot move")
+	}
+}
+
+// The cascade the mirror pod caused on the live cluster: treated as movable,
+// it was handed to the placement search, found no room under the ceiling, and
+// took its whole node down with it — on every node, because every node runs
+// one.
+func TestGKEManagedNoNodeIsBlockedByAMirrorPod(t *testing.T) {
+	snap := loadFixture(t, "gke-managed")
+	a := constraints.Analyze(snap)
+
+	for _, n := range snap.Nodes {
+		_, blockers := a.NodeDrainable(n.Name)
+		for _, b := range blockers {
+			if strings.Contains(b.Subject, "kube-proxy") {
+				t.Errorf("node %s is blocked by a mirror pod (%s: %s)",
+					n.Name, b.Kind, b.Explanation)
+			}
+		}
+	}
+}
+
+// DaemonSet pods are pinned, but pinning is not blocking: `kubectl drain
+// --ignore-daemonsets` is universal and the executor already drains through
+// them. A managed cluster runs five or more per node, so counting them is the
+// difference between a useful answer and "0 of N nodes will drain cleanly" on
+// every real cluster in existence.
+func TestGKEManagedDaemonSetsDoNotBlockDrains(t *testing.T) {
+	snap := loadFixture(t, "gke-managed")
+	a := constraints.Analyze(snap)
+
+	for _, n := range snap.Nodes {
+		_, blockers := a.NodeDrainable(n.Name)
+		for _, b := range blockers {
+			if b.Kind == constraints.KindControllerPinned && strings.Contains(b.Explanation, "DaemonSet") {
+				t.Errorf("node %s counts a DaemonSet as a drain blocker: %s", n.Name, b.Subject)
+			}
+		}
+	}
+}
+
+// The point of the two fixes together: a managed cluster becomes answerable.
+// Before them this fleet reported 0 of 4 nodes drainable behind roughly thirty
+// DaemonSet "blockers"; now one node drains and every remaining blocker is a
+// real capacity constraint an operator can act on.
+func TestGKEManagedGivesAUsefulAnswer(t *testing.T) {
+	snap := loadFixture(t, "gke-managed")
+	a := constraints.Analyze(snap)
+
+	drainable := 0
+	for _, n := range snap.Nodes {
+		ok, blockers := a.NodeDrainable(n.Name)
+		if ok {
+			drainable++
+		}
+		for _, b := range blockers {
+			if b.Kind != constraints.KindResources {
+				t.Errorf("node %s blocked by %s (%s); on this fixture every real blocker is capacity",
+					n.Name, b.Kind, b.Subject)
+			}
+		}
+	}
+	if drainable == 0 {
+		t.Errorf("no node drains: the fleet has slack, so this is the managed-cluster bug returning")
+	}
+}
+
+// The fixture is only useful while it keeps reproducing the cluster it was
+// taken from. These are the measurements from 2026-08-07.
+func TestGKEManagedShape(t *testing.T) {
+	snap := loadFixture(t, "gke-managed")
+
+	if got := len(snap.Nodes); got != 4 {
+		t.Fatalf("nodes = %d, want 4", got)
+	}
+	for _, n := range snap.Nodes {
+		if n.Allocatable.MilliCPU != 940 {
+			t.Errorf("%s allocatable = %dm, want 940m (e2-medium after GKE's reservation)",
+				n.Name, n.Allocatable.MilliCPU)
+		}
+		if n.InstanceType() != "e2-medium" {
+			t.Errorf("%s instance type = %q, want e2-medium", n.Name, n.InstanceType())
+		}
+	}
+
+	// System overhead per node, the number that cannot be reproduced on kwok.
+	system := map[string]int64{}
+	for _, p := range snap.Pods {
+		switch p.Namespace {
+		case "dencer-demo", "k8s-dencer":
+		default:
+			system[p.NodeName] += p.Requests.MilliCPU
+		}
+	}
+	var min, max int64 = 1 << 30, 0
+	for _, v := range system {
+		if v < min {
+			min = v
+		}
+		if v > max {
+			max = v
+		}
+	}
+	if min != 276 {
+		t.Errorf("minimum system overhead = %dm, want 276m", min)
+	}
+	if max < 600 {
+		t.Errorf("maximum system overhead = %dm, want the uneven fleet (>600m)", max)
+	}
+}

--- a/internal/model/cluster.go
+++ b/internal/model/cluster.go
@@ -148,6 +148,29 @@ type Pod struct {
 // Key is the namespace/name identifier.
 func (p Pod) Key() string { return p.Namespace + "/" + p.Name }
 
+// IsMirrorPod reports whether the kubelet, not a controller, owns this pod.
+//
+// A static pod is defined by a file on the node and mirrored into the API with
+// the Node itself as its controller. GKE ships kube-proxy this way, and every
+// managed platform ships something. Deleting the mirror object changes
+// nothing: the kubelet recreates it on the same node, immediately.
+func (p Pod) IsMirrorPod() bool { return p.Owner != nil && p.Owner.Kind == "Node" }
+
+// PinnedToNode reports whether the pod is bound to the node it is on by
+// design, so that no scheduler could place it anywhere else.
+//
+// This is deliberately not a list of owner kinds. The question is whether
+// anything is capable of moving the pod to a different node: a DaemonSet
+// recreates it here, and for a static pod there is no controller at all.
+// Treating a pinned pod as relocatable sends it to the placement search, which
+// then reports — correctly, and uselessly — that nowhere will take it.
+func (p Pod) PinnedToNode() bool {
+	if p.Owner == nil {
+		return false
+	}
+	return p.Owner.Kind == "DaemonSet" || p.Owner.Kind == "Node"
+}
+
 // IsMovable reports whether consolidation may relocate this pod at all.
 //
 // DaemonSet pods are excluded because they are pinned to their node by design:
@@ -157,7 +180,7 @@ func (p Pod) IsMovable() bool {
 	if p.Terminating || p.Phase == PodSucceeded || p.Phase == PodFailed {
 		return false
 	}
-	if p.Owner != nil && p.Owner.Kind == "DaemonSet" {
+	if p.PinnedToNode() {
 		return false
 	}
 	if p.DoNotDisrupt {

--- a/test/fixtures/gke-managed.yaml
+++ b/test/fixtures/gke-managed.yaml
@@ -1,0 +1,843 @@
+hasUsageData: false
+nodes:
+- allocatable:
+    memoryBytes: 2935664640
+    milliCPU: 940
+    pods: 110
+  capacity:
+    memoryBytes: 4294967296
+    milliCPU: 2000
+    pods: 110
+  createdAt: "2026-08-07T13:53:00Z"
+  labels:
+    cloud.google.com/gke-nodepool: default-pool
+    cloud.google.com/machine-family: e2
+    kubernetes.io/arch: amd64
+    kubernetes.io/hostname: gke-dencer-play-default-pool-4ddb9382-0xk4
+    kubernetes.io/os: linux
+    node.kubernetes.io/instance-type: e2-medium
+    topology.kubernetes.io/region: us-central1
+    topology.kubernetes.io/zone: us-central1-a
+  name: gke-dencer-play-default-pool-4ddb9382-0xk4
+  ready: true
+  unschedulable: false
+- allocatable:
+    memoryBytes: 2935664640
+    milliCPU: 940
+    pods: 110
+  capacity:
+    memoryBytes: 4294967296
+    milliCPU: 2000
+    pods: 110
+  createdAt: "2026-08-07T13:53:00Z"
+  labels:
+    cloud.google.com/gke-nodepool: default-pool
+    cloud.google.com/machine-family: e2
+    kubernetes.io/arch: amd64
+    kubernetes.io/hostname: gke-dencer-play-default-pool-4ddb9382-q58p
+    kubernetes.io/os: linux
+    node.kubernetes.io/instance-type: e2-medium
+    topology.kubernetes.io/region: us-central1
+    topology.kubernetes.io/zone: us-central1-a
+  name: gke-dencer-play-default-pool-4ddb9382-q58p
+  ready: true
+  unschedulable: false
+- allocatable:
+    memoryBytes: 2935664640
+    milliCPU: 940
+    pods: 110
+  capacity:
+    memoryBytes: 4294967296
+    milliCPU: 2000
+    pods: 110
+  createdAt: "2026-08-07T13:53:00Z"
+  labels:
+    cloud.google.com/gke-nodepool: default-pool
+    cloud.google.com/machine-family: e2
+    kubernetes.io/arch: amd64
+    kubernetes.io/hostname: gke-dencer-play-default-pool-4ddb9382-qvsk
+    kubernetes.io/os: linux
+    node.kubernetes.io/instance-type: e2-medium
+    topology.kubernetes.io/region: us-central1
+    topology.kubernetes.io/zone: us-central1-a
+  name: gke-dencer-play-default-pool-4ddb9382-qvsk
+  ready: true
+  unschedulable: false
+- allocatable:
+    memoryBytes: 2935664640
+    milliCPU: 940
+    pods: 110
+  capacity:
+    memoryBytes: 4294967296
+    milliCPU: 2000
+    pods: 110
+  createdAt: "2026-08-07T13:53:00Z"
+  labels:
+    cloud.google.com/gke-nodepool: default-pool
+    cloud.google.com/machine-family: e2
+    kubernetes.io/arch: amd64
+    kubernetes.io/hostname: gke-dencer-play-default-pool-4ddb9382-snln
+    kubernetes.io/os: linux
+    node.kubernetes.io/instance-type: e2-medium
+    topology.kubernetes.io/region: us-central1
+    topology.kubernetes.io/zone: us-central1-a
+  name: gke-dencer-play-default-pool-4ddb9382-snln
+  ready: true
+  unschedulable: false
+pdbs: null
+pods:
+- createdAt: "2026-08-07T13:58:00Z"
+  labels:
+    component: kube-proxy
+    tier: node
+  name: kube-proxy-gke-dencer-play-default-pool-4ddb9382-0xk4
+  namespace: kube-system
+  nodeName: gke-dencer-play-default-pool-4ddb9382-0xk4
+  owner:
+    kind: Node
+    name: gke-dencer-play-default-pool-4ddb9382-0xk4
+  phase: Running
+  ready: true
+  requests:
+    memoryBytes: 134217728
+    milliCPU: 100
+    pods: 0
+- createdAt: "2026-08-07T13:58:00Z"
+  labels:
+    k8s-app: fluentbit-gke
+  name: fluentbit-gke-0xk4
+  namespace: kube-system
+  nodeName: gke-dencer-play-default-pool-4ddb9382-0xk4
+  owner:
+    kind: DaemonSet
+    name: fluentbit-gke
+  phase: Running
+  ready: true
+  requests:
+    memoryBytes: 262144000
+    milliCPU: 105
+    pods: 0
+- createdAt: "2026-08-07T13:58:00Z"
+  labels:
+    k8s-app: node-local-dns
+  name: node-local-dns-0xk4
+  namespace: kube-system
+  nodeName: gke-dencer-play-default-pool-4ddb9382-0xk4
+  owner:
+    kind: DaemonSet
+    name: node-local-dns
+  phase: Running
+  ready: true
+  requests:
+    memoryBytes: 31457280
+    milliCPU: 30
+    pods: 0
+- createdAt: "2026-08-07T13:58:00Z"
+  labels:
+    component: gke-metrics-agent
+  name: gke-metrics-agent-0xk4
+  namespace: kube-system
+  nodeName: gke-dencer-play-default-pool-4ddb9382-0xk4
+  owner:
+    kind: DaemonSet
+    name: gke-metrics-agent
+  phase: Running
+  ready: true
+  requests:
+    memoryBytes: 104857600
+    milliCPU: 21
+    pods: 0
+- createdAt: "2026-08-07T13:58:00Z"
+  labels:
+    k8s-app: gcp-compute-persistent-disk-csi-driver
+  name: pdcsi-node-0xk4
+  namespace: kube-system
+  nodeName: gke-dencer-play-default-pool-4ddb9382-0xk4
+  owner:
+    kind: DaemonSet
+    name: pdcsi-node
+  phase: Running
+  ready: true
+  requests:
+    memoryBytes: 41943040
+    milliCPU: 15
+    pods: 0
+- createdAt: "2026-08-07T13:58:00Z"
+  labels:
+    app.kubernetes.io/name: collector
+  name: collector-0xk4
+  namespace: gmp-system
+  nodeName: gke-dencer-play-default-pool-4ddb9382-0xk4
+  owner:
+    kind: DaemonSet
+    name: collector
+  phase: Running
+  ready: true
+  requests:
+    memoryBytes: 41943040
+    milliCPU: 5
+    pods: 0
+- createdAt: "2026-08-07T13:58:00Z"
+  labels:
+    component: kube-proxy
+    tier: node
+  name: kube-proxy-gke-dencer-play-default-pool-4ddb9382-q58p
+  namespace: kube-system
+  nodeName: gke-dencer-play-default-pool-4ddb9382-q58p
+  owner:
+    kind: Node
+    name: gke-dencer-play-default-pool-4ddb9382-q58p
+  phase: Running
+  ready: true
+  requests:
+    memoryBytes: 134217728
+    milliCPU: 100
+    pods: 0
+- createdAt: "2026-08-07T13:58:00Z"
+  labels:
+    k8s-app: fluentbit-gke
+  name: fluentbit-gke-q58p
+  namespace: kube-system
+  nodeName: gke-dencer-play-default-pool-4ddb9382-q58p
+  owner:
+    kind: DaemonSet
+    name: fluentbit-gke
+  phase: Running
+  ready: true
+  requests:
+    memoryBytes: 262144000
+    milliCPU: 105
+    pods: 0
+- createdAt: "2026-08-07T13:58:00Z"
+  labels:
+    k8s-app: node-local-dns
+  name: node-local-dns-q58p
+  namespace: kube-system
+  nodeName: gke-dencer-play-default-pool-4ddb9382-q58p
+  owner:
+    kind: DaemonSet
+    name: node-local-dns
+  phase: Running
+  ready: true
+  requests:
+    memoryBytes: 31457280
+    milliCPU: 30
+    pods: 0
+- createdAt: "2026-08-07T13:58:00Z"
+  labels:
+    component: gke-metrics-agent
+  name: gke-metrics-agent-q58p
+  namespace: kube-system
+  nodeName: gke-dencer-play-default-pool-4ddb9382-q58p
+  owner:
+    kind: DaemonSet
+    name: gke-metrics-agent
+  phase: Running
+  ready: true
+  requests:
+    memoryBytes: 104857600
+    milliCPU: 21
+    pods: 0
+- createdAt: "2026-08-07T13:58:00Z"
+  labels:
+    k8s-app: gcp-compute-persistent-disk-csi-driver
+  name: pdcsi-node-q58p
+  namespace: kube-system
+  nodeName: gke-dencer-play-default-pool-4ddb9382-q58p
+  owner:
+    kind: DaemonSet
+    name: pdcsi-node
+  phase: Running
+  ready: true
+  requests:
+    memoryBytes: 41943040
+    milliCPU: 15
+    pods: 0
+- createdAt: "2026-08-07T13:58:00Z"
+  labels:
+    app.kubernetes.io/name: collector
+  name: collector-q58p
+  namespace: gmp-system
+  nodeName: gke-dencer-play-default-pool-4ddb9382-q58p
+  owner:
+    kind: DaemonSet
+    name: collector
+  phase: Running
+  ready: true
+  requests:
+    memoryBytes: 41943040
+    milliCPU: 5
+    pods: 0
+- createdAt: "2026-08-07T13:58:00Z"
+  labels:
+    component: kube-proxy
+    tier: node
+  name: kube-proxy-gke-dencer-play-default-pool-4ddb9382-qvsk
+  namespace: kube-system
+  nodeName: gke-dencer-play-default-pool-4ddb9382-qvsk
+  owner:
+    kind: Node
+    name: gke-dencer-play-default-pool-4ddb9382-qvsk
+  phase: Running
+  ready: true
+  requests:
+    memoryBytes: 134217728
+    milliCPU: 100
+    pods: 0
+- createdAt: "2026-08-07T13:58:00Z"
+  labels:
+    k8s-app: fluentbit-gke
+  name: fluentbit-gke-qvsk
+  namespace: kube-system
+  nodeName: gke-dencer-play-default-pool-4ddb9382-qvsk
+  owner:
+    kind: DaemonSet
+    name: fluentbit-gke
+  phase: Running
+  ready: true
+  requests:
+    memoryBytes: 262144000
+    milliCPU: 105
+    pods: 0
+- createdAt: "2026-08-07T13:58:00Z"
+  labels:
+    k8s-app: node-local-dns
+  name: node-local-dns-qvsk
+  namespace: kube-system
+  nodeName: gke-dencer-play-default-pool-4ddb9382-qvsk
+  owner:
+    kind: DaemonSet
+    name: node-local-dns
+  phase: Running
+  ready: true
+  requests:
+    memoryBytes: 31457280
+    milliCPU: 30
+    pods: 0
+- createdAt: "2026-08-07T13:58:00Z"
+  labels:
+    component: gke-metrics-agent
+  name: gke-metrics-agent-qvsk
+  namespace: kube-system
+  nodeName: gke-dencer-play-default-pool-4ddb9382-qvsk
+  owner:
+    kind: DaemonSet
+    name: gke-metrics-agent
+  phase: Running
+  ready: true
+  requests:
+    memoryBytes: 104857600
+    milliCPU: 21
+    pods: 0
+- createdAt: "2026-08-07T13:58:00Z"
+  labels:
+    k8s-app: gcp-compute-persistent-disk-csi-driver
+  name: pdcsi-node-qvsk
+  namespace: kube-system
+  nodeName: gke-dencer-play-default-pool-4ddb9382-qvsk
+  owner:
+    kind: DaemonSet
+    name: pdcsi-node
+  phase: Running
+  ready: true
+  requests:
+    memoryBytes: 41943040
+    milliCPU: 15
+    pods: 0
+- createdAt: "2026-08-07T13:58:00Z"
+  labels:
+    app.kubernetes.io/name: collector
+  name: collector-qvsk
+  namespace: gmp-system
+  nodeName: gke-dencer-play-default-pool-4ddb9382-qvsk
+  owner:
+    kind: DaemonSet
+    name: collector
+  phase: Running
+  ready: true
+  requests:
+    memoryBytes: 41943040
+    milliCPU: 5
+    pods: 0
+- createdAt: "2026-08-07T13:58:00Z"
+  labels:
+    component: kube-proxy
+    tier: node
+  name: kube-proxy-gke-dencer-play-default-pool-4ddb9382-snln
+  namespace: kube-system
+  nodeName: gke-dencer-play-default-pool-4ddb9382-snln
+  owner:
+    kind: Node
+    name: gke-dencer-play-default-pool-4ddb9382-snln
+  phase: Running
+  ready: true
+  requests:
+    memoryBytes: 134217728
+    milliCPU: 100
+    pods: 0
+- createdAt: "2026-08-07T13:58:00Z"
+  labels:
+    k8s-app: fluentbit-gke
+  name: fluentbit-gke-snln
+  namespace: kube-system
+  nodeName: gke-dencer-play-default-pool-4ddb9382-snln
+  owner:
+    kind: DaemonSet
+    name: fluentbit-gke
+  phase: Running
+  ready: true
+  requests:
+    memoryBytes: 262144000
+    milliCPU: 105
+    pods: 0
+- createdAt: "2026-08-07T13:58:00Z"
+  labels:
+    k8s-app: node-local-dns
+  name: node-local-dns-snln
+  namespace: kube-system
+  nodeName: gke-dencer-play-default-pool-4ddb9382-snln
+  owner:
+    kind: DaemonSet
+    name: node-local-dns
+  phase: Running
+  ready: true
+  requests:
+    memoryBytes: 31457280
+    milliCPU: 30
+    pods: 0
+- createdAt: "2026-08-07T13:58:00Z"
+  labels:
+    component: gke-metrics-agent
+  name: gke-metrics-agent-snln
+  namespace: kube-system
+  nodeName: gke-dencer-play-default-pool-4ddb9382-snln
+  owner:
+    kind: DaemonSet
+    name: gke-metrics-agent
+  phase: Running
+  ready: true
+  requests:
+    memoryBytes: 104857600
+    milliCPU: 21
+    pods: 0
+- createdAt: "2026-08-07T13:58:00Z"
+  labels:
+    k8s-app: gcp-compute-persistent-disk-csi-driver
+  name: pdcsi-node-snln
+  namespace: kube-system
+  nodeName: gke-dencer-play-default-pool-4ddb9382-snln
+  owner:
+    kind: DaemonSet
+    name: pdcsi-node
+  phase: Running
+  ready: true
+  requests:
+    memoryBytes: 41943040
+    milliCPU: 15
+    pods: 0
+- createdAt: "2026-08-07T13:58:00Z"
+  labels:
+    app.kubernetes.io/name: collector
+  name: collector-snln
+  namespace: gmp-system
+  nodeName: gke-dencer-play-default-pool-4ddb9382-snln
+  owner:
+    kind: DaemonSet
+    name: collector
+  phase: Running
+  ready: true
+  requests:
+    memoryBytes: 41943040
+    milliCPU: 5
+    pods: 0
+- createdAt: "2026-08-07T13:58:00Z"
+  labels:
+    k8s-app: kube-dns
+  name: kube-dns-7ddbc8bb55-a
+  namespace: kube-system
+  nodeName: gke-dencer-play-default-pool-4ddb9382-0xk4
+  owner:
+    kind: Deployment
+    name: kube-dns
+  phase: Running
+  ready: true
+  requests:
+    memoryBytes: 146800640
+    milliCPU: 270
+    pods: 0
+- createdAt: "2026-08-07T13:58:00Z"
+  labels:
+    app.kubernetes.io/name: kube-state-metrics
+  name: kube-state-metrics-0
+  namespace: gke-managed-cim
+  nodeName: gke-dencer-play-default-pool-4ddb9382-0xk4
+  owner:
+    kind: StatefulSet
+    name: kube-state-metrics
+  phase: Running
+  ready: true
+  requests:
+    memoryBytes: 209715200
+    milliCPU: 105
+    pods: 0
+- createdAt: "2026-08-07T13:58:00Z"
+  labels:
+    k8s-app: metrics-server
+  name: metrics-server-v1-a
+  namespace: kube-system
+  nodeName: gke-dencer-play-default-pool-4ddb9382-0xk4
+  owner:
+    kind: Deployment
+    name: metrics-server-v1.35.1
+  phase: Running
+  ready: true
+  requests:
+    memoryBytes: 209715200
+    milliCPU: 44
+    pods: 0
+- createdAt: "2026-08-07T13:58:00Z"
+  labels:
+    k8s-app: kube-dns-autoscaler
+  name: kube-dns-autoscaler-7dc78dc96-a
+  namespace: kube-system
+  nodeName: gke-dencer-play-default-pool-4ddb9382-0xk4
+  owner:
+    kind: Deployment
+    name: kube-dns-autoscaler
+  phase: Running
+  ready: true
+  requests:
+    memoryBytes: 10485760
+    milliCPU: 20
+    pods: 0
+- createdAt: "2026-08-07T13:58:00Z"
+  labels:
+    k8s-app: konnectivity-agent
+  name: konnectivity-agent-a
+  namespace: kube-system
+  nodeName: gke-dencer-play-default-pool-4ddb9382-0xk4
+  owner:
+    kind: Deployment
+    name: konnectivity-agent
+  phase: Running
+  ready: true
+  requests:
+    memoryBytes: 31457280
+    milliCPU: 10
+    pods: 0
+- createdAt: "2026-08-07T13:58:00Z"
+  labels:
+    k8s-app: kube-dns
+  name: kube-dns-7ddbc8bb55-b
+  namespace: kube-system
+  nodeName: gke-dencer-play-default-pool-4ddb9382-qvsk
+  owner:
+    kind: Deployment
+    name: kube-dns
+  phase: Running
+  ready: true
+  requests:
+    memoryBytes: 146800640
+    milliCPU: 270
+    pods: 0
+- createdAt: "2026-08-07T13:58:00Z"
+  labels:
+    k8s-app: metrics-server
+  name: metrics-server-v1-b
+  namespace: kube-system
+  nodeName: gke-dencer-play-default-pool-4ddb9382-qvsk
+  owner:
+    kind: Deployment
+    name: metrics-server-v1.35.1
+  phase: Running
+  ready: true
+  requests:
+    memoryBytes: 209715200
+    milliCPU: 43
+    pods: 0
+- createdAt: "2026-08-07T13:58:00Z"
+  labels:
+    k8s-app: konnectivity-agent
+  name: konnectivity-agent-b
+  namespace: kube-system
+  nodeName: gke-dencer-play-default-pool-4ddb9382-qvsk
+  owner:
+    kind: Deployment
+    name: konnectivity-agent
+  phase: Running
+  ready: true
+  requests:
+    memoryBytes: 31457280
+    milliCPU: 15
+    pods: 0
+- createdAt: "2026-08-07T13:58:00Z"
+  labels:
+    k8s-app: glbc
+  name: l7-default-backend-7d8d77ff56-a
+  namespace: kube-system
+  nodeName: gke-dencer-play-default-pool-4ddb9382-qvsk
+  owner:
+    kind: Deployment
+    name: l7-default-backend
+  phase: Running
+  ready: true
+  requests:
+    memoryBytes: 20971520
+    milliCPU: 10
+    pods: 0
+- createdAt: "2026-08-07T13:58:00Z"
+  labels:
+    k8s-app: event-exporter
+  name: event-exporter-gke-7c667c5978-a
+  namespace: kube-system
+  nodeName: gke-dencer-play-default-pool-4ddb9382-qvsk
+  owner:
+    kind: Deployment
+    name: event-exporter-gke
+  phase: Running
+  ready: true
+  requests:
+    memoryBytes: 104857600
+    milliCPU: 3
+    pods: 0
+- createdAt: "2026-08-07T13:58:00Z"
+  labels:
+    app.kubernetes.io/name: gmp-operator
+  name: gmp-operator-7db6db7879-a
+  namespace: gmp-system
+  nodeName: gke-dencer-play-default-pool-4ddb9382-qvsk
+  owner:
+    kind: Deployment
+    name: gmp-operator
+  phase: Running
+  ready: true
+  requests:
+    memoryBytes: 31457280
+    milliCPU: 1
+    pods: 0
+- createdAt: "2026-08-07T13:58:00Z"
+  labels:
+    app.kubernetes.io/component: planner
+  name: k8s-dencer-planner-a
+  namespace: k8s-dencer
+  nodeName: gke-dencer-play-default-pool-4ddb9382-0xk4
+  owner:
+    kind: Deployment
+    name: k8s-dencer-planner
+  phase: Running
+  ready: true
+  requests:
+    memoryBytes: 134217728
+    milliCPU: 50
+    pods: 0
+- createdAt: "2026-08-07T13:58:00Z"
+  labels:
+    app.kubernetes.io/component: executor
+  name: k8s-dencer-executor-a
+  namespace: k8s-dencer
+  nodeName: gke-dencer-play-default-pool-4ddb9382-0xk4
+  owner:
+    kind: Deployment
+    name: k8s-dencer-executor
+  phase: Running
+  ready: true
+  requests:
+    memoryBytes: 134217728
+    milliCPU: 50
+    pods: 0
+- createdAt: "2026-08-07T13:58:00Z"
+  labels:
+    app.kubernetes.io/component: ui-backend
+  name: k8s-dencer-ui-backend-a
+  namespace: k8s-dencer
+  nodeName: gke-dencer-play-default-pool-4ddb9382-0xk4
+  owner:
+    kind: Deployment
+    name: k8s-dencer-ui-backend
+  phase: Running
+  ready: true
+  requests:
+    memoryBytes: 134217728
+    milliCPU: 50
+    pods: 0
+- createdAt: "2026-08-07T13:58:00Z"
+  labels:
+    app.kubernetes.io/component: ui-frontend
+  name: k8s-dencer-ui-frontend-a
+  namespace: k8s-dencer
+  nodeName: gke-dencer-play-default-pool-4ddb9382-0xk4
+  owner:
+    kind: Deployment
+    name: k8s-dencer-ui-frontend
+  phase: Running
+  ready: true
+  requests:
+    memoryBytes: 33554432
+    milliCPU: 10
+    pods: 0
+- createdAt: "2026-08-07T13:58:00Z"
+  labels:
+    app.kubernetes.io/component: ui-frontend
+  name: k8s-dencer-ui-frontend-b
+  namespace: k8s-dencer
+  nodeName: gke-dencer-play-default-pool-4ddb9382-0xk4
+  owner:
+    kind: Deployment
+    name: k8s-dencer-ui-frontend
+  phase: Running
+  ready: true
+  requests:
+    memoryBytes: 33554432
+    milliCPU: 10
+    pods: 0
+- createdAt: "2026-08-07T13:58:00Z"
+  labels:
+    app: play-web
+  name: play-web-a
+  namespace: dencer-demo
+  nodeName: gke-dencer-play-default-pool-4ddb9382-q58p
+  owner:
+    kind: Deployment
+    name: play-web
+  phase: Running
+  ready: true
+  requests:
+    memoryBytes: 67108864
+    milliCPU: 150
+    pods: 0
+- createdAt: "2026-08-07T13:58:00Z"
+  labels:
+    app: play-web
+  name: play-web-b
+  namespace: dencer-demo
+  nodeName: gke-dencer-play-default-pool-4ddb9382-q58p
+  owner:
+    kind: Deployment
+    name: play-web
+  phase: Running
+  ready: true
+  requests:
+    memoryBytes: 67108864
+    milliCPU: 150
+    pods: 0
+- createdAt: "2026-08-07T13:58:00Z"
+  labels:
+    app: play-cache
+  name: play-cache-a
+  namespace: dencer-demo
+  nodeName: gke-dencer-play-default-pool-4ddb9382-q58p
+  owner:
+    kind: Deployment
+    name: play-cache
+  phase: Running
+  ready: true
+  requests:
+    memoryBytes: 134217728
+    milliCPU: 100
+    pods: 0
+- createdAt: "2026-08-07T13:58:00Z"
+  labels:
+    app: play-filler
+  name: play-filler-a
+  namespace: dencer-demo
+  nodeName: gke-dencer-play-default-pool-4ddb9382-q58p
+  owner:
+    kind: Deployment
+    name: play-filler
+  phase: Running
+  ready: true
+  requests:
+    memoryBytes: 67108864
+    milliCPU: 120
+    pods: 0
+- createdAt: "2026-08-07T13:58:00Z"
+  labels:
+    app: play-web
+  name: play-web-c
+  namespace: dencer-demo
+  nodeName: gke-dencer-play-default-pool-4ddb9382-qvsk
+  owner:
+    kind: Deployment
+    name: play-web
+  phase: Running
+  ready: true
+  requests:
+    memoryBytes: 67108864
+    milliCPU: 150
+    pods: 0
+- createdAt: "2026-08-07T13:58:00Z"
+  labels:
+    app: play-cache
+  name: play-cache-b
+  namespace: dencer-demo
+  nodeName: gke-dencer-play-default-pool-4ddb9382-qvsk
+  owner:
+    kind: Deployment
+    name: play-cache
+  phase: Running
+  ready: true
+  requests:
+    memoryBytes: 134217728
+    milliCPU: 120
+    pods: 0
+- createdAt: "2026-08-07T13:58:00Z"
+  labels:
+    app: play-web
+  name: play-web-d
+  namespace: dencer-demo
+  nodeName: gke-dencer-play-default-pool-4ddb9382-snln
+  owner:
+    kind: Deployment
+    name: play-web
+  phase: Running
+  ready: true
+  requests:
+    memoryBytes: 67108864
+    milliCPU: 150
+    pods: 0
+- createdAt: "2026-08-07T13:58:00Z"
+  labels:
+    app: play-web
+  name: play-web-e
+  namespace: dencer-demo
+  nodeName: gke-dencer-play-default-pool-4ddb9382-snln
+  owner:
+    kind: Deployment
+    name: play-web
+  phase: Running
+  ready: true
+  requests:
+    memoryBytes: 67108864
+    milliCPU: 150
+    pods: 0
+- createdAt: "2026-08-07T13:58:00Z"
+  labels:
+    app: play-cache
+  name: play-cache-c
+  namespace: dencer-demo
+  nodeName: gke-dencer-play-default-pool-4ddb9382-snln
+  owner:
+    kind: Deployment
+    name: play-cache
+  phase: Running
+  ready: true
+  requests:
+    memoryBytes: 134217728
+    milliCPU: 120
+    pods: 0
+- createdAt: "2026-08-07T13:58:00Z"
+  labels:
+    app: play-filler
+  name: play-filler-b
+  namespace: dencer-demo
+  nodeName: gke-dencer-play-default-pool-4ddb9382-snln
+  owner:
+    kind: Deployment
+    name: play-filler
+  phase: Running
+  ready: true
+  requests:
+    memoryBytes: 67108864
+    milliCPU: 50
+    pods: 0
+takenAt: "2026-08-07T14:18:00Z"


### PR DESCRIPTION
Closes #128, #129, #130.

A 45-minute GKE cluster found what a full CI suite could not: **on a managed cluster this product cannot produce a consolidation plan.** The planner logged `nodesUndrainable` equal to the node count on every 30s cycle, converge reported "0 nodes — every remaining node is either needed or undrainable", and three minutes later Google's own autoscaler reclaimed two of those nodes in 64 seconds. Doing nothing outperformed the tool.

Two mistakes pointing in opposite directions, both from one wrong idea: that owner kind decides drainability.

## Static pods were invisible (#128)

GKE runs kube-proxy as a static pod, mirrored into the API with the **Node** as its controller:

```
ownerReferences: [{"kind":"Node","controller":true}]
kubernetes.io/config.mirror: 61ad276afec25095a67bb9121dfeaa57
kubernetes.io/config.source: file
```

`analyzer.go:68` asked only for `DaemonSet`, so a mirror pod read as freely relocatable, went to the placement search, and was reported — correctly and uselessly — as having nowhere to go.

`IsMovable`'s own doc comment already claimed *"Mirror and static pods likewise"*. The code never said it. `PinnedToNode()` now asks the question that actually matters — **is anything capable of moving this pod to another node** — rather than matching owner kinds. For a DaemonSet the answer is no; for a static pod there is no controller at all.

## Pinned was conflated with blocking (#130)

`NodeDrainable` failed a node if any pod on it could not move, and DaemonSet pods never can. Every managed node runs five or more, so the verdict was fixed at undrainable before a single real constraint was consulted — preflight said "0 of 6 nodes will drain cleanly" where **30 of 32 blockers were DaemonSets**.

But pinned is not blocking. The eviction API and `kubectl drain --ignore-daemonsets` both pass straight over these pods, and the node puts them back afterwards. `PodConstraints.PinnedToNode` carries the distinction, so the explanation survives as context without poisoning the verdict.

## The fixture is the durable half (#129)

kwok nodes run **no system pods at all** — 0m of system CPU locally against 276m minimum on GKE. This entire class of bug was unreachable from CI, which is why it took a paid cluster to find.

`test/fixtures/gke-managed.yaml` reproduces the measured fleet: 940m allocatable on e2-medium, the real DaemonSet set at their real requests, kube-proxy Node-owned, and per-node totals within 2m of the live cluster.

| node | measured | fixture |
|---|---|---|
| 0xk4 | 725m sys / 170m wl | 725 / 170 |
| q58p | 276 / 520 | 276 / 520 |
| qvsk | 620 / 270 | 618 / 270 |
| snln | 276 / 470 | 276 / 470 |
| fleet | 88.5% requested | 88.4% |

## Verification

Both tests were **written failing and watched fail** before either fix existed:

```
--- FAIL: TestGKEManagedMirrorPodIsPinned
    kube-proxy is a Node-owned mirror pod and must not be movable
--- FAIL: TestGKEManagedDaemonSetsDoNotBlockDrains
    node ...-0xk4 counts a DaemonSet as a drain blocker: DaemonSet/fluentbit-gke
    (×20, four nodes × five DaemonSets)
```

After the fix, on the same fixture:

| | before | after |
|---|---|---|
| nodes drainable | 0 of 4 | 1 of 4 |
| blockers | ~30, all DaemonSets | 4, all real capacity |

The four that remain are `kube-dns` twice (270m, genuinely will not fit elsewhere) and two `play-web` pods — things an operator can actually act on.

Local gates: `go test ./...`, `make lint` (chart contract), UI typecheck and build, all clean. Golden planner tests unchanged on the kwok fixtures, as expected — they have no system pods for this to affect.