### PR TITLE
Say whether a maintenance window is open

### DIFF
--- a/cmd/ui-backend/main.go
+++ b/cmd/ui-backend/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/atedgimo/k8s-dencer/internal/pricing"
 	sqlitestore "github.com/atedgimo/k8s-dencer/internal/store/sqlite"
 	"github.com/atedgimo/k8s-dencer/internal/telemetry"
+	"github.com/atedgimo/k8s-dencer/internal/window"
 )
 
 // version is stamped at build time via -ldflags.
@@ -107,6 +108,18 @@ func run(ctx context.Context, log *slog.Logger) error {
 		api = api.WithClusterLabel(label)
 		log.Info("cluster label set", "label", label)
 	}
+	// Maintenance windows decide whether Red steps can run, and the UI has
+	// been naming that precondition without any way to check it. The read is
+	// already granted: the chart's -read ClusterRole covers maintenancewindows
+	// and is bound to ui-backend as well as the planner.
+	if cfg, err := ctrlconfig.GetConfig(); err != nil {
+		log.Warn("no cluster config; maintenance window state will be unavailable", "error", err)
+	} else if wr, err := window.NewReader(cfg, log); err != nil {
+		log.Warn("could not build the maintenance window reader", "error", err)
+	} else {
+		api = api.WithWindows(wr)
+	}
+
 	// Prices come from the operator or not at all. A malformed table is a
 	// configuration error worth saying out loud, but not worth refusing to
 	// serve over: the ledger falls back to capacity, which is still true.

--- a/internal/api/rest/rest.go
+++ b/internal/api/rest/rest.go
@@ -25,6 +25,7 @@ import (
 	"github.com/atedgimo/k8s-dencer/internal/model"
 	"github.com/atedgimo/k8s-dencer/internal/pricing"
 	"github.com/atedgimo/k8s-dencer/internal/store"
+	"github.com/atedgimo/k8s-dencer/internal/window"
 )
 
 // Guard authorizes a request before it reaches a handler.
@@ -56,10 +57,27 @@ type Server struct {
 	// header shows nothing rather than a guess.
 	clusterLabel string
 
+	// windows evaluates maintenance windows live. Nil when the deployment
+	// cannot read them, which is reported as "cannot read" rather than as
+	// "none defined" — those are different answers.
+	windows WindowReader
+
 	// pricing is what the operator says their machines cost. Empty means the
 	// ledger reports capacity and no currency, which is the honest half of
 	// the answer rather than a missing one.
 	pricing pricing.Table
+}
+
+// WindowReader evaluates the cluster's maintenance windows at this instant.
+// An interface so the server does not depend on a Kubernetes client.
+type WindowReader interface {
+	Current(ctx context.Context) (*window.Set, error)
+}
+
+// WithWindows lets the API answer whether Red steps can run right now.
+func (s *Server) WithWindows(r WindowReader) *Server {
+	s.windows = r
+	return s
 }
 
 // WithPricing supplies the operator's price table. Nothing is priced without
@@ -131,6 +149,7 @@ func (s *Server) Routes(mux *http.ServeMux) {
 
 	read("/api/v1/version", s.handleVersion)
 	read("/api/v1/reclamations", s.handleReclamations)
+	read("/api/v1/windows", s.handleWindows)
 	read("/api/v1/preflight", s.handlePreflight)
 	read("/api/v1/resilience", s.handleResilience)
 	read("/api/v1/rightsizing", s.handleRightsizing)

--- a/internal/api/rest/windows.go
+++ b/internal/api/rest/windows.go
@@ -1,0 +1,71 @@
+package rest
+
+import (
+	"net/http"
+	"time"
+)
+
+// Maintenance windows: whether Red steps can run, and if not, when they could.
+//
+// The UI has told operators "Maintenance window only" on every Red step since
+// the redesign and given them no way to see whether a window is open, when the
+// next one starts, or which windows exist at all. Worse, the window package
+// resolves every failure to CLOSED and writes a reason for each — an
+// unparseable cron, an unknown timezone, a suspended window — and nobody could
+// read any of them. A typo meant Red steps silently never became runnable.
+//
+// Evaluated per request rather than cached. The package's own doc is explicit
+// that a cached copy of a live authorisation is not one, and "is a window open
+// right now" is a question about now.
+func (s *Server) handleWindows(w http.ResponseWriter, r *http.Request) {
+	if s.windows == nil {
+		// No reader configured: say so rather than implying no windows exist.
+		// "None defined" and "not looking" are different answers and only one
+		// of them means Red can never run.
+		writeJSON(w, http.StatusOK, map[string]any{
+			"available": false,
+			"reason":    "this deployment cannot read maintenance windows",
+		})
+		return
+	}
+
+	set, err := s.windows.Current(r.Context())
+	if err != nil {
+		s.fail(w, err)
+		return
+	}
+
+	states := set.States()
+	out := make([]map[string]any, 0, len(states))
+	for _, st := range states {
+		row := map[string]any{
+			"name":      st.Name,
+			"open":      st.Open,
+			"allowsRed": st.AllowsRed,
+			"reason":    st.Reason,
+		}
+		if !st.ClosesAt.IsZero() {
+			row["closesAt"] = st.ClosesAt.UTC()
+		}
+		if !st.NextOpen.IsZero() {
+			row["nextOpen"] = st.NextOpen.UTC()
+		}
+		if len(st.Selector) > 0 {
+			row["selector"] = st.Selector
+		}
+		if st.MaxNodes > 0 {
+			row["maxNodes"] = st.MaxNodes
+		}
+		out = append(out, row)
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"available":   true,
+		"evaluatedAt": time.Now().UTC(),
+		// anyOpen is the question the top bar asks: can anything Red run at
+		// all right now. Per-node coverage is a different question and the
+		// step detail is where it belongs.
+		"anyOpen": set.Any(),
+		"windows": out,
+	})
+}

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -456,6 +456,9 @@ export const api = {
 
   run: (runId: string, signal?: AbortSignal) => get<RunDetail>(`/api/v1/runs/${runId}`, signal),
 
+  /** Whether Red steps can run right now, and if not, when they could. */
+  windows: (signal?: AbortSignal) => get<Windows>(`/api/v1/windows`, signal),
+
   /** Simulate losing nodes or a zone: does everything still fit? */
   whatif: (body: { removeNodes?: string[]; removeZone?: string }) =>
     post<WhatIf>(`/api/v1/whatif`, body),
@@ -603,6 +606,30 @@ export interface Preflight {
   nodes: PreflightNode[];
   drainable: number;
   total: number;
+}
+
+export interface WindowState {
+  name: string;
+  open: boolean;
+  allowsRed: boolean;
+  /** Why it is closed, in words. The window package writes one for every
+   *  failure — an unparseable cron, an unknown zone, a suspended window —
+   *  and until now nobody could read any of them. */
+  reason: string;
+  closesAt?: string;
+  nextOpen?: string;
+  selector?: Record<string, string>;
+  maxNodes?: number;
+}
+
+export interface Windows {
+  /** False when the deployment cannot read windows at all. Distinct from
+   *  "none are defined": only one of those means Red can never run. */
+  available: boolean;
+  reason?: string;
+  evaluatedAt?: string;
+  anyOpen?: boolean;
+  windows?: WindowState[];
 }
 
 export interface WhatIfHomeless {

--- a/ui/src/components/TopBar.tsx
+++ b/ui/src/components/TopBar.tsx
@@ -15,6 +15,7 @@
  */
 
 import { useEffect, useState } from "react";
+import { Windows, api } from "../api";
 import { Theme, applyTheme, storedTheme } from "../theme";
 
 interface Props {
@@ -28,6 +29,67 @@ interface Props {
   onRecompute?: () => void;
 }
 
+/** Maintenance window state, beside plan freshness because both answer the
+ *  same question: can I act right now. */
+function WindowChip() {
+  const [w, setW] = useState<Windows | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = () =>
+      api
+        .windows()
+        .then((d) => !cancelled && setW(d))
+        .catch(() => {
+          // Window state is context, never the reason the bar fails to draw.
+        });
+    load();
+    // Evaluated live server-side; a minute is close enough for a schedule
+    // measured in hours, and the exact boundary is in closesAt either way.
+    const t = setInterval(load, 60_000);
+    return () => {
+      cancelled = true;
+      clearInterval(t);
+    };
+  }, []);
+
+  if (!w?.available || !w.windows?.length) return null;
+
+  const open = w.windows.filter((x) => x.open);
+  if (open.length > 0) {
+    const closes = open
+      .map((x) => x.closesAt)
+      .filter(Boolean)
+      .sort()[0];
+    return (
+      <span className="topbar-window is-open" title={open.map((x) => x.name).join(", ")}>
+        maintenance window open
+        {closes ? ` · until ${new Date(closes).toLocaleTimeString()}` : ""}
+      </span>
+    );
+  }
+
+  // Closed. The next opening is the useful half; a window that will never
+  // open is the other kind of useful, and the reason says which.
+  const next = w.windows
+    .map((x) => x.nextOpen)
+    .filter(Boolean)
+    .sort()[0];
+  const stuck = w.windows.filter((x) => !x.nextOpen);
+  return (
+    <span
+      className="topbar-window"
+      title={w.windows.map((x) => `${x.name}: ${x.reason || "closed"}`).join("\n")}
+    >
+      {next
+        ? `next maintenance window ${new Date(next).toLocaleString()}`
+        : stuck.length > 0
+          ? `no window will open — ${stuck[0].reason || "check the schedule"}`
+          : "maintenance window closed"}
+    </span>
+  );
+}
+
 export default function TopBar({ planId, strategy, confirmedAt, stale, onRecompute }: Props) {
   return (
     <header className="topbar">
@@ -39,6 +101,7 @@ export default function TopBar({ planId, strategy, confirmedAt, stale, onRecompu
           </div>
           <span className="topbar-sep" aria-hidden="true" />
           <Freshness confirmedAt={confirmedAt} stale={stale} />
+          <WindowChip />
           {strategy && <span className="topbar-strategy mono">{strategy}</span>}
         </>
       )}

--- a/ui/src/styles/chrome.css
+++ b/ui/src/styles/chrome.css
@@ -35,3 +35,15 @@
   padding: var(--space-2) 0;
   text-align: center;
 }
+
+/* Maintenance window state, beside plan freshness: both answer "can I act
+   right now". Quiet by default; the open state is the exceptional one. */
+.topbar-window {
+  font-size: var(--text-2xs);
+  color: var(--text-5);
+  white-space: nowrap;
+}
+
+.topbar-window.is-open {
+  color: var(--safe);
+}


### PR DESCRIPTION
Closes #144. The last of the unsurfaced subsystems.

`internal/window` is complete — cron, timezones, node selectors, fail-closed — backed by the only CRD this chart ships, and it's what finally makes Red steps executable. The UI's entire engagement with it was one string:

```ts
Red: "Maintenance window only",
```

The screen named a precondition and gave no way to check it. And the package resolves *every* failure to CLOSED **and writes a reason for each** — an unparseable cron, an unknown timezone, a suspended window — which nobody could read. A typo meant Red steps silently never became runnable, with the diagnosis sitting in memory the whole time.

## No RBAC change needed

The chart's `-read` ClusterRole already covers `maintenancewindows` and is already bound to ui-backend alongside the planner. I checked before adding anything.

## Evaluated live, not stored

I started down the store route — planner writes state, ui-backend serves it — and backed out. Window state is a function of *now*, and the package's own doc is explicit that a cached copy of a live authorisation is not one. A stored snapshot would be wrong near exactly the boundary that matters.

**"Cannot read windows" and "no windows are defined" are different answers**, and only one of them means Red can never run. The endpoint distinguishes them.

## Where it lands

Beside plan freshness in the top bar, because both answer "can I act right now". Open shows when it closes; closed shows when the next one opens; a window that will never open says why — the case that was undiagnosable before.

## Verification

Against the live cluster, with two windows created for the purpose:

```json
{ "anyOpen": true, "available": true, "windows": [
  { "name": "always-open-test", "open": true,
    "reason": "open until 2026-08-07T17:48:00Z" },
  { "name": "broken-cron-test", "open": false,
    "reason": "schedule \"not a cron\" is not a valid cron expression
               (expected exactly 5 fields, found 3), so the window cannot open" }
]}
```

That second reason is the whole point of the issue — generated all along, readable for the first time.

Top bar rendered `maintenance window open · until 8:49:00 PM`. Both test windows deleted afterwards; `kubectl get maintenancewindow` is clean.

Also verified the empty case first: `available: true, windows: []` on a cluster with the CRD and no windows.

`gofmt`, `go test ./...`, `make lint`, UI typecheck/build/density all green.