### PR TITLE
Ask "what if this node were gone?" from the node itself

### DIFF
--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -456,6 +456,10 @@ export const api = {
 
   run: (runId: string, signal?: AbortSignal) => get<RunDetail>(`/api/v1/runs/${runId}`, signal),
 
+  /** Simulate losing nodes or a zone: does everything still fit? */
+  whatif: (body: { removeNodes?: string[]; removeZone?: string }) =>
+    post<WhatIf>(`/api/v1/whatif`, body),
+
   /** Requests against observed usage, per workload. Needs metrics-server. */
   rightsizing: (signal?: AbortSignal) => get<Rightsizing>(`/api/v1/rightsizing`, signal),
   /** Per node: will it drain, and if not, what is in the way. */
@@ -599,6 +603,21 @@ export interface Preflight {
   nodes: PreflightNode[];
   drainable: number;
   total: number;
+}
+
+export interface WhatIfHomeless {
+  pod: string;
+  why: string[];
+}
+
+export interface WhatIf {
+  removed: string[];
+  displaced: number;
+  /** False when at least one displaced pod has nowhere legal to go. */
+  fits: boolean;
+  homeless: WhatIfHomeless[];
+  basedOn: string;
+  takenAt: string;
 }
 
 export function formatCPU(milli: number): string {

--- a/ui/src/components/cluster/ClusterPage.tsx
+++ b/ui/src/components/cluster/ClusterPage.tsx
@@ -10,7 +10,7 @@
  */
 
 import { useMemo, useState } from "react";
-import { GraphPayload, Impact, PlanStep, formatCPU } from "../../api";
+import { GraphPayload, Impact, PlanStep, WhatIf, api, formatCPU } from "../../api";
 import { FieldView, VIEW_LABELS } from "../../view";
 import { VERDICT } from "../Impact";
 import type { ObservedNode } from "../../useObserved";
@@ -228,11 +228,22 @@ function RackLens({
   // a cluster with no plan meant the pane was inert for the whole session. But
   // "what is running here" is answerable about every node, always.
   const [pickedNode, setPickedNode] = useState<string | null>(null);
+  const [whatif, setWhatif] = useState<{ node: string; result?: WhatIf; error?: string } | null>(null);
   const picked = nodes.find((n) => n.name === pickedNode) ?? focused;
   const pickedPods = picked ? (podsByNode.get(`node:${picked.name}`) ?? []) : [];
   const selectNode = (n: NodeModel) => {
     setPickedNode(n.name);
+    // A stale answer next to a new node would be worse than no answer.
+    setWhatif(null);
     onSelectStep(n.drainStep ?? null);
+  };
+
+  const simulate = (name: string) => {
+    setWhatif({ node: name });
+    api
+      .whatif({ removeNodes: [name] })
+      .then((r) => setWhatif({ node: name, result: r }))
+      .catch(() => setWhatif({ node: name, error: "Could not simulate just now." }));
   };
 
   return (
@@ -343,6 +354,43 @@ function RackLens({
                 </p>
               </div>
               <div className="clusterdetail-body">
+                <button
+                  type="button"
+                  className="btn whatif-run"
+                  onClick={() => simulate(picked.name)}
+                  disabled={whatif?.node === picked.name && !whatif.result && !whatif.error}
+                >
+                  {whatif?.node === picked.name && !whatif.result && !whatif.error
+                    ? "Simulating…"
+                    : "What if this node were gone?"}
+                </button>
+                {whatif?.node === picked.name && whatif.error && (
+                  <p className="whatif-note">{whatif.error}</p>
+                )}
+                {whatif?.node === picked.name && whatif.result && (
+                  <div className={"whatif" + (whatif.result.fits ? " is-fits" : " is-tight")}>
+                    <p className="whatif-verdict">
+                      {whatif.result.fits
+                        ? `Everything fits. ${whatif.result.displaced} pod${whatif.result.displaced === 1 ? "" : "s"} would move.`
+                        : `${whatif.result.homeless.length} pod${whatif.result.homeless.length === 1 ? "" : "s"} would have nowhere legal to go.`}
+                    </p>
+                    {whatif.result.homeless.slice(0, 5).map((h) => (
+                      <div key={h.pod} className="whatif-homeless">
+                        <span className="mono">{h.pod}</span>
+                        {h.why[0] ? <span className="whatif-why"> — {h.why[0]}</span> : null}
+                      </div>
+                    ))}
+                    {whatif.result.homeless.length > 5 && (
+                      <p className="whatif-note">
+                        and {whatif.result.homeless.length - 5} more — run{" "}
+                        <span className="mono">dencer whatif --without-nodes {picked.name}</span>
+                      </p>
+                    )}
+                    <p className="whatif-note">
+                      A simulation against the last snapshot. Nothing was touched.
+                    </p>
+                  </div>
+                )}
                 <span className="eyebrow mono">What is running here</span>
                 <ul className="podlist">
                   {pickedPods.length === 0 && (

--- a/ui/src/styles/cluster.css
+++ b/ui/src/styles/cluster.css
@@ -618,3 +618,53 @@
 .loadrow-req {
   color: var(--caution-text);
 }
+
+/* "What if this node were gone?" — a simulation, run from the pane that
+   already describes the node. Deliberately not a button that does anything:
+   the answer is information, and the copy says nothing was touched. */
+.whatif-run {
+  align-self: flex-start;
+  margin-bottom: 4px;
+}
+
+.whatif {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px 11px;
+  margin-bottom: 6px;
+  border-radius: 7px;
+  background: var(--inset);
+  border: 1px solid var(--inset-border);
+}
+
+.whatif.is-fits {
+  border-color: var(--safe-border);
+}
+
+.whatif.is-tight {
+  border-color: var(--held-border);
+}
+
+.whatif-verdict {
+  margin: 0;
+  font-size: var(--text-xs);
+  color: var(--text-1);
+}
+
+.whatif-homeless {
+  font-size: var(--text-2xs);
+  color: var(--text-2);
+  line-height: 1.5;
+}
+
+.whatif-why {
+  color: var(--text-5);
+}
+
+.whatif-note {
+  margin: 0;
+  font-size: var(--text-2xs);
+  color: var(--text-5);
+  text-wrap: pretty;
+}


### PR DESCRIPTION
Closes #141.

`/api/v1/whatif` has been built and tested since before the redesign, and `ui/src/api.ts` never called it — so the only way to ask a resilience question was a terminal. It was one of four such endpoints an audit turned up; this is the third surfaced.

## It belongs on the node, not on a page

The detail pane already knows which node you're looking at and already lists what runs there, so *"and what if it were gone"* is the next question in the same breath. A separate destination would mean choosing the node twice.

The answer is either everything fits and N pods would move, or the pods that would have nowhere legal to go — each with the reason the analyzer already wrote for it. Capped at five with a pointer to `dencer whatif --without-nodes <node>` for the rest, on the same grounds as the empty-plan panel: a hundred rows is the same answer a hundred times.

## Two things the state handling has to get right

- **Selecting a different node clears the previous answer.** A stale result beside a new node is worse than no result.
- **The copy says nothing was touched.** This is the one button on the Cluster page that looks like it might *do* something, on a screen whose entire premise is that nothing happens without approval.

## Verification

Deployed to OrbStack and driven with Playwright — the real button, against the real API:

```
button present: true
VERDICT:  Everything fits. 3 pods would move.
NOTE:     A simulation against the last snapshot. Nothing was touched.
```

Every CSS custom property checked against `theme.css`. Also caught a class that didn't exist — the markup said `btn-quiet`, the stylesheet has `.btn` — which would have shipped an unstyled button.

Gates: typecheck, build, density, `go test ./...`, `gofmt` all clean.