### PR TITLE
gofmt the pricing test

### DIFF
--- a/internal/pricing/pricing_test.go
+++ b/internal/pricing/pricing_test.go
@@ -51,7 +51,7 @@ func TestValueCountsWhatItCouldNotPrice(t *testing.T) {
 		{InstanceType: "e2-medium", CapacityType: "on-demand"},
 		{InstanceType: "e2-medium", CapacityType: "spot"},
 		{InstanceType: "m5.large", CapacityType: "on-demand"}, // not in the table
-		{},                                                   // kwok: unpriced, not free
+		{}, // kwok: unpriced, not free
 	})
 
 	if got.Priced != 2 {


### PR DESCRIPTION
`main` is red on formatting. This fixes it.

`internal/pricing/pricing_test.go` was appended with a heredoc and never reformatted, so gofmt's alignment of one trailing comment differed by a few spaces:

```diff
-		{},                                                   // kwok: unpriced, not free
+		{}, // kwok: unpriced, not free
```

Every test in that package passes — the gofmt check lives inside the `go test` job, which is why the job went red while the tests were green.

## The real bug was mine

My merge watcher waited for CI to stop reporting *pending* and then merged, without checking whether it had **passed**. So a red commit reached `main` under my own hand. The pattern I've been using all session:

```bash
until ! gh pr checks N | grep -qE 'pending|in_progress'; do sleep 45; done
gh pr merge N --merge --delete-branch     # ← no gate on the result
```

It happened to be harmless this time — a whitespace difference in a test file, with `main` still building and every test passing. It would not have been harmless for anything else. Any further merges this session check for failures before merging, and it's worth remembering the next time that pattern is reached for.