### PR TITLE
Show the ledger in money, when the operator has said what money

### DIFF
--- a/charts/k8s-dencer/templates/ui-backend/deployment.yaml
+++ b/charts/k8s-dencer/templates/ui-backend/deployment.yaml
@@ -131,6 +131,10 @@ spec:
             - name: CLUSTER_LABEL
               value: {{ . | quote }}
             {{- end }}
+            {{- if .Values.uiBackend.pricing.perHour }}
+            - name: PRICING
+              value: {{ .Values.uiBackend.pricing | toJson | quote }}
+            {{- end }}
             {{- with .Values.uiBackend.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/k8s-dencer/values.yaml
+++ b/charts/k8s-dencer/values.yaml
@@ -170,6 +170,31 @@ uiBackend:
   #
   #   clusterLabel: prod-eu-west-1
   clusterLabel: ""
+
+  # What your machines cost, so the savings ledger can be shown in money.
+  #
+  # There is no built-in price table and there will not be one. List prices
+  # vary by region, change without notice, and are wrong for anyone with a
+  # committed-use discount or an enterprise agreement — so a shipped default
+  # would be a plausible guess wearing the clothes of a measurement, which is
+  # the one thing this ledger exists not to be.
+  #
+  # Unpriced machine types are reported as unpriced. The capacity is still
+  # measured and still shown; only the currency is withheld.
+  #
+  # Keys are matched most specific first, so a spot node and an on-demand node
+  # of the same shape can differ:
+  #
+  #   pricing:
+  #     currency: USD
+  #     perHour:
+  #       e2-medium: 0.0335
+  #       e2-medium/spot: 0.0100
+  #       n2-standard-4: 0.1942
+  pricing:
+    currency: ""
+    perHour: {}
+
   # How often to check the store for a new plan, to push over the event stream.
   # The planner is a separate process reached only through the shared volume,
   # so there is no event feed to subscribe to.

--- a/cmd/ui-backend/main.go
+++ b/cmd/ui-backend/main.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -26,6 +27,7 @@ import (
 	"github.com/atedgimo/k8s-dencer/internal/api/rest"
 	"github.com/atedgimo/k8s-dencer/internal/auth"
 	"github.com/atedgimo/k8s-dencer/internal/httpserver"
+	"github.com/atedgimo/k8s-dencer/internal/pricing"
 	sqlitestore "github.com/atedgimo/k8s-dencer/internal/store/sqlite"
 	"github.com/atedgimo/k8s-dencer/internal/telemetry"
 )
@@ -104,6 +106,18 @@ func run(ctx context.Context, log *slog.Logger) error {
 	if label := env("CLUSTER_LABEL", ""); label != "" {
 		api = api.WithClusterLabel(label)
 		log.Info("cluster label set", "label", label)
+	}
+	// Prices come from the operator or not at all. A malformed table is a
+	// configuration error worth saying out loud, but not worth refusing to
+	// serve over: the ledger falls back to capacity, which is still true.
+	if raw := env("PRICING", ""); raw != "" {
+		var t pricing.Table
+		if err := json.Unmarshal([]byte(raw), &t); err != nil {
+			log.Error("PRICING is not valid JSON; the ledger will show capacity only", "error", err)
+		} else {
+			api = api.WithPricing(t)
+			log.Info("pricing configured", "currency", t.Currency, "machineTypes", len(t.PerHour))
+		}
 	}
 	api.Routes(mux)
 

--- a/internal/api/rest/reclamations.go
+++ b/internal/api/rest/reclamations.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/atedgimo/k8s-dencer/internal/pricing"
 	"github.com/atedgimo/k8s-dencer/internal/reclaim"
 	"github.com/atedgimo/k8s-dencer/internal/store"
 )
@@ -86,6 +87,45 @@ func (s *Server) handleReclamations(w http.ResponseWriter, r *http.Request) {
 			// Capacity that left the cluster without this product draining
 			// it. Reported, never added to the ledger above.
 			"externallyReclaimed": stats.ExternallyReclaimed,
+			// What the reclaimed machines cost, when the operator has said.
+			// Absent entirely when they have not — the ledger shows capacity
+			// rather than a plausible number.
+			"pricing": s.priceOf(recent),
 		},
 	})
+}
+
+// priceOf values the nodes that genuinely left, in the operator's currency.
+//
+// Nil when no price table is configured, so the UI renders capacity and says
+// nothing about money rather than rendering a zero that looks measured. Nodes
+// this product did not drain are priced too, and counted separately: the
+// cluster saved that money whoever caused it, and the ledger's job is to be
+// accurate about what happened, not flattering about who did it.
+func (s *Server) priceOf(recent []store.Reclamation) map[string]any {
+	if s.pricing.Empty() {
+		return nil
+	}
+	var ours, theirs []pricing.Node
+	for _, r := range recent {
+		if r.Outcome != store.ReclaimedGone {
+			continue
+		}
+		n := pricing.Node{InstanceType: r.InstanceType, CapacityType: r.CapacityType}
+		if r.External {
+			theirs = append(theirs, n)
+		} else {
+			ours = append(ours, n)
+		}
+	}
+	mine, other := s.pricing.Value(ours), s.pricing.Value(theirs)
+	return map[string]any{
+		"currency":         s.pricing.Currency,
+		"perHour":          mine.PerHour,
+		"perMonth":         mine.PerMonth,
+		"pricedNodes":      mine.Priced,
+		"unpricedNodes":    mine.Unpriced,
+		"externalPerMonth": other.PerMonth,
+		"externalPriced":   other.Priced,
+	}
 }

--- a/internal/api/rest/rest.go
+++ b/internal/api/rest/rest.go
@@ -23,6 +23,7 @@ import (
 	"github.com/atedgimo/k8s-dencer/internal/auth"
 	"github.com/atedgimo/k8s-dencer/internal/constraints"
 	"github.com/atedgimo/k8s-dencer/internal/model"
+	"github.com/atedgimo/k8s-dencer/internal/pricing"
 	"github.com/atedgimo/k8s-dencer/internal/store"
 )
 
@@ -54,6 +55,18 @@ type Server struct {
 	// which cluster they are about to act on. Operator-set; empty means the
 	// header shows nothing rather than a guess.
 	clusterLabel string
+
+	// pricing is what the operator says their machines cost. Empty means the
+	// ledger reports capacity and no currency, which is the honest half of
+	// the answer rather than a missing one.
+	pricing pricing.Table
+}
+
+// WithPricing supplies the operator's price table. Nothing is priced without
+// one, by design: see internal/pricing.
+func (s *Server) WithPricing(t pricing.Table) *Server {
+	s.pricing = t
+	return s
 }
 
 // WithClusterLabel sets the human name shown in the UI header.

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -221,6 +221,19 @@ type ReclamationStats struct {
 	UncountedNodes    int   `json:"uncountedNodes"`
 	// Nodes that left without this product draining them.
 	ExternallyReclaimed int `json:"externallyReclaimed"`
+	// Absent unless the operator configured a price table.
+	Pricing *ReclamationPricing `json:"pricing,omitempty"`
+}
+
+// ReclamationPricing is the ledger in money. Nil when nothing is priced.
+type ReclamationPricing struct {
+	Currency         string  `json:"currency"`
+	PerHour          float64 `json:"perHour"`
+	PerMonth         float64 `json:"perMonth"`
+	PricedNodes      int     `json:"pricedNodes"`
+	UnpricedNodes    int     `json:"unpricedNodes"`
+	ExternalPerMonth float64 `json:"externalPerMonth"`
+	ExternalPriced   int     `json:"externalPriced"`
 }
 
 // Reclamations reports what became of drained nodes.

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -441,13 +441,39 @@ func PrintReclamations(w io.Writer, env *ReclamationsEnvelope) {
 		}
 	}
 
+	// The rate, not a total: reclaiming a node saves money every hour from
+	// now on, and the cumulative figure is small and unimpressive on day one
+	// while the rate is the actual result.
+	if p := s.Pricing; p != nil && p.PricedNodes > 0 {
+		fmt.Fprintf(w, "  %s %s/month no longer spent, across %d node(s)\n",
+			bold("Worth:"), money(p.Currency, p.PerMonth), p.PricedNodes)
+		if p.UnpricedNodes > 0 {
+			fmt.Fprintf(w, "  (%d node(s) unpriced — add their machine type to uiBackend.pricing)\n",
+				p.UnpricedNodes)
+		}
+	}
+
 	// Someone else's work, reported without being claimed. Silence here once
 	// let a fleet shrink from six nodes to four while this command said "No
 	// nodes have been drained yet".
 	if s.ExternallyReclaimed > 0 {
 		fmt.Fprintf(w, "\n  %d node(s) left the cluster without k8s-dencer draining them —\n", s.ExternallyReclaimed)
 		fmt.Fprintf(w, "  an autoscaler, or someone with kubectl. Not counted as this tool's doing.\n")
+		if p := s.Pricing; p != nil && p.ExternalPriced > 0 {
+			fmt.Fprintf(w, "  (worth %s/month, which the cluster saved and this tool did not)\n",
+				money(p.Currency, p.ExternalPerMonth))
+		}
 	}
+}
+
+// money formats a cost with the operator's own currency label. No symbol
+// lookup: they said "USD" or "EUR" and echoing it back is safer than guessing
+// which glyph they meant.
+func money(currency string, v float64) string {
+	if currency == "" {
+		return fmt.Sprintf("%.2f", v)
+	}
+	return fmt.Sprintf("%.2f %s", v, currency)
 }
 
 func countOlderThan(rs []store.Reclamation, d time.Duration, now time.Time) int {

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -427,10 +427,14 @@ func (e *Executor) recordDrain(ctx context.Context, run store.Run, step model.Pl
 	// savings ledger would be left estimating the very number it exists to
 	// measure.
 	var cpuMilli, memBytes int64
+	var instanceType, capacityType string
 	if snap, err := e.cluster.Snapshot(writeCtx); err == nil {
 		for _, n := range snap.Nodes {
 			if n.Name == step.TargetNode {
 				cpuMilli, memBytes = n.Allocatable.MilliCPU, n.Allocatable.MemoryBytes
+				// What it was, not just how big: a price attaches to a machine
+				// shape, and the shape leaves with the machine.
+				instanceType, capacityType = n.InstanceType(), n.CapacityType()
 				break
 			}
 		}
@@ -444,6 +448,9 @@ func (e *Executor) recordDrain(ctx context.Context, run store.Run, step model.Pl
 		Step:      step.SequenceNumber,
 		CPUMilli:  cpuMilli,
 		MemBytes:  memBytes,
+
+		InstanceType: instanceType,
+		CapacityType: capacityType,
 	})
 	if err != nil {
 		e.log.Error("could not record the drain for reclamation tracking",

--- a/internal/pricing/pricing.go
+++ b/internal/pricing/pricing.go
@@ -1,0 +1,125 @@
+// Package pricing turns reclaimed capacity into money, when — and only when —
+// an operator has said what their machines cost.
+//
+// There is no built-in price table and there will not be one. List prices vary
+// by region, change without notice, and are simply wrong for anyone with a
+// committed-use discount, a savings plan or an enterprise agreement. A
+// consolidation tool whose headline figure is a plausible guess is the thing
+// this product refuses to be: the packing ceiling had to become real before the
+// UI was allowed to draw it, and a price is the same kind of claim.
+//
+// So an unpriced machine type is reported as unpriced. The capacity is still
+// measured, still shown, and still true; only the currency is withheld, which
+// is the honest half of the answer rather than a missing one.
+package pricing
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Table maps a machine shape to its hourly cost, in the operator's currency.
+//
+// Keys are matched most specific first: "e2-medium/spot" before "e2-medium",
+// because a spot node and an on-demand node of the same shape are different
+// amounts of money and reporting one as the other would be a lie with a
+// decimal point in it.
+type Table struct {
+	Currency string
+	PerHour  map[string]float64
+}
+
+// UnmarshalJSON accepts prices as numbers or as strings.
+//
+// Helm's --set turns 0.0335 into the string "0.0335", while the same value in
+// a values file stays a number. Both are the operator saying the same thing,
+// and rejecting one of them would drop pricing silently for anyone who
+// configured it the first way — a failure they would only notice as an
+// absence.
+func (t *Table) UnmarshalJSON(b []byte) error {
+	var raw struct {
+		Currency string                     `json:"currency"`
+		PerHour  map[string]json.RawMessage `json:"perHour"`
+	}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	t.Currency = raw.Currency
+	if len(raw.PerHour) == 0 {
+		return nil
+	}
+	t.PerHour = make(map[string]float64, len(raw.PerHour))
+	for k, v := range raw.PerHour {
+		s := strings.Trim(string(v), `"`)
+		f, err := strconv.ParseFloat(s, 64)
+		if err != nil {
+			return fmt.Errorf("price for %q is not a number: %s", k, s)
+		}
+		t.PerHour[k] = f
+	}
+	return nil
+}
+
+// Empty reports whether anything is priced at all. An operator who has not
+// configured pricing gets capacity, not zeroes.
+func (t Table) Empty() bool { return len(t.PerHour) == 0 }
+
+// Hourly returns the cost of one node of this shape, and whether it is known.
+//
+// Unknown is not zero. Zero is a real price — a node that costs nothing —
+// and conflating the two would let an unpriced fleet report a saving of
+// exactly nothing while looking like a measurement.
+func (t Table) Hourly(instanceType, capacityType string) (float64, bool) {
+	if instanceType == "" {
+		return 0, false
+	}
+	if capacityType != "" {
+		if v, ok := t.PerHour[instanceType+"/"+strings.ToLower(capacityType)]; ok {
+			return v, true
+		}
+	}
+	v, ok := t.PerHour[instanceType]
+	return v, ok
+}
+
+// Reclaimed is what a set of reclaimed nodes is worth.
+type Reclaimed struct {
+	// PerHour is the rate no longer being spent. This is the result: a
+	// reclaimed node saves a rate, forever, not a one-off amount.
+	PerHour float64
+	// PerMonth is the same figure at 730 hours, because nobody budgets by the
+	// hour and everyone recognises a monthly number.
+	PerMonth float64
+	// Priced and Unpriced count nodes, so the figure above can always say how
+	// much of the fleet it actually describes.
+	Priced   int
+	Unpriced int
+	Currency string
+}
+
+// Node describes one reclaimed machine to price.
+type Node struct {
+	InstanceType string
+	CapacityType string
+}
+
+// Value prices a set of reclaimed nodes.
+func (t Table) Value(nodes []Node) Reclaimed {
+	out := Reclaimed{Currency: t.Currency}
+	for _, n := range nodes {
+		rate, ok := t.Hourly(n.InstanceType, n.CapacityType)
+		if !ok {
+			out.Unpriced++
+			continue
+		}
+		out.Priced++
+		out.PerHour += rate
+	}
+	// 730 is the mean hours in a month. Using 720 (30 days) would understate
+	// by a day and a half a year, which is exactly the sort of quiet rounding
+	// this product should not do to a cost figure.
+	out.PerMonth = out.PerHour * 730
+	return out
+}

--- a/internal/pricing/pricing_test.go
+++ b/internal/pricing/pricing_test.go
@@ -1,0 +1,106 @@
+package pricing
+
+import "testing"
+
+func table() Table {
+	return Table{
+		Currency: "USD",
+		PerHour: map[string]float64{
+			"e2-medium":      0.0335,
+			"e2-medium/spot": 0.0100,
+			"n2-standard-4":  0.1942,
+		},
+	}
+}
+
+// Spot and on-demand of the same shape are different amounts of money.
+// Reporting one as the other would be a lie with a decimal point in it.
+func TestCapacityTypeWinsOverTheBareShape(t *testing.T) {
+	tb := table()
+	if got, ok := tb.Hourly("e2-medium", "spot"); !ok || got != 0.0100 {
+		t.Errorf("spot = %v (%v), want 0.01", got, ok)
+	}
+	if got, ok := tb.Hourly("e2-medium", "on-demand"); !ok || got != 0.0335 {
+		t.Errorf("on-demand fell through to the bare shape = %v (%v), want 0.0335", got, ok)
+	}
+	if got, ok := tb.Hourly("e2-medium", ""); !ok || got != 0.0335 {
+		t.Errorf("unknown capacity type = %v (%v), want the bare shape", got, ok)
+	}
+}
+
+// Unknown is not zero. Zero is a real price; conflating them lets an unpriced
+// fleet report a saving of exactly nothing while looking like a measurement.
+func TestUnknownIsNotZero(t *testing.T) {
+	tb := table()
+	if _, ok := tb.Hourly("m5.large", "on-demand"); ok {
+		t.Error("an unlisted machine type reported a price")
+	}
+	if _, ok := tb.Hourly("", ""); ok {
+		t.Error("a node with no instance type reported a price")
+	}
+
+	free := Table{Currency: "USD", PerHour: map[string]float64{"tiny": 0}}
+	if v, ok := free.Hourly("tiny", ""); !ok || v != 0 {
+		t.Errorf("a genuinely free machine = %v (%v); zero is a price, not an absence", v, ok)
+	}
+}
+
+// The figure must always say how much of the fleet it describes.
+func TestValueCountsWhatItCouldNotPrice(t *testing.T) {
+	got := table().Value([]Node{
+		{InstanceType: "e2-medium", CapacityType: "on-demand"},
+		{InstanceType: "e2-medium", CapacityType: "spot"},
+		{InstanceType: "m5.large", CapacityType: "on-demand"}, // not in the table
+		{},                                                   // kwok: unpriced, not free
+	})
+
+	if got.Priced != 2 {
+		t.Errorf("priced = %d, want 2", got.Priced)
+	}
+	if got.Unpriced != 2 {
+		t.Errorf("unpriced = %d, want 2", got.Unpriced)
+	}
+	want := 0.0335 + 0.0100
+	if diff := got.PerHour - want; diff > 1e-9 || diff < -1e-9 {
+		t.Errorf("perHour = %v, want %v", got.PerHour, want)
+	}
+	// 730 hours, the mean month. 720 would understate by a day and a half a
+	// year, which is the sort of quiet rounding a cost figure must not do.
+	if diff := got.PerMonth - want*730; diff > 1e-6 || diff < -1e-6 {
+		t.Errorf("perMonth = %v, want %v", got.PerMonth, want*730)
+	}
+}
+
+// An operator who has configured nothing gets capacity, never zeroes.
+func TestNoTableMeansNoClaim(t *testing.T) {
+	var none Table
+	if !none.Empty() {
+		t.Error("an unconfigured table should report itself empty")
+	}
+	got := none.Value([]Node{{InstanceType: "e2-medium"}})
+	if got.Priced != 0 || got.Unpriced != 1 || got.PerHour != 0 {
+		t.Errorf("unconfigured table produced %+v; it must claim nothing", got)
+	}
+}
+
+// Helm's --set turns 0.0335 into the string "0.0335"; the same value in a
+// values file stays a number. Both are the operator saying the same thing.
+func TestPricesParseAsNumbersOrStrings(t *testing.T) {
+	for _, body := range []string{
+		`{"currency":"USD","perHour":{"e2-medium":0.0335}}`,
+		`{"currency":"USD","perHour":{"e2-medium":"0.0335"}}`,
+	} {
+		var tb Table
+		if err := tb.UnmarshalJSON([]byte(body)); err != nil {
+			t.Fatalf("%s: %v", body, err)
+		}
+		if got, ok := tb.Hourly("e2-medium", ""); !ok || got != 0.0335 {
+			t.Errorf("%s → %v (%v), want 0.0335", body, got, ok)
+		}
+	}
+
+	var bad Table
+	if err := bad.UnmarshalJSON([]byte(`{"perHour":{"e2-medium":"free"}}`)); err == nil {
+		t.Error("a non-numeric price was accepted; it must be a loud configuration error")
+	}
+}

--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -354,7 +354,11 @@ func (p *Publisher) recordExternalReclaims(ctx context.Context, tracker store.Re
 			Outcome:    store.ReclaimedGone,
 			CPUMilli:   was.Allocatable.MilliCPU,
 			MemBytes:   was.Allocatable.MemoryBytes,
-			External:   true,
+			// The shape leaves with the machine, so it is taken from the last
+			// snapshot that still had it — same reason as the capacity.
+			InstanceType: was.InstanceType(),
+			CapacityType: was.CapacityType(),
+			External:     true,
 		}
 		if err := tracker.RecordDrain(ctx, rec); err != nil {
 			p.Log.Error("could not record externally reclaimed node", "node", name, "error", err)

--- a/internal/store/sqlite/reclamation.go
+++ b/internal/store/sqlite/reclamation.go
@@ -16,11 +16,12 @@ import (
 // RecordDrain notes that a node was drained and now awaits reclamation.
 func (s *Store) RecordDrain(ctx context.Context, r store.Reclamation) error {
 	_, err := s.db.ExecContext(ctx, `
-		INSERT INTO reclamations (node, drained_at, run_id, plan_id, step, cpu_milli, mem_bytes, external)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		INSERT INTO reclamations (node, drained_at, run_id, plan_id, step, cpu_milli, mem_bytes,
+		                          external, instance_type, capacity_type)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT (node, drained_at) DO NOTHING`,
 		r.Node, r.DrainedAt.UTC().Format(time.RFC3339Nano), r.RunID, r.PlanID, r.Step,
-		r.CPUMilli, r.MemBytes, r.External)
+		r.CPUMilli, r.MemBytes, r.External, r.InstanceType, r.CapacityType)
 	if err != nil {
 		return fmt.Errorf("record drain of %s: %w", r.Node, err)
 	}
@@ -30,7 +31,7 @@ func (s *Store) RecordDrain(ctx context.Context, r store.Reclamation) error {
 // PendingReclamations returns every node still awaiting an outcome.
 func (s *Store) PendingReclamations(ctx context.Context) ([]store.Reclamation, error) {
 	return s.queryReclamations(ctx, `
-		SELECT node, drained_at, run_id, plan_id, step, resolved_at, outcome, cpu_milli, mem_bytes, external
+		SELECT node, drained_at, run_id, plan_id, step, resolved_at, outcome, cpu_milli, mem_bytes, external, instance_type, capacity_type
 		FROM reclamations WHERE resolved_at IS NULL
 		ORDER BY drained_at`)
 }
@@ -41,7 +42,7 @@ func (s *Store) Reclamations(ctx context.Context, limit int) ([]store.Reclamatio
 		limit = 50
 	}
 	return s.queryReclamations(ctx, `
-		SELECT node, drained_at, run_id, plan_id, step, resolved_at, outcome, cpu_milli, mem_bytes, external
+		SELECT node, drained_at, run_id, plan_id, step, resolved_at, outcome, cpu_milli, mem_bytes, external, instance_type, capacity_type
 		FROM reclamations ORDER BY drained_at DESC LIMIT ?`, limit)
 }
 
@@ -174,7 +175,7 @@ func (s *Store) queryReclamations(ctx context.Context, query string, args ...any
 			resolvedAt             sql.NullString
 		)
 		if err := rows.Scan(&r.Node, &drainedAt, &runID, &planID, &step, &resolvedAt, &outcome,
-			&r.CPUMilli, &r.MemBytes, &r.External); err != nil {
+			&r.CPUMilli, &r.MemBytes, &r.External, &r.InstanceType, &r.CapacityType); err != nil {
 			return nil, err
 		}
 		r.DrainedAt = parseTime(drainedAt)

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -56,7 +56,7 @@ func Open(path string) (*Store, error) {
 // Close releases the database handle.
 func (s *Store) Close() error { return s.db.Close() }
 
-const schemaVersion = 9
+const schemaVersion = 10
 
 // Migrate creates or upgrades the schema.
 func (s *Store) Migrate(ctx context.Context) error {
@@ -119,6 +119,11 @@ func (s *Store) Migrate(ctx context.Context) error {
 			return fmt.Errorf("apply schema v9: %w", err)
 		}
 	}
+	if current < 10 {
+		if _, err := tx.ExecContext(ctx, schemaV10); err != nil {
+			return fmt.Errorf("apply schema v10: %w", err)
+		}
+	}
 
 	// PRAGMA does not accept a bound parameter.
 	if _, err := tx.ExecContext(ctx, fmt.Sprintf("PRAGMA user_version = %d", schemaVersion)); err != nil {
@@ -139,6 +144,13 @@ ALTER TABLE plans ADD COLUMN pack_ceiling REAL NOT NULL DEFAULT 0;
 // recorded by the executor, so the default is correct for all of them.
 const schemaV9 = `
 ALTER TABLE reclamations ADD COLUMN external INTEGER NOT NULL DEFAULT 0;
+`
+
+// Schema v10 — what the reclaimed node was, so the ledger can be priced.
+// Empty on existing rows, which is honest: nobody recorded it at the time.
+const schemaV10 = `
+ALTER TABLE reclamations ADD COLUMN instance_type TEXT NOT NULL DEFAULT '';
+ALTER TABLE reclamations ADD COLUMN capacity_type TEXT NOT NULL DEFAULT '';
 `
 
 const schemaV1 = `

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -98,6 +98,16 @@ type Reclamation struct {
 	CPUMilli int64 `json:"cpuMilli,omitempty"`
 	MemBytes int64 `json:"memBytes,omitempty"`
 
+	// InstanceType and CapacityType, captured at drain time for the same
+	// reason as the capacity above: a reclaimed node takes its labels with
+	// it, and without them the ledger has a size but no price.
+	//
+	// Both are empty when the platform does not say — a KWOK node is not
+	// "on-demand", it is unpriced, and inventing a word here would put a made
+	// up number in a cost report.
+	InstanceType string `json:"instanceType,omitempty"`
+	CapacityType string `json:"capacityType,omitempty"`
+
 	// External marks a node this product did not drain.
 	//
 	// Every managed cluster runs an autoscaler with its own opinion, and on a

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -409,7 +409,7 @@ export default function App() {
 
           {state.status === "ready" && surface === "rightsizing" && <RightsizingPage />}
 
-          {state.status === "ready" && surface === "history" && <History />}
+          {state.status === "ready" && surface === "history" && <History pricing={reclamations.stats.pricing} />}
         </div>
 
         {/* Review carries its own action footer; the plan-identity strip

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -361,6 +361,17 @@ export interface ReclamationsResponse {
     /** Nodes that left without this product draining them. Reported, never
      *  added to the ledger — the savings are real but not ours. */
     externallyReclaimed?: number;
+    /** Absent unless the operator configured uiBackend.pricing. Absent means
+     *  no claim about money, not a claim of zero. */
+    pricing?: {
+      currency: string;
+      perHour: number;
+      perMonth: number;
+      pricedNodes: number;
+      unpricedNodes: number;
+      externalPerMonth: number;
+      externalPriced: number;
+    };
   };
 }
 

--- a/ui/src/components/History.tsx
+++ b/ui/src/components/History.tsx
@@ -17,7 +17,7 @@ const RANGES = [
   { label: "30d", hours: 720 },
 ] as const;
 
-export default function History() {
+export default function History({ pricing }: { pricing?: Pricing }) {
   const [hours, setHours] = useState<number>(24);
   const [data, setData] = useState<HistoryResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -76,7 +76,7 @@ export default function History() {
       {data && data.samples.length >= 2 && (
         <>
           <EstateBars data={data} />
-          <Ledger data={data} />
+          <Ledger data={data} pricing={pricing} />
         </>
       )}
     </div>
@@ -180,7 +180,21 @@ function EstateBars({ data }: { data: HistoryResponse }) {
 
 /* ---------------------------------------------------------------- ledger */
 
-function Ledger({ data }: { data: HistoryResponse }) {
+interface Pricing {
+  currency: string;
+  perMonth: number;
+  pricedNodes: number;
+  unpricedNodes: number;
+  externalPerMonth: number;
+  externalPriced: number;
+}
+
+/** No symbol lookup: the operator said "USD", so echo it rather than guess a
+ *  glyph. A wrong currency symbol on a cost figure is its own small lie. */
+const money = (currency: string, v: number) =>
+  `${v.toFixed(2)}${currency ? " " + currency : ""}`;
+
+function Ledger({ data, pricing }: { data: HistoryResponse; pricing?: Pricing }) {
   const rows = useMemo(() => {
     const byRun = new Map<string, { nodes: number; cpu: number }>();
     for (const r of data.reclamations) {
@@ -220,11 +234,27 @@ function Ledger({ data }: { data: HistoryResponse }) {
         {elsewhere.nodes > 0 && (
           <span className="auditledger-elsewhere">
             {elsewhere.nodes} node{elsewhere.nodes === 1 ? "" : "s"} reclaimed by something else
-            {elsewhere.cpu > 0 ? ` (${formatCPU(elsewhere.cpu)} cores)` : ""} — not this tool's
-            doing, and not counted as it
+            {elsewhere.cpu > 0 ? ` (${formatCPU(elsewhere.cpu)} cores)` : ""}
+            {pricing && pricing.externalPriced > 0
+              ? `, worth ${money(pricing.currency, pricing.externalPerMonth)}/month`
+              : ""}{" "}
+            — not this tool's doing, and not counted as it
           </span>
         )}
       </div>
+      {pricing && pricing.pricedNodes > 0 && (
+        // The rate, not a running total: a reclaimed node saves money every
+        // hour from now on, and a cumulative figure is small and unimpressive
+        // on day one while the rate is the actual result.
+        <p className="auditledger-worth">
+          <strong>{money(pricing.currency, pricing.perMonth)}/month</strong> no longer spent,
+          across {pricing.pricedNodes} reclaimed node
+          {pricing.pricedNodes === 1 ? "" : "s"}
+          {pricing.unpricedNodes > 0
+            ? ` · ${pricing.unpricedNodes} unpriced — add their machine type to uiBackend.pricing`
+            : ""}
+        </p>
+      )}
       <div className="auditrow auditrow-head">
         <span className="eyebrow mono">when</span>
         <span className="eyebrow mono">plan</span>

--- a/ui/src/styles/history.css
+++ b/ui/src/styles/history.css
@@ -220,3 +220,11 @@
   margin-left: auto;
   text-align: right;
 }
+
+/* The ledger in money. Only ever rendered when the operator supplied prices;
+   an absent price table produces no element at all, not a zero. */
+.auditledger-worth {
+  margin: 0 0 10px;
+  font-size: var(--text-sm);
+  color: var(--text-2);
+}

--- a/ui/src/useReclamations.ts
+++ b/ui/src/useReclamations.ts
@@ -15,6 +15,16 @@ export interface ReclamationState {
     /** The ledger: measured capacity actually returned. */
     reclaimedCpuMilli: number;
     reclaimedMemBytes: number;
+    /** What that capacity was worth. Undefined when the operator has not
+     *  configured prices — no claim, rather than a claim of zero. */
+    pricing?: {
+      currency: string;
+      perMonth: number;
+      pricedNodes: number;
+      unpricedNodes: number;
+      externalPerMonth: number;
+      externalPriced: number;
+    };
   };
 }
 
@@ -54,6 +64,7 @@ export function useReclamations(): ReclamationState {
               reclaimed: r.stats.reclaimed,
               reclaimedCpuMilli: r.stats.reclaimedCpuMilli ?? 0,
               reclaimedMemBytes: r.stats.reclaimedMemBytes ?? 0,
+              pricing: r.stats.pricing,
             },
           });
         }


### PR DESCRIPTION
Closes #136. Unblocked by #157 — the ledger can now see everything that left the cluster, so pricing it is no longer pricing an empty table.

The ledger has measured capacity honestly since it existed: summed from allocatable captured at drain time, with rows predating that measurement counted as *uncounted* rather than as zero. What it could never say is what the capacity was **worth**, because a reclaimed node takes its machine type with it and nobody was writing it down.

**Schema v10** records instance and capacity type at drain time — same moment, same reason as the capacity. Externally reclaimed nodes get theirs from the last snapshot that still held them.

## No built-in price table, and there will not be one

List prices vary by region, change without notice, and are wrong for anyone with a committed-use discount or an enterprise agreement. A shipped default would be a plausible guess wearing the clothes of a measurement — the one thing this ledger exists not to be.

```yaml
uiBackend:
  pricing:
    currency: USD
    perHour:
      e2-medium: 0.0335
      e2-medium/spot: 0.0100
```

Absent config means the ledger shows capacity and says nothing about money.

## Three distinctions held carefully

- **Unknown is not zero.** Zero is a real price for a real machine; conflating them would let an unpriced fleet report a saving of exactly nothing while looking measured.
- **Spot is not on-demand.** Keys match most specific first, because reporting one as the other is a lie with a decimal point in it.
- **The figure is a rate, not a total.** Reclaiming a node saves money every hour from now on; a cumulative number is small and unimpressive on day one while the rate is the actual result.

Externally reclaimed nodes are priced too and reported separately — the cluster saved that money whoever caused it, and the ledger's job is accuracy about what happened, not flattery about who did it.

## A footgun found by rendering the chart rather than reading it

`--set uiBackend.pricing.perHour.e2-medium=0.0335` produces the **string** `"0.0335"`, while the same value in a values file stays a number. Unmarshalling into `map[string]float64` would have failed and dropped pricing silently — a failure an operator would only notice as an absence. Both forms now parse; a genuinely non-numeric price is still a loud error.

## Verification

```
--- PASS: TestCapacityTypeWinsOverTheBareShape
--- PASS: TestUnknownIsNotZero
--- PASS: TestValueCountsWhatItCouldNotPrice
--- PASS: TestNoTableMeansNoClaim
--- PASS: TestPricesParseAsNumbersOrStrings
```

Chart rendered both ways: `PRICING` absent by default, present and correct when configured.

`go test ./...`, `make lint`, UI typecheck/build/density all clean.