### PR TITLE
Load lens: account for the nodes it is not showing

### DIFF
--- a/ui/src/components/cluster/ClusterPage.tsx
+++ b/ui/src/components/cluster/ClusterPage.tsx
@@ -518,6 +518,10 @@ function WellsLens({
 
 function LoadLens({ nodes, short }: { nodes: NodeModel[]; short: (n: string) => string }) {
   const measured = nodes.filter((n) => n.used != null);
+  // Simulated nodes have no kubelet, so metrics-server reports nothing for
+  // them. Dropping them is right; dropping them silently is not — the header
+  // says "18 nodes" and this lens would show one row without explanation.
+  const unmeasured = nodes.length - measured.length;
   if (measured.length === 0) {
     return (
       <div className="loadempty">
@@ -543,9 +547,20 @@ function LoadLens({ nodes, short }: { nodes: NodeModel[]; short: (n: string) => 
           <span className="eyebrow mono">Requested vs actually used</span>
           <h2 className="clusterpage-headline">
             {ratio != null
-              ? `Pods reserve ${ratio}× the CPU they use`
+              ? unmeasured > 0
+                ? `On the ${measured.length} measured node${measured.length === 1 ? "" : "s"}, pods reserve ${ratio}× the CPU they use`
+                : `Pods reserve ${ratio}× the CPU they use`
               : "Usage is being measured"}
           </h2>
+          {unmeasured > 0 && (
+            // Filtering silently would make the ratio above read as a claim
+            // about the whole fleet when it describes a fraction of it.
+            <span className="clusterpage-hint mono">
+              {unmeasured} node{unmeasured === 1 ? "" : "s"} report no usage and{" "}
+              {unmeasured === 1 ? "is" : "are"} not counted here — metrics-server has nothing to
+              scrape on {unmeasured === 1 ? "it" : "them"}.
+            </span>
+          )}
         </div>
         <div className="wellslegend">
           <span className="wellslegend-item">


### PR DESCRIPTION
Spotted on the demo cluster: the header said **18 nodes**, the Load lens drew **one row**, and nothing explained the other seventeen.

The filter itself is correct. A simulated node has no kubelet, so metrics-server has nothing to scrape, and drawing it would mean drawing a zero that is really an absence — the same distinction the lens already makes when *nothing* is measured. Filtering silently is what's wrong.

## The headline was the worse half

> Pods reserve 33.5× the CPU they use

That is computed over the measured subset and reads as a claim about the fleet. On a cluster where one node in eighteen reports usage, it's a number about 5% of the cluster wearing the whole cluster's clothes.

It now names its own scope whenever that's fewer than all nodes, with a line underneath saying how many are missing and why. Full coverage is unchanged — original wording, no hint, because there's nothing to disclose.

## Verified on the live cluster

Read out of the DOM rather than eyeballed:

```
HEADER   : 18 nodes · 84 pods · 2 pools
HEADLINE : On the 1 measured node, pods reserve 29.5× the CPU they use
HINT     : 17 nodes report no usage and are not counted here —
           metrics-server has nothing to scrape on them.
ROWS     : 1
```

Same family as everything else this week: the product knew something and didn't say it.

Gates: typecheck, build, density clean; deployed to OrbStack and checked.