### PR TITLE
The ledger notices nodes it did not drain

### DIFF
--- a/internal/api/rest/reclamations.go
+++ b/internal/api/rest/reclamations.go
@@ -83,6 +83,9 @@ func (s *Server) handleReclamations(w http.ResponseWriter, r *http.Request) {
 			"reclaimedCpuMilli": stats.ReclaimedCPUMilli,
 			"reclaimedMemBytes": stats.ReclaimedMemBytes,
 			"uncountedNodes":    stats.UncountedNodes,
+			// Capacity that left the cluster without this product draining
+			// it. Reported, never added to the ledger above.
+			"externallyReclaimed": stats.ExternallyReclaimed,
 		},
 	})
 }

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -219,6 +219,8 @@ type ReclamationStats struct {
 	ReclaimedCPUMilli int64 `json:"reclaimedCpuMilli"`
 	ReclaimedMemBytes int64 `json:"reclaimedMemBytes"`
 	UncountedNodes    int   `json:"uncountedNodes"`
+	// Nodes that left without this product draining them.
+	ExternallyReclaimed int `json:"externallyReclaimed"`
 }
 
 // Reclamations reports what became of drained nodes.

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -440,6 +440,14 @@ func PrintReclamations(w io.Writer, env *ReclamationsEnvelope) {
 				s.UncountedNodes)
 		}
 	}
+
+	// Someone else's work, reported without being claimed. Silence here once
+	// let a fleet shrink from six nodes to four while this command said "No
+	// nodes have been drained yet".
+	if s.ExternallyReclaimed > 0 {
+		fmt.Fprintf(w, "\n  %d node(s) left the cluster without k8s-dencer draining them —\n", s.ExternallyReclaimed)
+		fmt.Fprintf(w, "  an autoscaler, or someone with kubectl. Not counted as this tool's doing.\n")
+	}
 }
 
 func countOlderThan(rs []store.Reclamation, d time.Duration, now time.Time) int {

--- a/internal/publish/external_test.go
+++ b/internal/publish/external_test.go
@@ -1,0 +1,146 @@
+package publish
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/atedgimo/k8s-dencer/internal/model"
+	"github.com/atedgimo/k8s-dencer/internal/store"
+	"github.com/atedgimo/k8s-dencer/internal/store/sqlite"
+)
+
+// A real store, so the schema migration this needs is exercised too — a fake
+// would have happily accepted a column that does not exist.
+func newStore(t *testing.T) *sqlite.Store {
+	t.Helper()
+	db, err := sqlite.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	if err := db.Migrate(context.Background()); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func node(name string, cpu int64) model.Node {
+	return model.Node{Name: name, Allocatable: model.Resources{MilliCPU: cpu, MemoryBytes: cpu << 20}}
+}
+
+func snapOf(nodes ...model.Node) *model.ClusterSnapshot {
+	return &model.ClusterSnapshot{Nodes: nodes}
+}
+
+func newPublisher(db store.Store) *Publisher {
+	return &Publisher{DB: db, Log: slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))}
+}
+
+// The first cycle after a restart has no previous fleet. Treating every node
+// as newly absent would invent a reclamation for the whole cluster.
+func TestFirstCycleInventsNothing(t *testing.T) {
+	db := newStore(t)
+	p := newPublisher(db)
+	ctx := context.Background()
+
+	p.recordExternalReclaims(ctx, db, snapOf(node("a", 1000), node("b", 1000)))
+
+	got, err := db.Reclamations(ctx, 50)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("first cycle recorded %d reclamations; it has nothing to compare against", len(got))
+	}
+}
+
+// The case from the GKE run: nodes vanish, nobody here drained them.
+func TestNodeThatVanishesIsRecordedAsExternal(t *testing.T) {
+	db := newStore(t)
+	p := newPublisher(db)
+	ctx := context.Background()
+
+	p.recordExternalReclaims(ctx, db, snapOf(node("a", 940), node("b", 940), node("c", 940)))
+	p.recordExternalReclaims(ctx, db, snapOf(node("a", 940)))
+
+	got, err := db.Reclamations(ctx, 50)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("recorded %d, want 2 (b and c left the cluster)", len(got))
+	}
+	for _, r := range got {
+		if !r.External {
+			t.Errorf("%s recorded as ours; nothing here drained it", r.Node)
+		}
+		if r.Outcome != store.ReclaimedGone {
+			t.Errorf("%s outcome = %q, want reclaimed", r.Node, r.Outcome)
+		}
+		if r.ResolvedAt == nil {
+			t.Errorf("%s left unresolved; it is already gone, there is nothing to await", r.Node)
+		}
+		// Capacity comes from the last snapshot that still had the node — a
+		// departed node takes its capacity record with it.
+		if r.CPUMilli != 940 {
+			t.Errorf("%s cpu = %dm, want 940m from the last snapshot holding it", r.Node, r.CPUMilli)
+		}
+	}
+}
+
+// A node the executor drained resolves through the normal path. Counting it
+// here as well would attribute our own work to somebody else.
+func TestOurOwnDrainIsNotCountedAsExternal(t *testing.T) {
+	db := newStore(t)
+	p := newPublisher(db)
+	ctx := context.Background()
+
+	if err := db.RecordDrain(ctx, store.Reclamation{
+		Node: "b", DrainedAt: time.Now().UTC(), RunID: "run-1", CPUMilli: 940,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	p.recordExternalReclaims(ctx, db, snapOf(node("a", 940), node("b", 940)))
+	p.recordExternalReclaims(ctx, db, snapOf(node("a", 940)))
+
+	got, err := db.Reclamations(ctx, 50)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("recorded %d rows, want 1 — the executor's own drain, not a duplicate", len(got))
+	}
+	if got[0].External {
+		t.Error("our own drain was recorded as somebody else's work")
+	}
+}
+
+// The ledger's contract: it never overstates. External capacity is counted,
+// and counted apart.
+func TestStatsHoldExternalApartFromOurs(t *testing.T) {
+	db := newStore(t)
+	p := newPublisher(db)
+	ctx := context.Background()
+
+	p.recordExternalReclaims(ctx, db, snapOf(node("a", 940), node("gone", 940)))
+	p.recordExternalReclaims(ctx, db, snapOf(node("a", 940)))
+
+	stats, err := db.ReclamationSummary(ctx, time.Now().UTC().Add(-time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.ExternallyReclaimed != 1 {
+		t.Errorf("externallyReclaimed = %d, want 1", stats.ExternallyReclaimed)
+	}
+	if stats.Reclaimed != 0 {
+		t.Errorf("reclaimed = %d, want 0 — this product drained nothing", stats.Reclaimed)
+	}
+	if stats.ReclaimedCPUMilli != 0 {
+		t.Errorf("ledger claims %dm of savings it did not produce", stats.ReclaimedCPUMilli)
+	}
+}

--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -62,6 +62,12 @@ type Publisher struct {
 	latest         atomic.Pointer[model.ClusterSnapshot]
 	latestAnalysis atomic.Pointer[constraints.Analysis]
 	latestPlan     atomic.Pointer[model.Plan]
+
+	// seenNodes is the previous cycle's fleet, kept so a node that leaves
+	// without this product draining it can be noticed at all. Only the
+	// planning loop touches it, and only from the one goroutine that runs
+	// Cycle, so it needs no lock.
+	seenNodes map[string]model.Node
 }
 
 // LatestSnapshot returns the last successfully collected snapshot, or nil.
@@ -256,6 +262,8 @@ func (p *Publisher) observeReclamations(ctx context.Context, snap *model.Cluster
 		return
 	}
 
+	p.recordExternalReclaims(ctx, tracker, snap)
+
 	pending, err := tracker.PendingReclamations(ctx)
 	if err != nil {
 		p.Log.Error("could not read pending reclamations", "error", err)
@@ -294,6 +302,74 @@ func (p *Publisher) observeReclamations(ctx context.Context, snap *model.Cluster
 	if remaining, err := tracker.PendingReclamations(ctx); err == nil {
 		p.Metrics.NodesAwaitingReclamation.Set(float64(len(remaining)))
 	}
+}
+
+// recordExternalReclaims notices nodes that left the cluster without this
+// product draining them.
+//
+// Every managed cluster runs an autoscaler with its own opinion. On a real GKE
+// cluster one marked two nodes for deletion and removed them in 64 seconds,
+// while converge had just declined to touch either — and `dencer
+// reclamations` went on reporting "No nodes have been drained yet" as the
+// fleet shrank from six nodes to four in front of the operator.
+//
+// The ledger's contract is that it never overstates. Silence about capacity
+// that genuinely left the cluster is the opposite failure, so these are
+// recorded and held apart: what the cluster did, without claiming it.
+func (p *Publisher) recordExternalReclaims(ctx context.Context, tracker store.ReclamationStore, snap *model.ClusterSnapshot) {
+	current := make(map[string]model.Node, len(snap.Nodes))
+	for _, n := range snap.Nodes {
+		current[n.Name] = n
+	}
+
+	// The first cycle after a restart has no previous fleet to compare
+	// against. Treating every node as newly absent would invent a reclamation
+	// for the entire cluster, so the first cycle only observes.
+	if p.seenNodes == nil {
+		p.seenNodes = current
+		return
+	}
+
+	// Ours are already tracked; a node the executor drained resolves through
+	// the normal path and must not be counted twice.
+	ours := map[string]bool{}
+	if pending, err := tracker.PendingReclamations(ctx); err == nil {
+		for _, r := range pending {
+			ours[r.Node] = true
+		}
+	}
+
+	now := time.Now().UTC()
+	for name, was := range p.seenNodes {
+		if _, still := current[name]; still || ours[name] {
+			continue
+		}
+		// Capacity from the last snapshot that still had the node — the same
+		// reason the executor captures it at drain time, for the same reason:
+		// a departed node takes its capacity record with it.
+		rec := store.Reclamation{
+			Node:       name,
+			DrainedAt:  now,
+			ResolvedAt: &now,
+			Outcome:    store.ReclaimedGone,
+			CPUMilli:   was.Allocatable.MilliCPU,
+			MemBytes:   was.Allocatable.MemoryBytes,
+			External:   true,
+		}
+		if err := tracker.RecordDrain(ctx, rec); err != nil {
+			p.Log.Error("could not record externally reclaimed node", "node", name, "error", err)
+			continue
+		}
+		if err := tracker.ResolveReclamation(ctx, name, rec.DrainedAt, store.ReclaimedGone, now); err != nil &&
+			!errors.Is(err, store.ErrNotFound) {
+			p.Log.Error("could not resolve externally reclaimed node", "node", name, "error", err)
+		}
+		p.Log.Info("node reclaimed by something else",
+			"node", name, "cpuMilli", rec.CPUMilli,
+			"note", "not drained by k8s-dencer; recorded separately")
+	}
+
+	p.seenNodes = current
 }
 
 func pct(f float64) string {

--- a/internal/store/sqlite/reclamation.go
+++ b/internal/store/sqlite/reclamation.go
@@ -16,11 +16,11 @@ import (
 // RecordDrain notes that a node was drained and now awaits reclamation.
 func (s *Store) RecordDrain(ctx context.Context, r store.Reclamation) error {
 	_, err := s.db.ExecContext(ctx, `
-		INSERT INTO reclamations (node, drained_at, run_id, plan_id, step, cpu_milli, mem_bytes)
-		VALUES (?, ?, ?, ?, ?, ?, ?)
+		INSERT INTO reclamations (node, drained_at, run_id, plan_id, step, cpu_milli, mem_bytes, external)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT (node, drained_at) DO NOTHING`,
 		r.Node, r.DrainedAt.UTC().Format(time.RFC3339Nano), r.RunID, r.PlanID, r.Step,
-		r.CPUMilli, r.MemBytes)
+		r.CPUMilli, r.MemBytes, r.External)
 	if err != nil {
 		return fmt.Errorf("record drain of %s: %w", r.Node, err)
 	}
@@ -30,7 +30,7 @@ func (s *Store) RecordDrain(ctx context.Context, r store.Reclamation) error {
 // PendingReclamations returns every node still awaiting an outcome.
 func (s *Store) PendingReclamations(ctx context.Context) ([]store.Reclamation, error) {
 	return s.queryReclamations(ctx, `
-		SELECT node, drained_at, run_id, plan_id, step, resolved_at, outcome, cpu_milli, mem_bytes
+		SELECT node, drained_at, run_id, plan_id, step, resolved_at, outcome, cpu_milli, mem_bytes, external
 		FROM reclamations WHERE resolved_at IS NULL
 		ORDER BY drained_at`)
 }
@@ -41,7 +41,7 @@ func (s *Store) Reclamations(ctx context.Context, limit int) ([]store.Reclamatio
 		limit = 50
 	}
 	return s.queryReclamations(ctx, `
-		SELECT node, drained_at, run_id, plan_id, step, resolved_at, outcome, cpu_milli, mem_bytes
+		SELECT node, drained_at, run_id, plan_id, step, resolved_at, outcome, cpu_milli, mem_bytes, external
 		FROM reclamations ORDER BY drained_at DESC LIMIT ?`, limit)
 }
 
@@ -85,7 +85,7 @@ func (s *Store) ReclamationSummary(ctx context.Context, since time.Time) (store.
 
 	cutoff := since.UTC().Format(time.RFC3339Nano)
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT outcome, drained_at, resolved_at, cpu_milli, mem_bytes FROM reclamations
+		SELECT outcome, drained_at, resolved_at, cpu_milli, mem_bytes, external FROM reclamations
 		WHERE resolved_at IS NOT NULL AND resolved_at >= ?`, cutoff)
 	if err != nil {
 		return out, fmt.Errorf("summarise reclamations: %w", err)
@@ -96,8 +96,18 @@ func (s *Store) ReclamationSummary(ctx context.Context, since time.Time) (store.
 	for rows.Next() {
 		var outcome, drainedAt, resolvedAt string
 		var cpuMilli, memBytes int64
-		if err := rows.Scan(&outcome, &drainedAt, &resolvedAt, &cpuMilli, &memBytes); err != nil {
+		var external bool
+		if err := rows.Scan(&outcome, &drainedAt, &resolvedAt, &cpuMilli, &memBytes, &external); err != nil {
 			return out, err
+		}
+		if external {
+			// Counted, but never as ours: it is not a saving this product
+			// produced, and the ledger's whole point is that it does not
+			// overstate.
+			if store.ReclamationOutcome(outcome) == store.ReclaimedGone {
+				out.ExternallyReclaimed++
+			}
+			continue
 		}
 		switch store.ReclamationOutcome(outcome) {
 		case store.ReclaimedGone:
@@ -164,7 +174,7 @@ func (s *Store) queryReclamations(ctx context.Context, query string, args ...any
 			resolvedAt             sql.NullString
 		)
 		if err := rows.Scan(&r.Node, &drainedAt, &runID, &planID, &step, &resolvedAt, &outcome,
-			&r.CPUMilli, &r.MemBytes); err != nil {
+			&r.CPUMilli, &r.MemBytes, &r.External); err != nil {
 			return nil, err
 		}
 		r.DrainedAt = parseTime(drainedAt)

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -56,7 +56,7 @@ func Open(path string) (*Store, error) {
 // Close releases the database handle.
 func (s *Store) Close() error { return s.db.Close() }
 
-const schemaVersion = 8
+const schemaVersion = 9
 
 // Migrate creates or upgrades the schema.
 func (s *Store) Migrate(ctx context.Context) error {
@@ -114,6 +114,11 @@ func (s *Store) Migrate(ctx context.Context) error {
 			return fmt.Errorf("apply schema v8: %w", err)
 		}
 	}
+	if current < 9 {
+		if _, err := tx.ExecContext(ctx, schemaV9); err != nil {
+			return fmt.Errorf("apply schema v9: %w", err)
+		}
+	}
 
 	// PRAGMA does not accept a bound parameter.
 	if _, err := tx.ExecContext(ctx, fmt.Sprintf("PRAGMA user_version = %d", schemaVersion)); err != nil {
@@ -128,6 +133,12 @@ func (s *Store) Migrate(ctx context.Context) error {
 // different ceiling are the same actions.
 const schemaV8 = `
 ALTER TABLE plans ADD COLUMN pack_ceiling REAL NOT NULL DEFAULT 0;
+`
+
+// Schema v9 — nodes this product did not drain. Every existing row was
+// recorded by the executor, so the default is correct for all of them.
+const schemaV9 = `
+ALTER TABLE reclamations ADD COLUMN external INTEGER NOT NULL DEFAULT 0;
 `
 
 const schemaV1 = `

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -97,6 +97,20 @@ type Reclamation struct {
 	// ledger says so rather than guessing.
 	CPUMilli int64 `json:"cpuMilli,omitempty"`
 	MemBytes int64 `json:"memBytes,omitempty"`
+
+	// External marks a node this product did not drain.
+	//
+	// Every managed cluster runs an autoscaler with its own opinion, and on a
+	// real GKE cluster one reclaimed two nodes while converge was declining to
+	// touch them. The ledger reported "No nodes have been drained yet" while
+	// the fleet visibly shrank, which is the one number this mechanism exists
+	// to get right.
+	//
+	// Recorded, and kept separate. Counting someone else's work as a saving
+	// this product produced would be the same overstatement the ledger was
+	// built to remove — but pretending it did not happen understates what the
+	// cluster actually did.
+	External bool `json:"external,omitempty"`
 }
 
 // Pending reports whether this node is still drained and still present.
@@ -129,6 +143,12 @@ type ReclamationStats struct {
 	ReclaimedCPUMilli int64 `json:"reclaimedCpuMilli"`
 	ReclaimedMemBytes int64 `json:"reclaimedMemBytes"`
 	UncountedNodes    int   `json:"uncountedNodes"`
+
+	// ExternallyReclaimed counts nodes that left the cluster without this
+	// product draining them — an autoscaler, or a person with kubectl. Held
+	// apart from Reclaimed so the ledger can show what the cluster did without
+	// claiming credit for it.
+	ExternallyReclaimed int `json:"externallyReclaimed"`
 }
 
 // ReclamationStore tracks drained nodes until something removes them.

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -332,6 +332,9 @@ export interface Reclamation {
   /** Allocatable captured at drain time — the ledger's measured inputs. */
   cpuMilli?: number;
   memBytes?: number;
+  /** The node left without this product draining it: an autoscaler, or
+   *  someone with kubectl. Shown, never counted as ours. */
+  external?: boolean;
 }
 
 export interface ReclamationsResponse {
@@ -355,6 +358,9 @@ export interface ReclamationsResponse {
     reclaimedCpuMilli: number;
     reclaimedMemBytes: number;
     uncountedNodes: number;
+    /** Nodes that left without this product draining them. Reported, never
+     *  added to the ledger — the savings are real but not ours. */
+    externallyReclaimed?: number;
   };
 }
 

--- a/ui/src/components/History.tsx
+++ b/ui/src/components/History.tsx
@@ -196,6 +196,20 @@ function Ledger({ data }: { data: HistoryResponse }) {
       .map((r) => ({ ...r, reclaimed: byRun.get(r.id) }));
   }, [data]);
 
+  // Capacity that left without us. The ledger below is per-run and these have
+  // no run, so without this line a fleet can visibly halve while every row on
+  // screen says the product did nothing — which is what happened on GKE.
+  const elsewhere = useMemo(() => {
+    let nodes = 0;
+    let cpu = 0;
+    for (const r of data.reclamations) {
+      if (!r.external || r.outcome !== "reclaimed") continue;
+      nodes++;
+      cpu += r.cpuMilli ?? 0;
+    }
+    return { nodes, cpu };
+  }, [data]);
+
   return (
     <section className="auditledger">
       <div className="auditledger-head">
@@ -203,6 +217,13 @@ function Ledger({ data }: { data: HistoryResponse }) {
         <span className="auditledger-count">
           {rows.length} entr{rows.length === 1 ? "y" : "ies"}
         </span>
+        {elsewhere.nodes > 0 && (
+          <span className="auditledger-elsewhere">
+            {elsewhere.nodes} node{elsewhere.nodes === 1 ? "" : "s"} reclaimed by something else
+            {elsewhere.cpu > 0 ? ` (${formatCPU(elsewhere.cpu)} cores)` : ""} — not this tool's
+            doing, and not counted as it
+          </span>
+        )}
       </div>
       <div className="auditrow auditrow-head">
         <span className="eyebrow mono">when</span>

--- a/ui/src/styles/history.css
+++ b/ui/src/styles/history.css
@@ -211,3 +211,12 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
+/* Capacity that left without us. Quieter than the ledger's own count: it is
+   context for the rows below, not one of them. */
+.auditledger-elsewhere {
+  font-size: var(--text-2xs);
+  color: var(--text-5);
+  margin-left: auto;
+  text-align: right;
+}


### PR DESCRIPTION
Closes #135, #143.

On the real GKE cluster, Google's autoscaler marked two nodes for deletion and removed them in 64 seconds, while converge had just declined to touch either. `dencer reclamations` went on saying **"No nodes have been drained yet"** as the fleet shrank from six nodes to four in front of the operator.

The ledger's contract is that it never overstates — it counts capacity measured at drain time and admits when a row predates that measurement. **Silence about capacity that genuinely left the cluster is the opposite failure of the same kind.** Every managed cluster runs an autoscaler with its own opinion, so this is the normal case, not an edge one.

## How

The planner already watches nodes every cycle. It now keeps the previous fleet and notices names that are gone, recording them as reclamations marked `external` — resolved immediately, because there is nothing to await, and carrying the allocatable from the last snapshot that still held the node, for the same reason the executor captures it at drain time.

They're held apart everywhere they surface. The savings ledger is unchanged, `ReclaimedCPUMilli` does not move, and the CLI and History both say plainly that something else did this:

```
2 node(s) left the cluster without k8s-dencer draining them —
an autoscaler, or someone with kubectl. Not counted as this tool's doing.
```

## Two mistakes designed out rather than fixed later

- **The first cycle after a restart only observes.** It has no previous fleet, so treating every node as newly absent would invent a reclamation for the entire cluster.
- **A node the executor drained is skipped**, or our own work gets attributed to somebody else.

## Schema

v9 adds one column with a default that is correct for every existing row — all of them were recorded by the executor.

## Verification

Tested against a **real store**, not a fake, so the migration is exercised too — a fake would happily have accepted a column that doesn't exist:

```
--- PASS: TestFirstCycleInventsNothing
--- PASS: TestNodeThatVanishesIsRecordedAsExternal
--- PASS: TestOurOwnDrainIsNotCountedAsExternal
--- PASS: TestStatsHoldExternalApartFromOurs
```

The last asserts the thing that matters: `externallyReclaimed = 1`, `reclaimed = 0`, and the ledger claiming `0m` of savings it did not produce.

`go test ./...`, `make lint`, UI typecheck/build/density all clean.

**This unblocks #136** (savings in currency) — the ledger can now see everything that left the cluster, so pricing it is no longer pricing an empty table.