### PR TITLE
Say what would unlock a held node, not just what holds it

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -326,7 +326,7 @@ export default function App() {
 
               <RunTrail state={run.state} onDismiss={run.dismiss} />
 
-              {steps.length === 0 && <WhyNothing />}
+              {steps.length === 0 && <WhyNothing graph={state.graph} />}
 
               <main className="review-main">
                 <StepList

--- a/ui/src/components/review/WhyNothing.tsx
+++ b/ui/src/components/review/WhyNothing.tsx
@@ -17,16 +17,71 @@
  * cluster in existence.
  */
 
-import { useEffect, useState } from "react";
-import { Preflight, api } from "../../api";
+import { useEffect, useMemo, useState } from "react";
+import { GraphPayload, Preflight, api, formatCPU } from "../../api";
 
 /** This product targets a thousand nodes; a thousand rows is not an
  *  explanation, it is the same explanation a thousand times. */
 const MAX_ROWS = 8;
 
-export default function WhyNothing() {
+/** formatCPU drops the unit above a core, so "cores" is only right above it. */
+const cpu = (milli: number) => (milli >= 1000 ? `${formatCPU(milli)} cores` : formatCPU(milli));
+
+/**
+ * The constructive half: what would have to change for this node to drain.
+ *
+ * Only for capacity blockers. A PodDisruptionBudget at zero headroom is not
+ * unlocked by freeing CPU somewhere, and saying so would send someone to do
+ * work that changes nothing — worse than saying nothing at all.
+ */
+function unlock(
+  blocker: { pod: string; kind: string } | undefined,
+  requestOf: Map<string, number>,
+  room: { best: number; bestNode: string },
+) {
+  if (!blocker || blocker.kind !== "Resources") return null;
+  const need = requestOf.get(blocker.pod);
+  if (!need || need <= 0) return null;
+  const short = need - room.best;
+  if (short <= 0) return null; // it would fit; something else is in the way
+  return (
+    <span className="whynothing-unlock">
+      {" "}
+      Free {cpu(short)} more anywhere and this pod has somewhere to go
+      {room.bestNode ? ` — ${room.bestNode} has the most room today, ${cpu(room.best)}` : ""}.
+    </span>
+  );
+}
+
+export default function WhyNothing({ graph }: { graph: GraphPayload }) {
   const [data, setData] = useState<Preflight | null>(null);
   const [failed, setFailed] = useState(false);
+
+  // What the cluster could absorb right now: the largest single gap between a
+  // node's ceiling and what it already holds. A pod moves whole, so the
+  // biggest gap is the only one that decides whether it can move at all.
+  const room = useMemo(() => {
+    const ceiling = graph.stats.packCeiling && graph.stats.packCeiling > 0 ? graph.stats.packCeiling : 1;
+    let best = 0;
+    let bestNode = "";
+    for (const e of graph.elements) {
+      if (e.data.kind !== "node" || e.data.cordoned) continue;
+      const gap = (e.data.cpuAllocatable ?? 0) * ceiling - (e.data.cpuRequested ?? 0);
+      if (gap > best) {
+        best = gap;
+        bestNode = e.data.label;
+      }
+    }
+    return { best, bestNode };
+  }, [graph]);
+
+  const requestOf = useMemo(() => {
+    const m = new Map<string, number>();
+    for (const e of graph.elements) {
+      if (e.data.kind === "pod") m.set(e.data.id.replace(/^pod:/, ""), e.data.cpuRequest ?? 0);
+    }
+    return m;
+  }, [graph]);
 
   useEffect(() => {
     let cancelled = false;
@@ -75,6 +130,7 @@ export default function WhyNothing() {
                           and {more} other{more === 1 ? "" : "s"} on this node
                         </span>
                       )}
+                      {unlock(first, requestOf, room)}
                     </>
                   ) : n.cordoned ? (
                     "Cordoned, so nothing new can land here and it is already out of the pool."

--- a/ui/src/styles/review.css
+++ b/ui/src/styles/review.css
@@ -897,3 +897,9 @@
   font-size: var(--text-xs);
   color: var(--text-5);
 }
+
+/* What would have to change. Deliberately quieter than the blocker it
+   follows: the reason is the fact, this is the suggestion. */
+.whynothing-unlock {
+  color: var(--accent-text);
+}


### PR DESCRIPTION
Closes #142.

The empty-plan panel from #139 names the pod in the way and stops. For a **capacity** blocker the product already knows the rest of the sentence — the pod's request is in the graph, every node's allocatable and requested are in the graph, and the plan carries the packing ceiling it refused to pack above. The subtraction was sitting there and nobody was doing it.

A node held by *"No other node can currently accept this pod"* now also says how much would have to come free, and which node is closest:

> `kwok-std-2` — `shop/web-a` — No other node can currently accept this pod. **Free 130m more anywhere and this pod has somewhere to go — node-3 has the most room today, 120m.**

That turns a dead end into a task, and it's the first thing connecting Recommendations — which knows workloads are over-requesting — to Review, which knows the plan is stuck on capacity.

## Deliberately silent

- **PDB blockers.** A PodDisruptionBudget at zero headroom is not unlocked by freeing CPU somewhere. Saying so would send someone to do work that changes nothing, which is worse than saying nothing.
- **When the pod would already fit.** Then the blocker is something else and the arithmetic is a red herring.
- **When the pod isn't in the graph**, or there's no blocker at all.

## Verification

The arithmetic was checked in isolation across six cases before wiring it in: does-not-fit, huge pod, would-fit, PDB, pod missing from the graph, no blocker. Four correctly stay silent.

That check earned its keep twice. It caught the sentence claiming the free room was the *shortfall* — it's the opposite, 120m was what's available while 130m was needed — and `formatCPU` dropping its unit above a core, which had already produced "157m cores" on another screen this week.

Verified this way rather than by deploying a forced-render build to a live cluster, having learned that lesson earlier today.

Gates: typecheck, build, density clean.