### PR TITLE
Remember what each node usually does

### DIFF
--- a/internal/api/rest/rest.go
+++ b/internal/api/rest/rest.go
@@ -150,6 +150,7 @@ func (s *Server) Routes(mux *http.ServeMux) {
 	read("/api/v1/version", s.handleVersion)
 	read("/api/v1/reclamations", s.handleReclamations)
 	read("/api/v1/windows", s.handleWindows)
+	read("/api/v1/stability", s.handleStability)
 	read("/api/v1/preflight", s.handlePreflight)
 	read("/api/v1/resilience", s.handleResilience)
 	read("/api/v1/rightsizing", s.handleRightsizing)

--- a/internal/api/rest/stability.go
+++ b/internal/api/rest/stability.go
@@ -1,0 +1,42 @@
+package rest
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/atedgimo/k8s-dencer/internal/store"
+)
+
+// stabilityWindow is how far back "usually" reaches. Matched to the sampler's
+// retention: asking for more would silently answer from less.
+const stabilityWindow = 14 * 24 * time.Hour
+
+// Node stability: what a node usually does, not just what it is doing now.
+//
+// Every other surface in this product describes a single instant and then asks
+// for a decision about a system that varies. A node at 30% on a Tuesday
+// afternoon and a node that peaks at 92% every night look identical on the
+// Cluster page, and draining them are very different decisions.
+//
+// Aggregated in SQL and returned as one row per node: the browser needs a
+// sentence, not a fortnight of points for every node in the fleet.
+func (s *Server) handleStability(w http.ResponseWriter, r *http.Request) {
+	ts, ok := s.store.(store.SampleStore)
+	if !ok {
+		writeJSON(w, http.StatusOK, map[string]any{"available": false})
+		return
+	}
+	rows, err := ts.NodeStabilitySince(r.Context(), time.Now().Add(-stabilityWindow))
+	if err != nil {
+		s.fail(w, err)
+		return
+	}
+	// Empty is a real answer — no usage source configured, or a cluster that
+	// started ten minutes ago — and it is reported as empty rather than as
+	// zeroes, on the same principle as the rest of the ledger.
+	writeJSON(w, http.StatusOK, map[string]any{
+		"available":  true,
+		"windowDays": int(stabilityWindow.Hours() / 24),
+		"nodes":      rows,
+	})
+}

--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -216,6 +216,37 @@ func (p *Publisher) Cycle(ctx context.Context) {
 		if pruned, err := ts.PruneSamples(ctx, time.Now().Add(-30*24*time.Hour)); err == nil && pruned > 0 {
 			p.Log.Info("pruned timeline", "removed", pruned)
 		}
+
+		// Per-node utilisation, so the UI can tell a node that has been idle
+		// for a fortnight from one that spikes nightly — the distinction the
+		// operator is actually being asked to judge.
+		//
+		// Only when usage is measured. Writing zeroes from a requests-only
+		// snapshot would build a fortnight of evidence that every node is
+		// idle, which is worse than having no evidence at all.
+		if snap.HasUsageData {
+			nodeSamples := make([]store.NodeSample, 0, len(snap.Nodes))
+			for _, n := range snap.Nodes {
+				if n.Usage == nil {
+					continue // this node is unmeasured; a zero would be a lie
+				}
+				nodeSamples = append(nodeSamples, store.NodeSample{
+					Node: n.Name, TakenAt: at,
+					CPUUsedMilli:  n.Usage.MilliCPU,
+					CPUAllocMilli: n.Allocatable.MilliCPU,
+				})
+			}
+			if err := ts.SaveNodeSamples(ctx, nodeSamples); err != nil {
+				p.Log.Warn("saving per-node samples failed", "error", err)
+			}
+			// Days, not the month the fleet timeline keeps: this is one row
+			// per node per cycle, so a thousand nodes on a thirty-second
+			// resync is millions of rows a day. A fortnight is long enough to
+			// say "stably idle" and short enough to stay a database.
+			if pruned, err := ts.PruneNodeSamples(ctx, time.Now().Add(-14*24*time.Hour)); err == nil && pruned > 0 {
+				p.Log.Info("pruned per-node timeline", "removed", pruned)
+			}
+		}
 	}
 
 	// The planner is the only component watching nodes continuously, so it is

--- a/internal/store/sqlite/node_samples.go
+++ b/internal/store/sqlite/node_samples.go
@@ -1,0 +1,110 @@
+package sqlite
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/atedgimo/k8s-dencer/internal/store"
+)
+
+// Per-node utilisation over time. See store.NodeSample for why this is
+// separate from the fleet timeline: "how big was the cluster" and "is this
+// node stably idle" are different questions and only one of them can be
+// answered from a total.
+
+// SaveNodeSamples writes one point per node in a single transaction.
+//
+// A thousand nodes every thirty seconds is a thousand statements, and doing
+// that outside a transaction turns a planning cycle into a thousand fsyncs.
+func (s *Store) SaveNodeSamples(ctx context.Context, samples []store.NodeSample) error {
+	if len(samples) == 0 {
+		return nil
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	stmt, err := tx.PrepareContext(ctx, `
+		INSERT INTO node_samples (node, taken_at, cpu_used_milli, cpu_alloc_milli)
+		VALUES (?, ?, ?, ?)
+		ON CONFLICT (node, taken_at) DO NOTHING`)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = stmt.Close() }()
+
+	for _, n := range samples {
+		if _, err := stmt.ExecContext(ctx, n.Node,
+			n.TakenAt.UTC().Format(time.RFC3339Nano), n.CPUUsedMilli, n.CPUAllocMilli); err != nil {
+			return fmt.Errorf("save node sample for %s: %w", n.Node, err)
+		}
+	}
+	return tx.Commit()
+}
+
+// NodeStabilitySince summarises each node's utilisation over a window.
+//
+// The median is computed in SQL rather than in Go because the alternative is
+// shipping every point for every node to compute one number per node. On a
+// large fleet that is the difference between a query and an outage.
+//
+// Rows with no allocatable are skipped rather than divided by: a node whose
+// capacity was not recorded produces no percentage, which is the honest
+// answer, instead of an infinity.
+func (s *Store) NodeStabilitySince(ctx context.Context, since time.Time) ([]store.NodeStability, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		WITH pct AS (
+			SELECT node, taken_at,
+			       (cpu_used_milli * 100.0) / cpu_alloc_milli AS p
+			FROM node_samples
+			WHERE taken_at >= ? AND cpu_alloc_milli > 0
+		),
+		ranked AS (
+			SELECT node, p,
+			       ROW_NUMBER()  OVER (PARTITION BY node ORDER BY p) AS rn,
+			       COUNT(*)      OVER (PARTITION BY node)            AS n,
+			       MAX(p)        OVER (PARTITION BY node)            AS peak,
+			       MIN(taken_at) OVER (PARTITION BY node)            AS oldest
+			FROM pct
+		)
+		SELECT node, n, oldest, peak, p AS median
+		FROM ranked
+		WHERE rn = (n / 2) + 1
+		ORDER BY node`, since.UTC().Format(time.RFC3339Nano))
+	if err != nil {
+		return nil, fmt.Errorf("summarise node stability: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := []store.NodeStability{}
+	for rows.Next() {
+		var (
+			n            store.NodeStability
+			oldest       string
+			peak, median float64
+		)
+		if err := rows.Scan(&n.Node, &n.Samples, &oldest, &peak, &median); err != nil {
+			return nil, err
+		}
+		n.Since = parseTime(oldest)
+		n.PeakPct = int(peak + 0.5)
+		n.MedianPct = int(median + 0.5)
+		out = append(out, n)
+	}
+	return out, rows.Err()
+}
+
+// PruneNodeSamples removes per-node points older than before.
+func (s *Store) PruneNodeSamples(ctx context.Context, before time.Time) (int, error) {
+	res, err := s.db.ExecContext(ctx,
+		`DELETE FROM node_samples WHERE taken_at < ?`,
+		before.UTC().Format(time.RFC3339Nano))
+	if err != nil {
+		return 0, fmt.Errorf("prune node samples: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	return int(n), nil
+}

--- a/internal/store/sqlite/node_samples_test.go
+++ b/internal/store/sqlite/node_samples_test.go
@@ -1,0 +1,132 @@
+package sqlite_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/atedgimo/k8s-dencer/internal/store"
+	"github.com/atedgimo/k8s-dencer/internal/store/sqlite"
+)
+
+func nodeStore(t *testing.T) *sqlite.Store {
+	t.Helper()
+	db, err := sqlite.Open(filepath.Join(t.TempDir(), "n.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := db.Migrate(context.Background()); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+// The distinction the whole thing exists for: a node that sits at 30% for a
+// fortnight is a different decision from one that spikes to 90% nightly, and
+// a single instant cannot tell them apart.
+func TestStabilitySeparatesSteadyFromSpiky(t *testing.T) {
+	db := nodeStore(t)
+	ctx := context.Background()
+	base := time.Now().UTC().Add(-6 * time.Hour)
+
+	var samples []store.NodeSample
+	for i := 0; i < 20; i++ {
+		at := base.Add(time.Duration(i) * time.Minute)
+		// steady: 300m of 1000m, every time.
+		samples = append(samples, store.NodeSample{
+			Node: "steady", TakenAt: at, CPUUsedMilli: 300, CPUAllocMilli: 1000,
+		})
+		// spiky: 300m usually, 900m on one reading in five.
+		used := int64(300)
+		if i%5 == 0 {
+			used = 900
+		}
+		samples = append(samples, store.NodeSample{
+			Node: "spiky", TakenAt: at, CPUUsedMilli: used, CPUAllocMilli: 1000,
+		})
+	}
+	if err := db.SaveNodeSamples(ctx, samples); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := db.NodeStabilitySince(ctx, base.Add(-time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	by := map[string]store.NodeStability{}
+	for _, n := range got {
+		by[n.Node] = n
+	}
+
+	if s := by["steady"]; s.MedianPct != 30 || s.PeakPct != 30 {
+		t.Errorf("steady = median %d%% peak %d%%, want 30/30", s.MedianPct, s.PeakPct)
+	}
+	// The median is what the node usually does; the peak is what it does at
+	// its worst. Reporting only one of them hides the decision.
+	if s := by["spiky"]; s.MedianPct != 30 || s.PeakPct != 90 {
+		t.Errorf("spiky = median %d%% peak %d%%, want 30/90", s.MedianPct, s.PeakPct)
+	}
+	if s := by["steady"]; s.Samples != 20 {
+		t.Errorf("steady samples = %d, want 20", s.Samples)
+	}
+}
+
+// A node whose allocatable was never recorded produces no percentage rather
+// than an infinity.
+func TestStabilitySkipsNodesWithoutCapacity(t *testing.T) {
+	db := nodeStore(t)
+	ctx := context.Background()
+	at := time.Now().UTC()
+
+	if err := db.SaveNodeSamples(ctx, []store.NodeSample{
+		{Node: "sized", TakenAt: at, CPUUsedMilli: 100, CPUAllocMilli: 1000},
+		{Node: "unsized", TakenAt: at, CPUUsedMilli: 100, CPUAllocMilli: 0},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := db.NodeStabilitySince(ctx, at.Add(-time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, n := range got {
+		if n.Node == "unsized" {
+			t.Error("a node with no allocatable produced a percentage")
+		}
+	}
+	if len(got) != 1 {
+		t.Errorf("summarised %d nodes, want 1", len(got))
+	}
+}
+
+// One row per node per resync is millions a day on a large fleet. Retention
+// is the difference between a database and a disk-full alert.
+func TestPruneNodeSamplesDropsOnlyTheOld(t *testing.T) {
+	db := nodeStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	if err := db.SaveNodeSamples(ctx, []store.NodeSample{
+		{Node: "a", TakenAt: now.Add(-20 * 24 * time.Hour), CPUUsedMilli: 1, CPUAllocMilli: 1000},
+		{Node: "a", TakenAt: now.Add(-1 * time.Hour), CPUUsedMilli: 1, CPUAllocMilli: 1000},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	n, err := db.PruneNodeSamples(ctx, now.Add(-14*24*time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Errorf("pruned %d, want 1", n)
+	}
+	got, err := db.NodeStabilitySince(ctx, now.Add(-30*24*time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].Samples != 1 {
+		t.Errorf("after pruning: %+v, want one node with one sample", got)
+	}
+}

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -56,7 +56,7 @@ func Open(path string) (*Store, error) {
 // Close releases the database handle.
 func (s *Store) Close() error { return s.db.Close() }
 
-const schemaVersion = 10
+const schemaVersion = 11
 
 // Migrate creates or upgrades the schema.
 func (s *Store) Migrate(ctx context.Context) error {
@@ -124,6 +124,11 @@ func (s *Store) Migrate(ctx context.Context) error {
 			return fmt.Errorf("apply schema v10: %w", err)
 		}
 	}
+	if current < 11 {
+		if _, err := tx.ExecContext(ctx, schemaV11); err != nil {
+			return fmt.Errorf("apply schema v11: %w", err)
+		}
+	}
 
 	// PRAGMA does not accept a bound parameter.
 	if _, err := tx.ExecContext(ctx, fmt.Sprintf("PRAGMA user_version = %d", schemaVersion)); err != nil {
@@ -144,6 +149,24 @@ ALTER TABLE plans ADD COLUMN pack_ceiling REAL NOT NULL DEFAULT 0;
 // recorded by the executor, so the default is correct for all of them.
 const schemaV9 = `
 ALTER TABLE reclamations ADD COLUMN external INTEGER NOT NULL DEFAULT 0;
+`
+
+// Schema v11 — utilisation per node over time, so the UI can distinguish a
+// node that has been idle for a fortnight from one that spikes nightly.
+//
+// One row per node per resync. At a thousand nodes and a thirty-second cycle
+// that is 2.9M rows a day, which is why retention here is days rather than the
+// month the fleet-level timeline keeps, and why the read path aggregates in
+// SQL rather than shipping points.
+const schemaV11 = `
+CREATE TABLE IF NOT EXISTS node_samples (
+    node            TEXT NOT NULL,
+    taken_at        TEXT NOT NULL,
+    cpu_used_milli  INTEGER NOT NULL,
+    cpu_alloc_milli INTEGER NOT NULL,
+    PRIMARY KEY (node, taken_at)
+) WITHOUT ROWID;
+CREATE INDEX IF NOT EXISTS node_samples_taken_at ON node_samples (taken_at);
 `
 
 // Schema v10 — what the reclaimed node was, so the ledger can be priced.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -244,6 +244,37 @@ type Sample struct {
 	Reclaimable int `json:"reclaimable"`
 }
 
+// NodeSample is one node's utilisation at one moment.
+//
+// Separate from Sample because the questions differ: Sample answers "how big
+// was the fleet", NodeSample answers "is this node stably idle or does it
+// spike". A step rated Green on a Tuesday afternoon can be the worst possible
+// drain at 02:00, and until this existed the product had no way to say so.
+type NodeSample struct {
+	Node    string    `json:"node"`
+	TakenAt time.Time `json:"takenAt"`
+	// CPUUsedMilli is written only when a usage source is configured; rows
+	// without one are not written at all, so a zero here always means zero
+	// and never "unmeasured".
+	CPUUsedMilli  int64 `json:"cpuUsedMilli"`
+	CPUAllocMilli int64 `json:"cpuAllocMilli"`
+}
+
+// NodeStability is what a UI can say in a sentence, computed in SQL so a
+// thousand nodes times a fortnight of points never crosses the wire.
+type NodeStability struct {
+	Node string `json:"node"`
+	// Samples is how many points back the numbers below, so a claim made from
+	// three readings can be told apart from one made from three thousand.
+	Samples int `json:"samples"`
+	// Since is the oldest point considered; a node added yesterday cannot
+	// honestly be described as "stable for a fortnight".
+	Since time.Time `json:"since"`
+	// Percentages of allocatable, 0-100.
+	MedianPct int `json:"medianPct"`
+	PeakPct   int `json:"peakPct"`
+}
+
 // SampleStore persists the timeline. Implemented by the SQLite store;
 // optional the same way ReclamationStore is.
 type SampleStore interface {
@@ -252,4 +283,17 @@ type SampleStore interface {
 	Samples(ctx context.Context, since time.Time) ([]Sample, error)
 	// PruneSamples removes points older than before, returning how many.
 	PruneSamples(ctx context.Context, before time.Time) (int, error)
+
+	// SaveNodeSamples writes one point per node. Batched because it is one
+	// row per node per resync, and a thousand separate statements every
+	// thirty seconds is a different kind of product.
+	SaveNodeSamples(ctx context.Context, samples []NodeSample) error
+
+	// NodeStabilitySince summarises each node's utilisation over a window.
+	// Aggregated in the database on purpose: the browser needs a sentence,
+	// not a fortnight of points for every node in the fleet.
+	NodeStabilitySince(ctx context.Context, since time.Time) ([]NodeStability, error)
+
+	// PruneNodeSamples removes per-node points older than before.
+	PruneNodeSamples(ctx context.Context, before time.Time) (int, error)
 }

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -456,6 +456,9 @@ export const api = {
 
   run: (runId: string, signal?: AbortSignal) => get<RunDetail>(`/api/v1/runs/${runId}`, signal),
 
+  /** What each node usually does, not just what it is doing now. */
+  stability: (signal?: AbortSignal) => get<Stability>(`/api/v1/stability`, signal),
+
   /** Whether Red steps can run right now, and if not, when they could. */
   windows: (signal?: AbortSignal) => get<Windows>(`/api/v1/windows`, signal),
 
@@ -606,6 +609,22 @@ export interface Preflight {
   nodes: PreflightNode[];
   drainable: number;
   total: number;
+}
+
+export interface NodeStability {
+  node: string;
+  /** How many readings back the numbers, so a claim from three points can be
+   *  told apart from one made from three thousand. */
+  samples: number;
+  since: string;
+  medianPct: number;
+  peakPct: number;
+}
+
+export interface Stability {
+  available: boolean;
+  windowDays?: number;
+  nodes?: NodeStability[];
 }
 
 export interface WindowState {

--- a/ui/src/components/cluster/ClusterPage.tsx
+++ b/ui/src/components/cluster/ClusterPage.tsx
@@ -9,8 +9,8 @@
  * vice versa.
  */
 
-import { useMemo, useState } from "react";
-import { GraphPayload, Impact, PlanStep, WhatIf, api, formatCPU } from "../../api";
+import { useEffect, useMemo, useState } from "react";
+import { GraphPayload, Impact, NodeStability, PlanStep, WhatIf, api, formatCPU } from "../../api";
 import { FieldView, VIEW_LABELS } from "../../view";
 import { VERDICT } from "../Impact";
 import type { ObservedNode } from "../../useObserved";
@@ -177,6 +177,36 @@ export default function ClusterPage({
   );
 }
 
+/**
+ * What a node usually does, in one sentence.
+ *
+ * Every other surface here describes a single instant and then asks for a
+ * decision about a system that varies. A node at 30% on a Tuesday afternoon
+ * and a node that peaks at 92% every night look identical on this page, and
+ * draining them are very different decisions.
+ *
+ * Silent when there is nothing to say. A handful of readings cannot support
+ * "usually", and inventing a trend from six points would be the confident
+ * wrongness this product exists to avoid.
+ */
+function stabilityLine(s?: NodeStability) {
+  if (!s || s.samples < 30) return null;
+
+  const days = Math.max(1, Math.round((Date.now() - Date.parse(s.since)) / 86_400_000));
+  const span = days === 1 ? "the last day" : `${days} days`;
+  // A peak well above the median is the whole point: it means the quiet
+  // number on screen is not the number that matters.
+  const spiky = s.peakPct >= s.medianPct + 25;
+
+  return (
+    <p className={"nodetrend" + (spiky ? " is-spiky" : "")}>
+      {spiky
+        ? `Usually ${s.medianPct}%, but peaks at ${s.peakPct}% over ${span} — quiet now is not quiet always.`
+        : `Steady around ${s.medianPct}% over ${span}, peaking at ${s.peakPct}%.`}
+    </p>
+  );
+}
+
 /* ------------------------------------------------------------------ rack */
 
 function intentOf(impact?: Impact): { cls: string; label: string } {
@@ -229,6 +259,25 @@ function RackLens({
   // "what is running here" is answerable about every node, always.
   const [pickedNode, setPickedNode] = useState<string | null>(null);
   const [whatif, setWhatif] = useState<{ node: string; result?: WhatIf; error?: string } | null>(null);
+
+  // What each node usually does. Fetched once for the lens rather than per
+  // selection: it changes on the sampler's cadence, not on a click.
+  const [stability, setStability] = useState<Map<string, NodeStability>>(new Map());
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .stability()
+      .then((d) => {
+        if (cancelled || !d.available) return;
+        setStability(new Map((d.nodes ?? []).map((n) => [n.node, n])));
+      })
+      .catch(() => {
+        // History is context. Its absence must never blank the lens.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
   const picked = nodes.find((n) => n.name === pickedNode) ?? focused;
   const pickedPods = picked ? (podsByNode.get(`node:${picked.name}`) ?? []) : [];
   const selectNode = (n: NodeModel) => {
@@ -346,6 +395,7 @@ function RackLens({
                   {picked.drainStep == null ? "Stays in this plan" : "On this node"}
                 </span>
                 <span className="clusterdetail-name mono">{picked.name}</span>
+                {stabilityLine(stability.get(picked.name))}
                 <p className="clusterdetail-why">
                   {formatCPU(picked.req)} of {formatCPU(picked.alloc)} requested by{" "}
                   {picked.pods} pod{picked.pods === 1 ? "" : "s"}

--- a/ui/src/styles/cluster.css
+++ b/ui/src/styles/cluster.css
@@ -668,3 +668,17 @@
   color: var(--text-5);
   text-wrap: pretty;
 }
+
+/* What a node usually does. Quieter than the headline it follows, louder
+   when the peak says the quiet number is misleading. */
+.nodetrend {
+  margin: 0;
+  font-size: var(--text-xs);
+  line-height: 1.5;
+  color: var(--text-3);
+  text-wrap: pretty;
+}
+
+.nodetrend.is-spiky {
+  color: var(--caution-text);
+}


### PR DESCRIPTION
Closes #145.

Every surface in this product describes a single instant and then asks for a decision about a system that varies. **A node sitting at 30% on a Tuesday afternoon and a node that peaks at 92% every night look identical on the Cluster page**, and draining them are very different decisions.

The history kept was fleet-level only — `store.Sample` answers "how big was the cluster", which cannot answer "is this node stably idle".

## Storage sized for what it actually produces

Schema v11 keeps utilisation per node. One row per node per resync means a thousand nodes on a thirty-second cycle is **millions of rows a day**, so:

- the write is **batched in one transaction** — a thousand separate statements every thirty seconds is a different kind of product
- retention is a **fortnight**, not the month the fleet timeline keeps: long enough to say "usually", short enough to stay a database
- the read **aggregates in SQL** (median and peak per node, via window functions) because the browser needs a sentence, not a fortnight of points per node

## Three honesty guards

- **Rows written only when usage is measured**, and only for nodes that reported it. A requests-only snapshot would otherwise build a fortnight of evidence that every node is idle.
- **Nodes with no recorded allocatable are skipped**, not divided by — a missing capacity produces no percentage rather than an infinity.
- **The sentence stays silent below thirty readings.** A handful of points cannot support "usually", and inventing a trend from six would be the confident wrongness this product exists to avoid.

## What it says

> Steady around 30% over 12 days, peaking at 34%.

> Usually 30%, but peaks at 92% over 12 days — quiet now is not quiet always.

The second form appears when the peak sits well above the median, because that's the case where the quiet number on screen is not the number that matters.

## Verification

```
--- PASS: TestStabilitySeparatesSteadyFromSpiky      (steady 30/30, spiky 30/90)
--- PASS: TestStabilitySkipsNodesWithoutCapacity
--- PASS: TestPruneNodeSamplesDropsOnlyTheOld
```

The first is the point of the feature: two nodes with the same median, told apart by their peak.

A first attempt used a correlated subquery for the median and failed against SQLite (`no such column: pct.node`) — caught by the tests before it went anywhere.

`gofmt`, `go test ./...`, `make lint`, UI typecheck/build/density all green; CSS tokens checked against `theme.css`.