### PR TITLE
Surface rightsizing: the number that says why the nodes are full

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -20,6 +20,7 @@ import { runtimeConfig } from "./runtime-config";
 import { useObserved } from "./useObserved";
 import { usePlan } from "./usePlan";
 import { useReclamations } from "./useReclamations";
+import RightsizingPage from "./components/rightsizing/RightsizingPage";
 import { useRecommendations } from "./useRecommendations";
 import { useRun } from "./useRun";
 import { useVersion } from "./useVersion";
@@ -402,6 +403,8 @@ export default function App() {
               }}
             />
           )}
+
+          {state.status === "ready" && surface === "rightsizing" && <RightsizingPage />}
 
           {state.status === "ready" && surface === "history" && <History />}
         </div>

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -436,6 +436,9 @@ export const api = {
 
   run: (runId: string, signal?: AbortSignal) => get<RunDetail>(`/api/v1/runs/${runId}`, signal),
 
+  /** Requests against observed usage, per workload. Needs metrics-server. */
+  rightsizing: (signal?: AbortSignal) => get<Rightsizing>(`/api/v1/rightsizing`, signal),
+
   /** The in-flight run, if any. Lets a page reload rejoin a consolidation
    *  already in progress rather than losing sight of it. */
   activeRun: (signal?: AbortSignal) => get<{ active: Run | null }>("/api/v1/runs", signal),
@@ -531,6 +534,26 @@ function dispatchFrame(frame: string, onEvent: (event: string, data: string) => 
     else if (field === "data") data.push(value);
   }
   if (data.length > 0) onEvent(event, data.join("\n"));
+}
+
+/** One workload's requests against what it actually uses. */
+export interface RightsizingRow {
+  workload: string;
+  pods: number;
+  requestedMilli: number;
+  usedMilli: number;
+  requestedBytes: number;
+  usedBytes: number;
+}
+
+export interface Rightsizing {
+  /** False when no usage source is configured — unmeasured, never idle. */
+  available: boolean;
+  reason?: string;
+  takenAt?: string;
+  workloads?: RightsizingRow[];
+  totalRequestedMilli?: number;
+  totalUsedMilli?: number;
 }
 
 export function formatCPU(milli: number): string {

--- a/ui/src/components/Rail.tsx
+++ b/ui/src/components/Rail.tsx
@@ -50,6 +50,12 @@ const ICONS: Record<Surface, React.ReactNode> = {
       <circle cx="8" cy="8" r="3" stroke="currentColor" strokeWidth="1.4" fill="none" />
     </svg>
   ),
+  rightsizing: (
+    <svg viewBox="0 0 16 16" className="rail-icon" aria-hidden="true">
+      <rect x="2.5" y="4" width="11" height="3.4" rx="1" stroke="currentColor" strokeWidth="1.4" fill="none" />
+      <rect x="2.5" y="9.2" width="4.6" height="3.4" rx="1" fill="currentColor" />
+    </svg>
+  ),
   history: (
     <svg viewBox="0 0 16 16" className="rail-icon" aria-hidden="true">
       <circle cx="8" cy="8" r="6" stroke="currentColor" strokeWidth="1.4" fill="none" />
@@ -62,6 +68,7 @@ const LABELS: Record<Surface, string> = {
   review: "Review",
   cluster: "Cluster",
   recommendations: "Recommendations",
+  rightsizing: "Rightsizing",
   history: "History",
 };
 

--- a/ui/src/components/rightsizing/RightsizingPage.tsx
+++ b/ui/src/components/rightsizing/RightsizingPage.tsx
@@ -1,0 +1,185 @@
+/**
+ * Rightsizing — requests against what is actually used.
+ *
+ * The endpoint has existed since the CLI shipped and the UI never called it,
+ * which put the most actionable number in the product behind a terminal. On a
+ * real GKE cluster it read: requested 3.0 cores, observed 0.2. Consolidation
+ * moves pods between nodes; over-requesting by that margin is *why* the nodes
+ * were too full to consolidate. This is the room, not the furniture.
+ *
+ * Every row is a measurement or it is absent. With no usage source configured
+ * the screen says so and stops, because "0 used" and "not measured" are
+ * different claims and only one of them is ever true here.
+ */
+
+import { useEffect, useState } from "react";
+import { Rightsizing, api, formatBytes, formatCPU } from "../../api";
+
+/** Below this the gap is noise, not a finding worth a row's attention. */
+const WORTH_SHOWING_MILLI = 50;
+
+/** formatCPU drops the unit above a core, so "cores" is only right above it. */
+const cores = (milli: number) => (milli >= 1000 ? `${formatCPU(milli)} cores` : formatCPU(milli));
+
+export default function RightsizingPage() {
+  const [data, setData] = useState<Rightsizing | null>(null);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = () =>
+      api
+        .rightsizing()
+        .then((d) => !cancelled && setData(d))
+        .catch(() => !cancelled && setFailed(true));
+    load();
+    const t = setInterval(load, 60_000);
+    return () => {
+      cancelled = true;
+      clearInterval(t);
+    };
+  }, []);
+
+  if (failed) {
+    return (
+      <div className="rightsizing">
+        <Head />
+        <p className="rightsizing-empty">
+          Could not read usage just now. It will retry on its own.
+        </p>
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div className="rightsizing">
+        <Head />
+        <p className="rightsizing-empty">Reading usage…</p>
+      </div>
+    );
+  }
+
+  if (!data.available) {
+    return (
+      <div className="rightsizing">
+        <Head />
+        <p className="rightsizing-empty">
+          {data.reason ||
+            "No measured usage. Enable it with planner.usageSource=metrics-server, at install time."}{" "}
+          Until then this screen would be guessing, and a guess about capacity is worth less
+          than nothing.
+        </p>
+      </div>
+    );
+  }
+
+  const rows = [...(data.workloads ?? [])].sort(
+    (a, b) => b.requestedMilli - b.usedMilli - (a.requestedMilli - a.usedMilli),
+  );
+  const req = data.totalRequestedMilli ?? 0;
+  const used = data.totalUsedMilli ?? 0;
+  const slack = Math.max(req - used, 0);
+  const ratio = used > 0 ? req / used : 0;
+
+  return (
+    <div className="rightsizing">
+      <Head takenAt={data.takenAt} />
+
+      <div className="rightsizing-hero">
+        <span className="eyebrow mono">What the cluster asked for, against what it used</span>
+        <h2 className="rightsizing-headline">
+          {cores(slack)} requested and not used
+        </h2>
+        <div className="rightsizing-stats">
+          <Stat label="requested" value={cores(req)} />
+          <Stat label="observed" value={cores(used)} />
+          {ratio >= 1.5 && (
+            <Stat label="over-requested by" value={`${ratio.toFixed(1)}×`} accent />
+          )}
+        </div>
+        <p className="rightsizing-note">
+          Requests are what the scheduler packs against, so unused requests hold nodes open
+          whether or not anything runs on them. Nothing here drains anything — these are
+          numbers to take to the workload's owner.
+        </p>
+      </div>
+
+      <div className="rightsizing-tablewrap">
+        <table className="rightsizing-table">
+          <thead>
+            <tr>
+              <th scope="col">Workload</th>
+              <th scope="col" className="num">Pods</th>
+              <th scope="col" className="num">CPU req</th>
+              <th scope="col" className="num">CPU used</th>
+              <th scope="col" className="rightsizing-barcol">Gap</th>
+              <th scope="col" className="num">Mem req</th>
+              <th scope="col" className="num">Mem used</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.length === 0 && (
+              <tr>
+                <td colSpan={7} className="rightsizing-empty">
+                  Nothing measured yet.
+                </td>
+              </tr>
+            )}
+            {rows.map((r) => {
+              const gap = Math.max(r.requestedMilli - r.usedMilli, 0);
+              const usedPct = r.requestedMilli > 0 ? (r.usedMilli / r.requestedMilli) * 100 : 0;
+              return (
+                <tr key={r.workload}>
+                  <td className="mono rightsizing-name">{r.workload}</td>
+                  <td className="num mono">{r.pods}</td>
+                  <td className="num mono">{formatCPU(r.requestedMilli)}</td>
+                  <td className="num mono">{formatCPU(r.usedMilli)}</td>
+                  <td className="rightsizing-barcol">
+                    <div
+                      className="rightsizing-bar"
+                      role="img"
+                      aria-label={`${Math.round(usedPct)} percent of requested CPU in use`}
+                    >
+                      <div
+                        className="rightsizing-bar-used"
+                        style={{ width: `${Math.min(usedPct, 100)}%` }}
+                      />
+                    </div>
+                    <span className="rightsizing-gap mono">
+                      {gap >= WORTH_SHOWING_MILLI ? `${formatCPU(gap)} spare` : "—"}
+                    </span>
+                  </td>
+                  <td className="num mono">{formatBytes(r.requestedBytes)}</td>
+                  <td className="num mono">{formatBytes(r.usedBytes)}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function Head({ takenAt }: { takenAt?: string }) {
+  return (
+    <div className="rightsizing-head">
+      <span className="rightsizing-title">Rightsizing</span>
+      {takenAt && (
+        <span className="rightsizing-taken mono">
+          measured {new Date(takenAt).toLocaleTimeString()}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function Stat({ label, value, accent }: { label: string; value: string; accent?: boolean }) {
+  return (
+    <div className={"rightsizing-stat" + (accent ? " is-accent" : "")}>
+      <span className="rightsizing-stat-value mono">{value}</span>
+      <span className="rightsizing-stat-label">{label}</span>
+    </div>
+  );
+}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -16,4 +16,5 @@
 @import "./styles/sidebar.css";
 @import "./styles/run.css";
 @import "./styles/views.css";
+@import "./styles/rightsizing.css";
 @import "./styles/history.css";

--- a/ui/src/styles/rightsizing.css
+++ b/ui/src/styles/rightsizing.css
@@ -1,0 +1,173 @@
+/*
+ * Rightsizing — a dense table, so it borrows History's ledger rhythm rather
+ * than inventing a third one. The only graphic is the gap bar, because the
+ * gap is the finding.
+ */
+
+.rightsizing {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.rightsizing-head {
+  height: var(--topbar-h);
+  flex-shrink: 0;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 0 var(--space-6);
+  background: var(--surface);
+}
+
+.rightsizing-title {
+  font-size: var(--text-md);
+  font-weight: 600;
+}
+
+.rightsizing-taken {
+  font-size: var(--text-xs);
+  color: var(--text-5);
+}
+
+.rightsizing-hero {
+  padding: 20px var(--space-6) 18px;
+  border-bottom: 1px solid var(--border);
+  background: var(--surface);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.rightsizing-headline {
+  margin: 0;
+  font-size: 26px;
+  font-weight: 600;
+  letter-spacing: var(--tracking-display);
+  text-wrap: balance;
+}
+
+.rightsizing-stats {
+  display: flex;
+  gap: 28px;
+}
+
+.rightsizing-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.rightsizing-stat-value {
+  font-size: var(--text-lg);
+  color: var(--text-1);
+  font-variant-numeric: tabular-nums;
+}
+
+.rightsizing-stat.is-accent .rightsizing-stat-value {
+  color: var(--caution);
+}
+
+.rightsizing-stat-label {
+  font-size: var(--text-2xs);
+  color: var(--text-5);
+}
+
+.rightsizing-note {
+  margin: 0;
+  max-width: 76ch;
+  font-size: var(--text-sm);
+  line-height: 1.55;
+  color: var(--text-3);
+  text-wrap: pretty;
+}
+
+.rightsizing-tablewrap {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  padding: 0 var(--space-6) 20px;
+}
+
+.rightsizing-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--text-xs);
+}
+
+.rightsizing-table th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: var(--canvas);
+  text-align: left;
+  font-weight: 500;
+  font-size: var(--text-2xs);
+  letter-spacing: var(--tracking-label);
+  text-transform: uppercase;
+  color: var(--text-5);
+  padding: 14px 12px 8px;
+  border-bottom: 1px solid var(--border);
+  white-space: nowrap;
+}
+
+.rightsizing-table td {
+  padding: 9px 12px;
+  border-bottom: 1px solid var(--hairline);
+  color: var(--text-2);
+}
+
+.rightsizing-table .num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.rightsizing-name {
+  color: var(--text-1);
+  max-width: 34ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.rightsizing-barcol {
+  width: 190px;
+  white-space: nowrap;
+}
+
+.rightsizing-bar {
+  display: inline-block;
+  vertical-align: middle;
+  width: 110px;
+  height: 7px;
+  border-radius: 4px;
+  background: var(--fill-50);
+  overflow: hidden;
+}
+
+/* Filled portion is what is actually used; the rest of the track is the
+   request nobody is spending. */
+.rightsizing-bar-used {
+  height: 100%;
+  border-radius: 4px;
+  background: var(--accent);
+}
+
+.rightsizing-gap {
+  margin-left: 9px;
+  font-size: var(--text-2xs);
+  color: var(--text-5);
+  font-variant-numeric: tabular-nums;
+}
+
+.rightsizing-empty {
+  padding: 22px var(--space-6);
+  max-width: 76ch;
+  font-size: var(--text-sm);
+  line-height: 1.55;
+  color: var(--text-5);
+  text-wrap: pretty;
+}

--- a/ui/src/view.ts
+++ b/ui/src/view.ts
@@ -34,7 +34,7 @@ export type FieldView = "rack" | "wells" | "load";
  * the axes is what made the old view switcher read as four equal views of
  * the same thing.
  */
-export type Surface = "review" | "cluster" | "recommendations" | "history";
+export type Surface = "review" | "cluster" | "recommendations" | "rightsizing" | "history";
 
 const KEY = "dencer.view";
 


### PR DESCRIPTION
Closes #140.

`/api/v1/rightsizing` has existed since the CLI shipped and `ui/src/api.ts` never called it — leaving the most actionable figure in the product behind a terminal. An audit against the router found **four** such endpoints; this is the first and most valuable.

## Why this number

On the real GKE cluster: **3.0 cores requested, 0.2 observed.** On the local demo: **3.3 cores against 157m — over-requested by 20.8×.**

Consolidation moves pods between nodes. Over-requesting by that margin is *why* the nodes were too full to consolidate. It's the difference between rearranging the furniture and noticing the room is mostly empty boxes.

It's also the only advice in the product that costs nothing to act on — no drain, no approval, no risk window. Edit the requests and the packing math changes.

## The screen

A new destination between Recommendations and History. Hero states the slack in one sentence, three stats (requested, observed, the ratio in amber when it's ≥1.5×), then a table sorted by gap — because the gap is the finding. The only graphic is a bar of used-against-requested.

With no usage source configured it says so and stops:

> No measured usage. Enable it with `planner.usageSource=metrics-server`, at install time. Until then this screen would be guessing, and a guess about capacity is worth less than nothing.

"0 used" and "not measured" are different claims, and shipping the first when the second is true would put a fabricated number on the one screen whose entire job is measurement.

## Verification

Built, deployed to OrbStack, driven with Playwright and inspected. Rendered against the live cluster with real metrics-server data:

```
3.1 cores requested and not used
3.3 cores requested · 157m observed · 20.8× over-requested

kagent/Deployment/kagent-postgresql   1   250m   9m   ▁▁▁ 241m spare  256 MiB  50.7 MiB
kagent/Deployment/kagent-grafana-mcp  1   100m   0m   ▁▁▁ 100m spare  128 MiB  11.9 MiB
…
```

Caught and fixed a unit bug in review of that screenshot: `formatCPU` drops the unit above a core, so sub-core totals were rendering as "157m cores".

Gates: typecheck, build, density all clean; every CSS custom property checked against `theme.css`.