### PR TITLE
Record how long the workloads took to come back

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -495,6 +495,13 @@ func (e *Executor) verifyRecovered(ctx context.Context, run store.Run, step mode
 	if len(affected) == 0 {
 		return nil
 	}
+	// This loop already observes recovery on every drain and has never
+	// recorded how long it took. "3 pods move" is a count; how long the
+	// workload is degraded is the consequence, and two Green steps can differ
+	// by an order of magnitude in it while looking identical on screen.
+	started := time.Now()
+	recoveredAt := make(map[string]time.Duration, len(affected))
+
 	deadline := time.Now().Add(e.opts.SettleTimeout)
 	for {
 		live, err := e.cluster.Snapshot(ctx)
@@ -506,14 +513,22 @@ func (e *Executor) verifyRecovered(ctx context.Context, run store.Run, step mode
 		lagging := ""
 		for owner := range affected {
 			if now[owner] < before[owner] {
-				lagging = fmt.Sprintf("%s has %d/%d healthy pod(s)", owner, now[owner], before[owner])
-				break
+				if lagging == "" {
+					lagging = fmt.Sprintf("%s has %d/%d healthy pod(s)", owner, now[owner], before[owner])
+				}
+				continue
+			}
+			// First cycle in which this workload is whole again. Recorded once:
+			// a later flap is a different event, not a slower recovery.
+			if _, seen := recoveredAt[owner]; !seen {
+				recoveredAt[owner] = time.Since(started)
 			}
 		}
 		if lagging == "" {
 			e.event(ctx, run, store.RunEvent{
 				Step: step.SequenceNumber, Node: step.TargetNode, Action: "Verify",
-				Message: fmt.Sprintf("all %d affected workload(s) recovered elsewhere", len(affected)),
+				Message: fmt.Sprintf("all %d affected workload(s) recovered elsewhere%s",
+					len(affected), recoverySummary(recoveredAt)),
 			})
 			return nil
 		}
@@ -525,6 +540,34 @@ func (e *Executor) verifyRecovered(ctx context.Context, run store.Run, step mode
 			return err
 		}
 	}
+}
+
+// recoverySummary reports how long the workloads took to come back.
+//
+// The slowest one is the story: a two-minute recovery on a single-replica
+// workload is a two-minute outage, and it deserves to be visible in the audit
+// trail rather than inferred from timestamps afterwards. Named, because "the
+// slowest was 2m" is actionable only if you know which.
+func recoverySummary(took map[string]time.Duration) string {
+	if len(took) == 0 {
+		return ""
+	}
+	var slowest string
+	var worst time.Duration
+	for owner, d := range took {
+		if d > worst {
+			worst, slowest = d, owner
+		}
+	}
+	// Sub-second recoveries are the KWOK fabric or a pod that never left;
+	// reporting "0s" as a measurement would be noise dressed as precision.
+	if worst < time.Second {
+		return ", all within a second"
+	}
+	if len(took) == 1 {
+		return fmt.Sprintf(", in %s", worst.Round(time.Second))
+	}
+	return fmt.Sprintf(", slowest %s at %s", slowest, worst.Round(time.Second))
 }
 
 // abort restores schedulability and records why.

--- a/internal/executor/recovery_test.go
+++ b/internal/executor/recovery_test.go
@@ -1,0 +1,51 @@
+package executor
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// "3 pods move" is a count. How long the workload is degraded is the
+// consequence, and two Green steps can differ by an order of magnitude in it
+// while looking identical on screen.
+func TestRecoverySummaryNamesTheSlowest(t *testing.T) {
+	got := recoverySummary(map[string]time.Duration{
+		"shop/web":      8 * time.Second,
+		"shop/payments": 2*time.Minute + 10*time.Second,
+		"shop/cache":    40 * time.Second,
+	})
+	if !strings.Contains(got, "shop/payments") {
+		t.Errorf("summary does not name the slowest workload: %q", got)
+	}
+	if !strings.Contains(got, "2m10s") {
+		t.Errorf("summary does not carry the slowest duration: %q", got)
+	}
+}
+
+// One workload needs no comparison, so it reads as a plain duration.
+func TestRecoverySummaryReadsPlainlyForOne(t *testing.T) {
+	got := recoverySummary(map[string]time.Duration{"shop/web": 12 * time.Second})
+	if got != ", in 12s" {
+		t.Errorf("summary = %q, want \", in 12s\"", got)
+	}
+}
+
+// Sub-second recoveries are the simulated fabric, or a pod that never really
+// left. Reporting "0s" would be noise dressed as precision.
+func TestRecoverySummaryDoesNotReportZero(t *testing.T) {
+	got := recoverySummary(map[string]time.Duration{"shop/web": 120 * time.Millisecond})
+	if strings.Contains(got, "0s") {
+		t.Errorf("sub-second recovery reported as a measurement: %q", got)
+	}
+	if !strings.Contains(got, "within a second") {
+		t.Errorf("summary = %q, want it to say the recovery was under a second", got)
+	}
+}
+
+// Nothing observed means nothing claimed.
+func TestRecoverySummaryEmpty(t *testing.T) {
+	if got := recoverySummary(nil); got != "" {
+		t.Errorf("summary = %q, want empty", got)
+	}
+}


### PR DESCRIPTION
Refs #146 — the measuring half.

The executor waits for pods to be Ready after every drain. That distinction is called out as load-bearing right there in the file, because treating Running as recovered means draining the next node while the service is still down. So it **observes recovery every single time**, and has never recorded how long it took.

"3 pods move" is a count. How long the workload is degraded is the consequence, and two Green steps can differ by an order of magnitude in it while looking identical on screen. A two-minute recovery on a single-replica workload is a two-minute outage.

## What changes

The verify loop notes the first cycle in which each workload is whole again — **once**, because a later flap is a different event, not a slower recovery — and the Verify event carries the slowest, named:

```
all 3 affected workload(s) recovered elsewhere, slowest shop/payments at 2m10s
```

Named because "the slowest was 2m10s" is only actionable if you know which one.

Sub-second recoveries read *"all within a second"* rather than *"0s"*: that's the simulated fabric or a pod that never really left, and a zero there would be noise dressed as precision.

It lands in the run trail and the audit ledger, which already persist events — no schema change.

## Scope

This measures and reports. **Predicting** the next drain from the last — "these workloads were Ready in 8s, 40s and 2m last time" on the step detail — needs durations retained per workload, which is a store change and a separate piece of work. Leaving #146 open for that half rather than closing it on a partial.

## Verification

```
--- PASS: TestRecoverySummaryNamesTheSlowest
--- PASS: TestRecoverySummaryReadsPlainlyForOne
--- PASS: TestRecoverySummaryDoesNotReportZero
--- PASS: TestRecoverySummaryEmpty
```

`gofmt` clean, `go test ./...`, `make lint` green.