### PR TITLE
Review: an empty plan says why, instead of saying nothing

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -20,6 +20,7 @@ import { runtimeConfig } from "./runtime-config";
 import { useObserved } from "./useObserved";
 import { usePlan } from "./usePlan";
 import { useReclamations } from "./useReclamations";
+import WhyNothing from "./components/review/WhyNothing";
 import { useRecommendations } from "./useRecommendations";
 import { useRun } from "./useRun";
 import { useVersion } from "./useVersion";
@@ -323,6 +324,8 @@ export default function App() {
               />
 
               <RunTrail state={run.state} onDismiss={run.dismiss} />
+
+              {steps.length === 0 && <WhyNothing />}
 
               <main className="review-main">
                 <StepList

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -436,6 +436,9 @@ export const api = {
 
   run: (runId: string, signal?: AbortSignal) => get<RunDetail>(`/api/v1/runs/${runId}`, signal),
 
+  /** Per node: will it drain, and if not, what is in the way. */
+  preflight: (signal?: AbortSignal) => get<Preflight>(`/api/v1/preflight`, signal),
+
   /** The in-flight run, if any. Lets a page reload rejoin a consolidation
    *  already in progress rather than losing sight of it. */
   activeRun: (signal?: AbortSignal) => get<{ active: Run | null }>("/api/v1/runs", signal),
@@ -531,6 +534,29 @@ function dispatchFrame(frame: string, onEvent: (event: string, data: string) => 
     else if (field === "data") data.push(value);
   }
   if (data.length > 0) onEvent(event, data.join("\n"));
+}
+
+export interface PreflightBlocker {
+  pod: string;
+  kind: string;
+  explanation: string;
+}
+
+export interface PreflightNode {
+  node: string;
+  ready: boolean;
+  cordoned: boolean;
+  pods: number;
+  drainable: boolean;
+  blockers: PreflightBlocker[];
+}
+
+export interface Preflight {
+  takenAt: string;
+  planId: string;
+  nodes: PreflightNode[];
+  drainable: number;
+  total: number;
 }
 
 export function formatCPU(milli: number): string {

--- a/ui/src/components/review/WhyNothing.tsx
+++ b/ui/src/components/review/WhyNothing.tsx
@@ -1,0 +1,106 @@
+/**
+ * Why the plan is empty.
+ *
+ * An empty plan used to render as a headline and nothing else — and it is the
+ * state a healthy cluster spends most of its life in. On a real GKE cluster an
+ * operator scaled workloads down, watched utilisation fall, saw no plan appear
+ * and had no way to find out why. The planner knew the whole time: every node
+ * undrainable, with a named pod and a named reason for each.
+ *
+ * That answer is not an absence of information. It is a full constraint
+ * analysis with a definite conclusion about every node, and a product whose
+ * pitch is that it explains itself owes the reader that conclusion.
+ *
+ * The data comes from preflight, which already answers exactly this question
+ * per node and now answers it usefully — before DaemonSets stopped counting as
+ * blockers it reported "0 of N nodes will drain cleanly" on every managed
+ * cluster in existence.
+ */
+
+import { useEffect, useState } from "react";
+import { Preflight, api } from "../../api";
+
+/** This product targets a thousand nodes; a thousand rows is not an
+ *  explanation, it is the same explanation a thousand times. */
+const MAX_ROWS = 8;
+
+export default function WhyNothing() {
+  const [data, setData] = useState<Preflight | null>(null);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .preflight()
+      .then((d) => !cancelled && setData(d))
+      .catch(() => !cancelled && setFailed(true));
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (failed || !data) return null;
+
+  // A node with no pods and no blockers is already empty — worth saying,
+  // because it is the one case where the answer is "nothing is wrong".
+  const held = data.nodes.filter((n) => !n.drainable);
+  const free = data.nodes.filter((n) => n.drainable);
+
+  return (
+    <section className="whynothing">
+      <span className="eyebrow mono">Why there is nothing to do</span>
+      <p className="whynothing-lead">
+        {held.length === 0
+          ? `All ${data.total} nodes could drain, but moving their pods would not free a node — the workloads need the room they are using.`
+          : `${held.length} of ${data.total} node${data.total === 1 ? "" : "s"} cannot be freed right now. Each one is held by something specific:`}
+      </p>
+
+      {held.length > 0 && (
+        <ul className="whynothing-list">
+          {held.slice(0, MAX_ROWS).map((n) => {
+            // One line per node: the first blocker is the story, the rest are
+            // the same story repeated.
+            const first = n.blockers[0];
+            const more = n.blockers.length - 1;
+            return (
+              <li key={n.node} className="whynothing-row">
+                <span className="whynothing-node mono">{n.node}</span>
+                <span className="whynothing-why">
+                  {first ? (
+                    <>
+                      <span className="whynothing-pod mono">{first.pod}</span> — {first.explanation}
+                      {more > 0 && (
+                        <span className="whynothing-more">
+                          {" "}
+                          and {more} other{more === 1 ? "" : "s"} on this node
+                        </span>
+                      )}
+                    </>
+                  ) : n.cordoned ? (
+                    "Cordoned, so nothing new can land here and it is already out of the pool."
+                  ) : (
+                    "Its workloads have nowhere else to go with room to spare."
+                  )}
+                </span>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      {held.length > MAX_ROWS && (
+        <p className="whynothing-foot">
+          and {held.length - MAX_ROWS} more held the same way — run{" "}
+          <span className="mono">dencer preflight</span> for the full list.
+        </p>
+      )}
+
+      {free.length > 0 && held.length > 0 && (
+        <p className="whynothing-foot">
+          {free.length} node{free.length === 1 ? "" : "s"} could drain, but emptying{" "}
+          {free.length === 1 ? "it" : "them"} would not free a node worth reclaiming.
+        </p>
+      )}
+    </section>
+  );
+}

--- a/ui/src/styles/review.css
+++ b/ui/src/styles/review.css
@@ -825,3 +825,75 @@
 .btn-caution:disabled {
   opacity: 0.45;
 }
+
+/* Why the plan is empty. Not an error state and not a placeholder: the
+   planner reached a definite conclusion about every node, and this is it. */
+.whynothing {
+  padding: 18px var(--space-6) 20px;
+  border-bottom: 1px solid var(--border);
+  background: var(--surface);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.whynothing-lead {
+  margin: 0;
+  max-width: 82ch;
+  font-size: var(--text-sm);
+  line-height: 1.55;
+  color: var(--text-2);
+  text-wrap: pretty;
+}
+
+.whynothing-list {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  margin: 2px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.whynothing-row {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  padding: 8px 11px;
+  border-radius: 7px;
+  background: var(--inset);
+  border: 1px solid var(--inset-border);
+}
+
+.whynothing-node {
+  flex: 0 0 auto;
+  max-width: 28ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: var(--text-2xs);
+  color: var(--text-1);
+}
+
+.whynothing-why {
+  flex: 1;
+  min-width: 0;
+  font-size: var(--text-xs);
+  line-height: 1.5;
+  color: var(--text-3);
+  text-wrap: pretty;
+}
+
+.whynothing-pod {
+  color: var(--text-2);
+}
+
+.whynothing-more {
+  color: var(--text-5);
+}
+
+.whynothing-foot {
+  margin: 0;
+  font-size: var(--text-xs);
+  color: var(--text-5);
+}


### PR DESCRIPTION
Closes #139.

The state a healthy cluster spends most of its life in rendered as a headline and nothing else:

> **Nothing is safely reclaimable right now**

On the real GKE cluster, an operator scaled workloads down, watched CPU requests fall from 88.5% to 80%, saw no plan appear, and had no way to find out why. The planner knew the whole time and was writing it to a log nobody reads:

```
constraints  movable:29 controllerPinned:20 nodesUndrainable:4
plan         steps:0
```

An empty plan is not an absence of information. It's a complete constraint analysis reaching a definite conclusion about **every node** — and a product whose pitch is that it explains itself owes the reader that conclusion. It's also the most common state, not an edge case.

## Where the answer comes from

`/api/v1/preflight`, which has always answered exactly this question per node, and which the UI never called. It only answers it *usefully* as of #130 — before DaemonSets stopped counting as blockers it reported "0 of N nodes will drain cleanly" on every managed cluster in existence.

So this is one of the four unsurfaced endpoints, surfaced where it's actually needed rather than as a page nobody visits.

## Verified against the live cluster

Rendered with real preflight data:

> **WHY THERE IS NOTHING TO DO**
> 4 of 18 nodes cannot be freed right now. Each one is held by something specific:
>
> `kwok-spot-0` — `dencer-demo-payments-674fd6dc9d-gvs9t` — PodDisruptionBudget dencer-demo/dencer-demo-payments currently allows 0 disruptions (1 healthy, 3 required). The API server will refuse to evict this pod.
> `kwok-spot-1` — …
> `kwok-std-2` — …
> `orbstack` — `company-product/chomp-58454f5479-wmrpv` — No other node can currently accept this pod. *and 47 others on this node*
>
> 14 nodes could drain, but emptying them would not free a node worth reclaiming.

Screenshotted by temporarily forcing the panel on a cluster that *does* have a plan, then reverting — the committed condition is `steps.length === 0`.

Capped at eight rows: this product targets a thousand nodes, and a thousand rows is the same explanation a thousand times rather than an explanation. The remainder is one `dencer preflight` away and the panel says so.

Gates: typecheck, build, density clean.