### PR TITLE
Read the node pool from the provider, instead of guessing it

### DIFF
--- a/internal/api/graph/graph.go
+++ b/internal/api/graph/graph.go
@@ -73,8 +73,11 @@ type Data struct {
 	Label string `json:"label"`
 
 	// Node fields.
-	Zone           string `json:"zone,omitempty"`
-	InstanceType   string `json:"instanceType,omitempty"`
+	Zone         string `json:"zone,omitempty"`
+	InstanceType string `json:"instanceType,omitempty"`
+	// Pool is the node group, from the provider's own label. Distinct from
+	// InstanceType: a pool can hold mixed shapes, and two pools can share one.
+	Pool           string `json:"pool,omitempty"`
 	CapacityType   string `json:"capacityType,omitempty"`
 	Ready          bool   `json:"ready,omitempty"`
 	Cordoned       bool   `json:"cordoned,omitempty"`
@@ -198,6 +201,7 @@ func BuildWith(plan *model.Plan, snap *model.ClusterSnapshot, analysis *constrai
 				Label:          n.Name,
 				Zone:           n.Zone(),
 				InstanceType:   n.InstanceType(),
+				Pool:           n.Pool(),
 				CapacityType:   n.CapacityType(),
 				Ready:          n.Ready,
 				Cordoned:       n.Unschedulable,

--- a/internal/model/cluster.go
+++ b/internal/model/cluster.go
@@ -57,6 +57,33 @@ func (n Node) InstanceType() string { return n.Labels["node.kubernetes.io/instan
 // it is unpriced, and pretending otherwise would put a made-up word in a
 // cost report.
 
+// Pool returns the node group this machine belongs to, from whichever
+// provider label is present. Empty when nothing says.
+//
+// This is not the machine type, though the UI conflated the two for a while:
+// it reported "1 pool" while counting distinct instance types, so two pools of
+// one shape read as one and a single pool of mixed shapes read as two.
+//
+// A pool is the unit that scales, the unit that gets rotated, and the unit
+// that has a price — which makes it the unit an operator's question is
+// usually about ("which pool should shrink"), and worth reading properly.
+func (n Node) Pool() string {
+	for _, k := range []string{
+		"cloud.google.com/gke-nodepool",    // GKE
+		"eks.amazonaws.com/nodegroup",      // EKS managed node groups
+		"karpenter.sh/nodepool",            // Karpenter v1
+		"karpenter.sh/provisioner-name",    // Karpenter v1beta1 and earlier
+		"kubernetes.azure.com/agentpool",   // AKS
+		"agentpool",                        // AKS, older clusters
+		"node.kubernetes.io/instancegroup", // various self-managed setups
+	} {
+		if v := n.Labels[k]; v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
 // DoNotDisrupt reports the node-level hands-off marker
 // (karpenter.sh/do-not-disrupt: "true"). Such a node is not a drain
 // candidate, whatever its utilisation says.

--- a/internal/model/pool_test.go
+++ b/internal/model/pool_test.go
@@ -1,0 +1,72 @@
+package model
+
+import "testing"
+
+// A pool is not a machine type. The UI conflated them and reported "1 pool"
+// while counting distinct instance types, so two pools of one shape read as
+// one and a single pool of mixed shapes read as two.
+func TestPoolReadsWhicheverProviderLabelIsPresent(t *testing.T) {
+	cases := []struct {
+		name   string
+		labels map[string]string
+		want   string
+	}{
+		{"GKE", map[string]string{"cloud.google.com/gke-nodepool": "default-pool"}, "default-pool"},
+		{"EKS", map[string]string{"eks.amazonaws.com/nodegroup": "workers"}, "workers"},
+		{"Karpenter v1", map[string]string{"karpenter.sh/nodepool": "general"}, "general"},
+		{"Karpenter v1beta1", map[string]string{"karpenter.sh/provisioner-name": "spot-pool"}, "spot-pool"},
+		{"AKS", map[string]string{"kubernetes.azure.com/agentpool": "agentpool1"}, "agentpool1"},
+		{"AKS older", map[string]string{"agentpool": "nodepool2"}, "nodepool2"},
+		{"unlabelled", map[string]string{"node.kubernetes.io/instance-type": "e2-medium"}, ""},
+		{"no labels", nil, ""},
+	}
+	for _, c := range cases {
+		if got := (Node{Labels: c.labels}).Pool(); got != c.want {
+			t.Errorf("%s: pool = %q, want %q", c.name, got, c.want)
+		}
+	}
+}
+
+// The machine shape must never be reported as the pool: that was the bug.
+func TestPoolIsNotTheInstanceType(t *testing.T) {
+	n := Node{Labels: map[string]string{
+		"node.kubernetes.io/instance-type": "e2-medium",
+		"cloud.google.com/gke-nodepool":    "batch",
+	}}
+	if got := n.Pool(); got != "batch" {
+		t.Errorf("pool = %q, want batch", got)
+	}
+	if got := n.InstanceType(); got != "e2-medium" {
+		t.Errorf("instance type = %q, want e2-medium", got)
+	}
+}
+
+// Two pools of one shape are two pools; one pool of mixed shapes is one.
+// Counting instance types got both of these wrong, in opposite directions.
+func TestPoolCountIndependentOfShape(t *testing.T) {
+	sameShape := []Node{
+		{Labels: map[string]string{"cloud.google.com/gke-nodepool": "a", "node.kubernetes.io/instance-type": "e2-medium"}},
+		{Labels: map[string]string{"cloud.google.com/gke-nodepool": "b", "node.kubernetes.io/instance-type": "e2-medium"}},
+	}
+	if got := distinctPools(sameShape); got != 2 {
+		t.Errorf("two pools sharing a machine type counted as %d, want 2", got)
+	}
+
+	mixedShape := []Node{
+		{Labels: map[string]string{"cloud.google.com/gke-nodepool": "a", "node.kubernetes.io/instance-type": "e2-medium"}},
+		{Labels: map[string]string{"cloud.google.com/gke-nodepool": "a", "node.kubernetes.io/instance-type": "n2-standard-4"}},
+	}
+	if got := distinctPools(mixedShape); got != 1 {
+		t.Errorf("one pool of mixed machine types counted as %d, want 1", got)
+	}
+}
+
+func distinctPools(nodes []Node) int {
+	seen := map[string]bool{}
+	for _, n := range nodes {
+		if p := n.Pool(); p != "" {
+			seen[p] = true
+		}
+	}
+	return len(seen)
+}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -452,12 +452,18 @@ export default function App() {
 
 /** The focused step's pool chip, joined from the graph's node metadata. */
 function poolOf(
-  graph: { elements: Array<{ data: { kind: string; label: string; instanceType?: string; capacityType?: string } }> },
+  graph: {
+    elements: Array<{
+      data: { kind: string; label: string; pool?: string; instanceType?: string; capacityType?: string };
+    }>;
+  },
   step?: PlanStep,
 ): string | undefined {
   if (!step?.targetNode) return undefined;
   const n = graph.elements.find((e) => e.data.kind === "node" && e.data.label === step.targetNode);
-  return n?.data.instanceType || n?.data.capacityType || undefined;
+  // The pool is the thing an operator recognises and the thing that scales;
+  // the machine shape is the fallback when the provider names no pool.
+  return n?.data.pool || n?.data.instanceType || n?.data.capacityType || undefined;
 }
 
 /**

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -67,6 +67,9 @@ export interface GraphData {
   zone?: string;
   instanceType?: string;
   capacityType?: string;
+  /** The node group, from the provider's own label. Distinct from
+   *  instanceType: a pool can hold mixed shapes, and two pools can share one. */
+  pool?: string;
   ready?: boolean;
   cordoned?: boolean;
   cpuAllocatable?: number;

--- a/ui/src/components/cluster/ClusterPage.tsx
+++ b/ui/src/components/cluster/ClusterPage.tsx
@@ -30,7 +30,11 @@ interface Props {
 
 interface NodeModel {
   name: string;
+  /** The node group. Empty when the provider does not label one. */
   pool?: string;
+  /** The machine shape. Shown as an attribute of a node, not as its pool —
+   *  the two were conflated, so "1 pool" was really "1 instance type". */
+  shape?: string;
   alloc: number;
   req: number;
   used?: number;
@@ -92,7 +96,8 @@ function buildNodes(graph: GraphPayload, steps: PlanStep[], observed: Map<string
       const obs = observed.get(d.label);
       return {
         name: d.label,
-        pool: d.instanceType || d.capacityType,
+        pool: d.pool,
+        shape: d.instanceType || d.capacityType,
         alloc: d.cpuAllocatable ?? 0,
         req: d.cpuRequested ?? 0,
         used: d.cpuUsed || undefined,
@@ -125,6 +130,7 @@ export default function ClusterPage({
 }: Props) {
   const nodes = useMemo(() => buildNodes(graph, steps, observed), [graph, steps, observed]);
   const pools = new Set(nodes.map((n) => n.pool).filter(Boolean)).size;
+  const shapes = new Set(nodes.map((n) => n.shape).filter(Boolean)).size;
   const pods = nodes.reduce((n, x) => n + x.pods, 0);
   const short = useMemo(() => shortener(nodes.map((n) => n.name)), [nodes]);
 
@@ -133,7 +139,9 @@ export default function ClusterPage({
       <div className="clusterpage-head">
         <span className="clusterpage-title">Cluster</span>
         <span className="clusterpage-counts mono">
-          {nodes.length} nodes · {pods} pods · {pools} pool{pools === 1 ? "" : "s"}
+          {nodes.length} nodes · {pods} pods
+          {pools > 0 && ` · ${pools} pool${pools === 1 ? "" : "s"}`}
+          {pools === 0 && shapes > 0 && ` · ${shapes} machine type${shapes === 1 ? "" : "s"}`}
         </span>
         <div className="viewswitch clusterpage-lenses" role="group" aria-label="Cluster lens">
           {(Object.keys(VIEW_LABELS) as FieldView[]).map((v) => (
@@ -592,7 +600,9 @@ function LoadLens({ nodes, short }: { nodes: NodeModel[]; short: (n: string) => 
           return (
             <div key={n.name} className="loadrow">
               <span className="loadrow-name mono" title={n.name}>{short(n.name)}</span>
-              <span className="loadrow-pool">{n.pool}</span>
+              <span className="loadrow-pool" title={n.pool && n.shape ? `${n.pool} · ${n.shape}` : undefined}>
+                {n.pool || n.shape}
+              </span>
               <div className="loadbar" aria-hidden="true">
                 <div className="loadbar-used" style={{ width: `${used}%` }} />
                 <div className="loadbar-gap" style={{ width: `${Math.max(0, req - used)}%` }} />


### PR DESCRIPTION
Closes #147.

The Cluster header reported **"1 pool"** and was counting distinct *instance types*. Two pools of one machine shape read as one; a single pool of mixed shapes read as two. The word on screen did not mean what it said.

```ts
pool: d.instanceType || d.capacityType,   // ← not a pool
```

A pool is the unit that scales, the unit that gets rotated, and the unit that has a price — which makes *"which pool should shrink"* the question an operator usually arrives with, and the one the header was quietly answering wrong.

## What it reads now

`Node.Pool()` takes whichever label the provider actually sets:

| Provider | Label |
|---|---|
| GKE | `cloud.google.com/gke-nodepool` |
| EKS | `eks.amazonaws.com/nodegroup` |
| Karpenter v1 | `karpenter.sh/nodepool` |
| Karpenter v1beta1 and earlier | `karpenter.sh/provisioner-name` |
| AKS | `kubernetes.azure.com/agentpool`, and `agentpool` on older clusters |
| Self-managed | `node.kubernetes.io/instancegroup` |

Empty when nothing says — the same principle as `InstanceType` and `CapacityType` beside it. A KWOK node has no pool, and inventing one would put a made-up word next to real numbers.

## The machine shape keeps its own job

It's an attribute of a node, not a stand-in for its pool. Where a cluster labels no pools at all, the header says "N machine types", which is honestly what it was counting before. The Load column falls back to the shape rather than going blank, and shows both in its tooltip when both are known.

## Verification

The `gke-managed` fixture already carries `gke-nodepool` on all four nodes, so this runs against the shape of a real managed cluster rather than an invented one.

Three tests, including the two failure modes that motivated it:

```
--- PASS: TestPoolReadsWhicheverProviderLabelIsPresent   (8 providers + unlabelled)
--- PASS: TestPoolIsNotTheInstanceType
--- PASS: TestPoolCountIndependentOfShape
```

The last asserts both directions: two pools sharing a machine type count as two, one pool of mixed types counts as one.

`gofmt` clean, `go test ./...`, `make lint`, UI typecheck/build/density all green.