### PR TITLE
CLI: answer status honestly, and stop caring where the argument goes

### DIFF
--- a/cmd/dencer/args_test.go
+++ b/cmd/dencer/args_test.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"flag"
+	"io"
+	"strings"
+	"testing"
+	"time"
+)
+
+// A FlagSet shaped like the real ones: a mix of string, bool and duration
+// flags, which is what makes "does this flag eat the next argument" a real
+// question rather than a guess.
+func drainLikeFlags() *flag.FlagSet {
+	fs := flag.NewFlagSet("drain", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	fs.String("context", "", "")
+	fs.String("namespace", "", "")
+	fs.Bool("dry-run", false, "")
+	fs.Bool("yes", false, "")
+	fs.Duration("timeout", 30*time.Second, "")
+	return fs
+}
+
+func TestReorderArgsAcceptsThePositionalAnywhere(t *testing.T) {
+	// Every one of these means the same thing to a person. Before this,
+	// only the last parsed — the node had to come after every flag, with
+	// nothing following it.
+	cases := [][]string{
+		{"worker-3"},
+		{"worker-3", "--yes"},
+		{"worker-3", "--context", "gke-play", "--dry-run"},
+		{"--context", "gke-play", "worker-3", "--timeout", "60s"},
+		{"--dry-run", "worker-3"},
+		{"--context=gke-play", "worker-3", "--yes"},
+		{"--context", "gke-play", "--timeout", "60s", "--yes", "worker-3"},
+	}
+
+	for _, args := range cases {
+		fs := drainLikeFlags()
+		if err := fs.Parse(reorderArgs(fs, args)); err != nil {
+			t.Errorf("%v: parse: %v", args, err)
+			continue
+		}
+		if fs.NArg() != 1 {
+			t.Errorf("%v: NArg = %d, want 1 (positional swallowed by the flags)", args, fs.NArg())
+			continue
+		}
+		if got := fs.Arg(0); got != "worker-3" {
+			t.Errorf("%v: node = %q, want worker-3", args, got)
+		}
+	}
+}
+
+func TestReorderArgsKeepsFlagValuesWithTheirFlags(t *testing.T) {
+	fs := drainLikeFlags()
+	if err := fs.Parse(reorderArgs(fs, []string{"worker-3", "--context", "gke-play", "--timeout", "90s"})); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got := fs.Lookup("context").Value.String(); got != "gke-play" {
+		t.Errorf("context = %q, want gke-play — a flag's value was treated as positional", got)
+	}
+	if got := fs.Lookup("timeout").Value.String(); got != "1m30s" {
+		t.Errorf("timeout = %q, want 1m30s", got)
+	}
+	if fs.Arg(0) != "worker-3" {
+		t.Errorf("node = %q, want worker-3", fs.Arg(0))
+	}
+}
+
+// A bool flag stands alone. Treating it as value-taking would eat the node.
+func TestReorderArgsDoesNotLetBoolFlagsEatTheArgument(t *testing.T) {
+	fs := drainLikeFlags()
+	if err := fs.Parse(reorderArgs(fs, []string{"--dry-run", "worker-3"})); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if fs.Arg(0) != "worker-3" {
+		t.Fatalf("node = %q, want worker-3: --dry-run consumed it", fs.Arg(0))
+	}
+	if fs.Lookup("dry-run").Value.String() != "true" {
+		t.Error("--dry-run did not take effect")
+	}
+}
+
+// Everything after `--` is positional, by long-standing convention.
+func TestReorderArgsHonoursTheDoubleDash(t *testing.T) {
+	fs := drainLikeFlags()
+	if err := fs.Parse(reorderArgs(fs, []string{"--yes", "--", "--weirdly-named-node"})); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got := fs.Arg(0); got != "--weirdly-named-node" {
+		t.Errorf("arg = %q, want --weirdly-named-node", got)
+	}
+}
+
+// An unknown flag must still produce Parse's own error, not be silently
+// rearranged into a positional argument.
+func TestReorderArgsLeavesUnknownFlagsToParse(t *testing.T) {
+	fs := drainLikeFlags()
+	err := fs.Parse(reorderArgs(fs, []string{"--nope", "worker-3"}))
+	if err == nil {
+		t.Fatal("expected an error for an unknown flag")
+	}
+	if !strings.Contains(err.Error(), "nope") {
+		t.Errorf("error should name the unknown flag, got: %v", err)
+	}
+}

--- a/cmd/dencer/main.go
+++ b/cmd/dencer/main.go
@@ -43,7 +43,8 @@ Commands:
   audit                 what cannot survive a node loss, and why
   recommend             what is missing — PDBs, replicas, requests — with fixes
   rightsizing           requests vs observed usage, per workload
-  whatif                simulate losing nodes or a zone: does everything still fit?
+  whatif --without-nodes a,b | --without-zone z
+                        simulate losing nodes or a zone: does everything still fit?
   drain <node>          guarded drain of one node: the rails, not bare kubectl
   version               the version of this binary (also --version)
 
@@ -63,9 +64,67 @@ Examples:
   dencer why shop/web-7d9f-abcde
   dencer run --steps 1,2 --dry-run
   dencer converge --max-nodes 5 --max-impact Green
+  dencer whatif --without-zone eu-west-1a
+  dencer drain worker-3 --dry-run
   dencer reclamations
   dencer plan -o json | jq '.plan.steps[] | select(.impact=="Red")'
 `
+
+// reorderArgs moves positional arguments after the flags, so that
+// `dencer drain node-3 --dry-run` parses the same as
+// `dencer drain --dry-run node-3`.
+//
+// Go's flag package stops parsing at the first non-flag argument, so the
+// obvious ordering — the one this tool's own error message demonstrates,
+// "e.g. dencer drain worker-3" — fails the moment any flag is added, and
+// --context is not optional for anyone with more than one cluster. It fails
+// with "which node?" while the node is right there in the command line.
+//
+// Which flags consume the next argument is a question only the FlagSet can
+// answer, so it is asked rather than guessed: boolean flags stand alone,
+// everything else takes a value.
+func reorderArgs(fs *flag.FlagSet, args []string) []string {
+	var flags, positional []string
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		switch {
+		case a == "--":
+			// Everything after it is positional by definition.
+			positional = append(positional, args[i+1:]...)
+			return joinArgs(flags, positional)
+		case len(a) > 1 && a[0] == '-':
+			flags = append(flags, a)
+			name := strings.TrimLeft(a, "-")
+			if strings.ContainsRune(name, '=') {
+				continue // --flag=value carries its own value
+			}
+			f := fs.Lookup(name)
+			if f == nil {
+				continue // unknown flag: let Parse report it properly
+			}
+			if b, ok := f.Value.(interface{ IsBoolFlag() bool }); ok && b.IsBoolFlag() {
+				continue
+			}
+			if i+1 < len(args) {
+				i++
+				flags = append(flags, args[i])
+			}
+		default:
+			positional = append(positional, a)
+		}
+	}
+	return joinArgs(flags, positional)
+}
+
+// joinArgs puts the positionals behind an explicit `--`, so Parse treats them
+// as arguments whatever they look like — including a node someone has managed
+// to name with a leading dash.
+func joinArgs(flags, positional []string) []string {
+	if len(positional) == 0 {
+		return flags
+	}
+	return append(append(flags, "--"), positional...)
+}
 
 type globals struct {
 	cfg    cli.Config
@@ -207,7 +266,7 @@ func cmdPlan(ctx context.Context, args []string) error {
 func cmdExplain(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("explain", flag.ExitOnError)
 	g := bind(fs)
-	if err := fs.Parse(args); err != nil {
+	if err := fs.Parse(reorderArgs(fs, args)); err != nil {
 		return err
 	}
 	if fs.NArg() < 1 {
@@ -242,7 +301,7 @@ func cmdExplain(ctx context.Context, args []string) error {
 func cmdWhy(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("why", flag.ExitOnError)
 	g := bind(fs)
-	if err := fs.Parse(args); err != nil {
+	if err := fs.Parse(reorderArgs(fs, args)); err != nil {
 		return err
 	}
 	if fs.NArg() < 1 {
@@ -462,7 +521,7 @@ func cmdDrain(ctx context.Context, args []string) error {
 	dryRun := fs.Bool("dry-run", false, "run every guard check and emit the same events without touching the node")
 	watch := fs.Bool("watch", true, "follow the drain until it finishes")
 	yes := fs.Bool("yes", false, "skip the confirmation prompt")
-	if err := fs.Parse(args); err != nil {
+	if err := fs.Parse(reorderArgs(fs, args)); err != nil {
 		return err
 	}
 	if fs.NArg() != 1 {
@@ -636,18 +695,29 @@ func cmdStatus(ctx context.Context, args []string) error {
 	defer c.Close()
 
 	if *runID == "" {
-		active, err := c.ActiveRun(ctx)
+		active, latest, err := c.RunStatus(ctx)
 		if err != nil {
 			return err
 		}
-		if active == nil {
-			if g.format != cli.FormatText {
-				return cli.Encode(os.Stdout, g.format, map[string]any{"active": nil})
+		switch {
+		case active != nil:
+			*runID = active.ID
+		case latest != nil:
+			// Nothing in flight, so show the last one and say so. The
+			// alternative — "No run in flight." — is true and useless to
+			// someone whose drain was halted thirty seconds ago.
+			if g.format == cli.FormatText {
+				fmt.Println("No run in flight. The most recent one:")
+				fmt.Println()
 			}
-			fmt.Println("No run in flight.")
+			*runID = latest.ID
+		default:
+			if g.format != cli.FormatText {
+				return cli.Encode(os.Stdout, g.format, map[string]any{"active": nil, "latest": nil})
+			}
+			fmt.Println("No run in flight, and none has ever run.")
 			return nil
 		}
-		*runID = active.ID
 	}
 
 	env, err := c.Run(ctx, *runID)

--- a/internal/api/rest/execute.go
+++ b/internal/api/rest/execute.go
@@ -209,21 +209,32 @@ func (s *Server) handleRunsForPlan(w http.ResponseWriter, r *http.Request) {
 
 // handleActiveRun lets the UI discover an in-flight run on load, so refreshing
 // the page during a consolidation does not lose sight of it.
+// handleActiveRun answers "is anything running, and if not, what happened
+// last".
+//
+// The second half matters: "no run in flight" is a true but useless answer to
+// someone who just watched a drain get halted by the Safety Guard and wants to
+// know why. latest is nil only when nothing has ever run.
 func (s *Server) handleActiveRun(w http.ResponseWriter, r *http.Request) {
 	if s.runs == nil {
-		writeJSON(w, http.StatusOK, map[string]any{"active": nil})
+		writeJSON(w, http.StatusOK, map[string]any{"active": nil, "latest": nil})
 		return
 	}
+	body := map[string]any{"active": nil, "latest": nil}
+
 	run, err := s.runs.ActiveRun(r.Context())
-	if errors.Is(err, store.ErrNotFound) {
-		writeJSON(w, http.StatusOK, map[string]any{"active": nil})
-		return
-	}
-	if err != nil {
+	switch {
+	case err == nil:
+		body["active"] = run
+	case !errors.Is(err, store.ErrNotFound):
 		s.fail(w, err)
 		return
 	}
-	writeJSON(w, http.StatusOK, map[string]any{"active": run})
+
+	if recent, err := s.runs.RecentRuns(r.Context(), 1); err == nil && len(recent) > 0 {
+		body["latest"] = recent[0]
+	}
+	writeJSON(w, http.StatusOK, body)
 }
 
 func (s *Server) failRun(w http.ResponseWriter, err error) {

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -91,11 +91,21 @@ func (c *Client) Run(ctx context.Context, id string) (*RunEnvelope, error) {
 
 // ActiveRun returns the run in flight, or nil.
 func (c *Client) ActiveRun(ctx context.Context) (*store.Run, error) {
+	active, _, err := c.RunStatus(ctx)
+	return active, err
+}
+
+// RunStatus returns the run in flight and the most recent run, either of which
+// may be nil. `status` promises "the run in flight, or the last one", and
+// answering only the first half tells someone whose drain was just halted by
+// the Safety Guard precisely nothing.
+func (c *Client) RunStatus(ctx context.Context) (active, latest *store.Run, err error) {
 	var out struct {
 		Active *store.Run `json:"active"`
+		Latest *store.Run `json:"latest"`
 	}
-	err := c.get(ctx, "/api/v1/runs", &out)
-	return out.Active, err
+	err = c.get(ctx, "/api/v1/runs", &out)
+	return out.Active, out.Latest, err
 }
 
 // Wait polls a run until it reaches a terminal state, reporting events as they


### PR DESCRIPTION
Closes #134, #137, #138. Three things a metered GKE window spent minutes on.

## `status` only answered half its own promise

The help says *"the run in flight, or the last one"*. Seconds after a guarded drain was halted by the Safety Guard, it printed:

```
No run in flight.
```

True, and useless to the person who wanted to know what stopped it. The store has had `RecentRuns` all along — `/api/v1/runs` now returns `latest` alongside `active`, and `status` shows it, saying that is what you are looking at. "Nothing has ever run" is a different sentence from "nothing is running", and both are now available.

## `dencer drain worker-3 --dry-run` said "which node?"

While the node was sitting right there in the command line. Go's `flag` stops parsing at the first non-flag argument, so the node and every flag after it landed in `Args()` and the `NArg() != 1` check rejected them. The only ordering that worked put the argument **last**, after every flag — the opposite of what that error's own example (`e.g. dencer drain worker-3`) demonstrates, and `--context` is not optional for anyone with more than one cluster.

`reorderArgs` moves positionals behind an explicit `--`, asking the FlagSet which flags consume a value rather than guessing: bool flags stand alone, everything else takes the next argument. Applies to `explain`, `why`, `drain`.

Tests cover seven orderings, flag values not being mistaken for arguments, bools not eating the argument, `--` being honoured, and unknown flags still producing Parse's own error rather than being silently rearranged.

## `whatif`'s flags were documented nowhere

`--nodes` is the obvious guess and fails. The real ones are `--without-nodes` and `--without-zone`. Both now appear in the usage block with an example, as `run --steps` already did.

## Verification

Against the real binary — every ordering that previously failed:

```
dencer drain worker-3 --dry-run          → reaches the API
dencer drain --context x worker-3        → reaches the confirmation prompt
dencer explain 3                         → reaches the API
dencer why shop/web-abc                  → reaches the API
```

And `status` against the live OrbStack cluster:

```
No run in flight. The most recent one:

run 19977e414b79601d  Succeeded
plan 147506f06179, steps [1], by system:serviceaccount:k8s-dencer:dencer-operator
completed 1 step(s), draining 1 node(s)

Audit trail
    14:07:28 Claim   run claimed by k8s-dencer-executor-… …
```

Backend rebuilt and redeployed to OrbStack to test the endpoint change for real, not just in unit tests. `go test ./...`, `make lint`, UI gates all clean.