### PR TITLE
Say what a drain is likely to cost, before it is approved

### DIFF
--- a/cmd/executor/main.go
+++ b/cmd/executor/main.go
@@ -116,6 +116,7 @@ func run(ctx context.Context, log *slog.Logger) error {
 		Readiness:     executor.Readiness(env("EXECUTOR_READINESS", string(executor.ReadinessReady))),
 		Metrics:       metrics,
 		Reclamations:  db,
+		Recoveries:    db,
 	})
 
 	health := &httpserver.Health{}

--- a/internal/api/rest/rest.go
+++ b/internal/api/rest/rest.go
@@ -341,12 +341,46 @@ func (s *Server) handleStep(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	writeJSON(w, http.StatusOK, map[string]any{
+	// What past drains say these workloads cost. "3 pods move" is a count;
+	// how long the service is degraded is the consequence, and the executor
+	// has been measuring it on every drain. Absent for a workload never
+	// observed — never observed and instantaneous are different claims.
+	body := map[string]any{
 		"planId":      rec.Plan.ID,
 		"step":        step,
 		"constraints": podConstraints,
 		"singletons":  singletons,
-	})
+	}
+	if rs, ok := s.store.(store.RecoveryStore); ok && rec.Snapshot != nil {
+		if known, err := rs.RecoveryFor(r.Context(), workloadsOf(step, rec.Snapshot)); err == nil && len(known) > 0 {
+			body["recovery"] = known
+		}
+	}
+	writeJSON(w, http.StatusOK, body)
+}
+
+// workloadsOf names the workloads a step's moves belong to, deduplicated.
+// Keyed the same way recommend keys them, so the two agree about what a
+// workload is.
+func workloadsOf(step *model.PlanStep, snap *model.ClusterSnapshot) []string {
+	byKey := make(map[string]*model.Pod, len(snap.Pods))
+	for i := range snap.Pods {
+		byKey[snap.Pods[i].Key()] = &snap.Pods[i]
+	}
+	seen := map[string]bool{}
+	out := []string{}
+	for _, m := range step.Moves {
+		p, ok := byKey[m.Namespace+"/"+m.Pod]
+		if !ok || p.Owner == nil {
+			continue
+		}
+		w := p.Namespace + "/" + p.Owner.Kind + "/" + p.Owner.Name
+		if !seen[w] {
+			seen[w] = true
+			out = append(out, w)
+		}
+	}
+	return out
 }
 
 func (s *Server) handleGraph(w http.ResponseWriter, r *http.Request) {

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -52,6 +52,11 @@ type Options struct {
 	// whether anything removed them. Nil disables tracking.
 	Reclamations store.ReclamationStore
 
+	// Recoveries remembers how long workloads took to come back, so a step
+	// detail can say what a drain is likely to cost before it is approved.
+	// Optional: nil measures and reports without remembering.
+	Recoveries store.RecoveryStore
+
 	// StepTimeout bounds a single step end to end. Exceeding it aborts.
 	StepTimeout time.Duration
 
@@ -135,6 +140,11 @@ type Executor struct {
 	// reclamations is optional: nil disables tracking rather than failing, so
 	// a caller that has not wired a store still drains.
 	reclamations store.ReclamationStore
+
+	// recoveries is optional in the same way. The executor measures how long
+	// workloads take to come back on every drain; without a store it reports
+	// the number once and forgets it.
+	recoveries store.RecoveryStore
 }
 
 // New builds an executor.
@@ -153,6 +163,7 @@ func New(cluster Cluster, runs store.ExecutionStore, plans store.Store, log *slo
 		opts:         opts,
 		metrics:      opts.Metrics,
 		reclamations: opts.Reclamations,
+		recoveries:   opts.Recoveries,
 	}
 }
 
@@ -530,6 +541,7 @@ func (e *Executor) verifyRecovered(ctx context.Context, run store.Run, step mode
 				Message: fmt.Sprintf("all %d affected workload(s) recovered elsewhere%s",
 					len(affected), recoverySummary(recoveredAt)),
 			})
+			e.rememberRecovery(ctx, recoveredAt)
 			return nil
 		}
 		if time.Now().After(deadline) {
@@ -538,6 +550,26 @@ func (e *Executor) verifyRecovered(ctx context.Context, run store.Run, step mode
 		}
 		if err := sleep(ctx, e.opts.PollInterval); err != nil {
 			return err
+		}
+	}
+}
+
+// rememberRecovery persists what the verify loop just measured, so the next
+// plan can say what a drain is likely to cost before anyone approves it.
+//
+// Detached and best-effort: this is a note for later, and losing it must
+// never fail a drain that already succeeded.
+func (e *Executor) rememberRecovery(ctx context.Context, took map[string]time.Duration) {
+	if e.recoveries == nil || len(took) == 0 {
+		return
+	}
+	writeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+	defer cancel()
+
+	now := time.Now().UTC()
+	for owner, d := range took {
+		if err := e.recoveries.RecordRecovery(writeCtx, owner, now, d); err != nil {
+			e.log.Warn("could not record recovery time", "workload", owner, "error", err)
 		}
 	}
 }

--- a/internal/store/sqlite/recoveries.go
+++ b/internal/store/sqlite/recoveries.go
@@ -1,0 +1,92 @@
+package sqlite
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/atedgimo/k8s-dencer/internal/store"
+)
+
+// How long workloads take to come back. The executor watches this on every
+// drain; this is where it stops being forgotten the moment the event scrolls.
+
+// RecordRecovery notes one workload's time to Ready after an eviction.
+func (s *Store) RecordRecovery(ctx context.Context, workload string, at time.Time, took time.Duration) error {
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO recoveries (workload, observed_at, took_seconds)
+		VALUES (?, ?, ?)
+		ON CONFLICT (workload, observed_at) DO NOTHING`,
+		workload, at.UTC().Format(time.RFC3339Nano), int64(took.Seconds()))
+	if err != nil {
+		return fmt.Errorf("record recovery for %s: %w", workload, err)
+	}
+	return nil
+}
+
+// RecoveryFor returns what past drains say about these workloads.
+//
+// Workloads with no history are absent from the map rather than present with
+// zeroes: never observed and instantaneous are different claims, and only one
+// of them should ever reach a screen.
+func (s *Store) RecoveryFor(ctx context.Context, workloads []string) (map[string]store.Recovery, error) {
+	out := map[string]store.Recovery{}
+	if len(workloads) == 0 {
+		return out, nil
+	}
+
+	holders := strings.TrimSuffix(strings.Repeat("?,", len(workloads)), ",")
+	args := make([]any, 0, len(workloads))
+	for _, w := range workloads {
+		args = append(args, w)
+	}
+
+	// Median via window function, the same shape as node stability: the
+	// typical case is what to expect and the worst is what to plan for, and
+	// a mean would let one pathological restart speak for both.
+	rows, err := s.db.QueryContext(ctx, `
+		WITH ranked AS (
+			SELECT workload, took_seconds,
+			       ROW_NUMBER()      OVER (PARTITION BY workload ORDER BY took_seconds) AS rn,
+			       COUNT(*)          OVER (PARTITION BY workload)                       AS n,
+			       MAX(took_seconds) OVER (PARTITION BY workload)                       AS worst,
+			       MAX(observed_at)  OVER (PARTITION BY workload)                       AS last_seen
+			FROM recoveries
+			WHERE workload IN (`+holders+`)
+		)
+		SELECT workload, n, took_seconds AS typical, worst, last_seen
+		FROM ranked
+		WHERE rn = (n / 2) + 1`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("read recoveries: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var r store.Recovery
+		var lastSeen string
+		if err := rows.Scan(&r.Workload, &r.Observations, &r.TypicalSeconds, &r.WorstSeconds, &lastSeen); err != nil {
+			return nil, err
+		}
+		r.LastSeen = parseTime(lastSeen)
+		out[r.Workload] = r
+	}
+	return out, rows.Err()
+}
+
+// PruneRecoveries removes observations older than before.
+//
+// A year, by default caller. Recovery time is a property of the workload's
+// image and probes, which change on a release cadence rather than a daily
+// one, so old observations stay useful far longer than a utilisation point.
+func (s *Store) PruneRecoveries(ctx context.Context, before time.Time) (int, error) {
+	res, err := s.db.ExecContext(ctx,
+		`DELETE FROM recoveries WHERE observed_at < ?`,
+		before.UTC().Format(time.RFC3339Nano))
+	if err != nil {
+		return 0, fmt.Errorf("prune recoveries: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	return int(n), nil
+}

--- a/internal/store/sqlite/recoveries_test.go
+++ b/internal/store/sqlite/recoveries_test.go
@@ -1,0 +1,89 @@
+package sqlite_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/atedgimo/k8s-dencer/internal/store/sqlite"
+)
+
+func recStore(t *testing.T) *sqlite.Store {
+	t.Helper()
+	db, err := sqlite.Open(filepath.Join(t.TempDir(), "r.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := db.Migrate(context.Background()); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+// The median is what to expect; the worst is what to plan for. A mean would
+// let one pathological restart speak for both.
+func TestRecoveryReportsTypicalAndWorst(t *testing.T) {
+	db := recStore(t)
+	ctx := context.Background()
+	base := time.Now().UTC().Add(-time.Hour)
+
+	for i, d := range []time.Duration{5 * time.Second, 7 * time.Second, 9 * time.Second, 4 * time.Minute} {
+		if err := db.RecordRecovery(ctx, "shop/Deployment/web", base.Add(time.Duration(i)*time.Minute), d); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got, err := db.RecoveryFor(ctx, []string{"shop/Deployment/web"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	r, ok := got["shop/Deployment/web"]
+	if !ok {
+		t.Fatal("no recovery recorded for the workload")
+	}
+	if r.Observations != 4 {
+		t.Errorf("observations = %d, want 4", r.Observations)
+	}
+	if r.WorstSeconds != 240 {
+		t.Errorf("worst = %ds, want 240 — the outlier is exactly what to plan for", r.WorstSeconds)
+	}
+	// Four observations: the upper median is the third, 9s. A mean would be
+	// 63s, which describes none of the four drains that happened.
+	if r.TypicalSeconds != 9 {
+		t.Errorf("typical = %ds, want 9", r.TypicalSeconds)
+	}
+}
+
+// Never observed and instantaneous are different claims, and only one of
+// them should ever reach a screen.
+func TestRecoveryOmitsWorkloadsNeverSeen(t *testing.T) {
+	db := recStore(t)
+	ctx := context.Background()
+
+	if err := db.RecordRecovery(ctx, "shop/Deployment/web", time.Now().UTC(), 5*time.Second); err != nil {
+		t.Fatal(err)
+	}
+	got, err := db.RecoveryFor(ctx, []string{"shop/Deployment/web", "shop/Deployment/never-drained"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, present := got["shop/Deployment/never-drained"]; present {
+		t.Error("a workload never drained was reported as having a recovery time")
+	}
+	if len(got) != 1 {
+		t.Errorf("returned %d workloads, want 1", len(got))
+	}
+}
+
+func TestRecoveryHandlesNoWorkloads(t *testing.T) {
+	db := recStore(t)
+	got, err := db.RecoveryFor(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Errorf("returned %d, want 0", len(got))
+	}
+}

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -56,7 +56,7 @@ func Open(path string) (*Store, error) {
 // Close releases the database handle.
 func (s *Store) Close() error { return s.db.Close() }
 
-const schemaVersion = 11
+const schemaVersion = 12
 
 // Migrate creates or upgrades the schema.
 func (s *Store) Migrate(ctx context.Context) error {
@@ -129,6 +129,11 @@ func (s *Store) Migrate(ctx context.Context) error {
 			return fmt.Errorf("apply schema v11: %w", err)
 		}
 	}
+	if current < 12 {
+		if _, err := tx.ExecContext(ctx, schemaV12); err != nil {
+			return fmt.Errorf("apply schema v12: %w", err)
+		}
+	}
 
 	// PRAGMA does not accept a bound parameter.
 	if _, err := tx.ExecContext(ctx, fmt.Sprintf("PRAGMA user_version = %d", schemaVersion)); err != nil {
@@ -149,6 +154,20 @@ ALTER TABLE plans ADD COLUMN pack_ceiling REAL NOT NULL DEFAULT 0;
 // recorded by the executor, so the default is correct for all of them.
 const schemaV9 = `
 ALTER TABLE reclamations ADD COLUMN external INTEGER NOT NULL DEFAULT 0;
+`
+
+// Schema v12 — how long each workload took to come back after an eviction.
+//
+// Far smaller than node_samples: one row per workload per drain, not per
+// resync. A busy cluster produces a handful a day.
+const schemaV12 = `
+CREATE TABLE IF NOT EXISTS recoveries (
+    workload     TEXT NOT NULL,
+    observed_at  TEXT NOT NULL,
+    took_seconds INTEGER NOT NULL,
+    PRIMARY KEY (workload, observed_at)
+) WITHOUT ROWID;
+CREATE INDEX IF NOT EXISTS recoveries_observed_at ON recoveries (observed_at);
 `
 
 // Schema v11 — utilisation per node over time, so the UI can distinguish a

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -275,6 +275,37 @@ type NodeStability struct {
 	PeakPct   int `json:"peakPct"`
 }
 
+// RecoveryStore remembers how long workloads took to come back.
+//
+// The executor observes this on every drain — it waits for Ready before
+// proceeding — and until now reported it once in an event and forgot it. The
+// question a step detail wants to answer is the next one: given these
+// workloads, how long is this likely to hurt.
+type RecoveryStore interface {
+	// RecordRecovery notes one workload's time to Ready after an eviction.
+	RecordRecovery(ctx context.Context, workload string, at time.Time, took time.Duration) error
+
+	// RecoveryFor returns what is known about these workloads. Absent from the
+	// map means never observed, which is different from fast.
+	RecoveryFor(ctx context.Context, workloads []string) (map[string]Recovery, error)
+
+	// PruneRecoveries removes observations older than before.
+	PruneRecoveries(ctx context.Context, before time.Time) (int, error)
+}
+
+// Recovery is what past drains say about one workload.
+type Recovery struct {
+	Workload string `json:"workload"`
+	// Observations is how many drains this rests on. One is an anecdote and
+	// the UI says so rather than presenting it as a rate.
+	Observations int `json:"observations"`
+	// Typical is the median; Worst is the slowest seen. Both matter: the
+	// median is what to expect, the worst is what to plan for.
+	TypicalSeconds int       `json:"typicalSeconds"`
+	WorstSeconds   int       `json:"worstSeconds"`
+	LastSeen       time.Time `json:"lastSeen"`
+}
+
 // SampleStore persists the timeline. Implemented by the SQLite store;
 // optional the same way ReclamationStore is.
 type SampleStore interface {

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -148,6 +148,18 @@ export interface StepDetail {
    * review pane flags exactly these.
    */
   singletons?: string[];
+  /**
+   * What past drains say these workloads cost, keyed by namespace/Kind/name.
+   * A workload never drained is absent rather than zero — never observed and
+   * instantaneous are different claims.
+   */
+  recovery?: Record<string, {
+    workload: string;
+    observations: number;
+    typicalSeconds: number;
+    worstSeconds: number;
+    lastSeen: string;
+  }>;
 }
 
 /** One point on the planner's timeline. Mirrors store.Sample. */

--- a/ui/src/components/review/StepDetail.tsx
+++ b/ui/src/components/review/StepDetail.tsx
@@ -33,6 +33,14 @@ interface Check {
   detail?: string;
 }
 
+/** Seconds as something a person reads at a glance. */
+function fmtSeconds(s: number): string {
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  const r = s % 60;
+  return r === 0 ? `${m}m` : `${m}m ${r}s`;
+}
+
 export default function StepDetail({ planId, step, pool, checked, stale, onAdd, onSkip }: Props) {
   const [detail, setDetail] = useState<StepDetailData | null>(null);
 
@@ -180,6 +188,16 @@ function buildChecks(detail: StepDetailData): Check[] {
   const singles = detail.singletons?.length ?? 0;
   const placed = detail.step.moves.filter((m) => m.toNode).length;
 
+  // What this step is likely to cost in time, from drains that actually
+  // happened. The executor has always measured it; until now it reported the
+  // number once and forgot it, so the screen could only say how many pods
+  // move and never how long the service is degraded.
+  const recovery = Object.values(detail.recovery ?? {});
+  const slowest = recovery.reduce<(typeof recovery)[number] | undefined>(
+    (worst, r) => (!worst || r.worstSeconds > worst.worstSeconds ? r : worst),
+    undefined,
+  );
+
   const checks: Check[] = [
     category("PodDisruptionBudgets", ["PodDisruptionBudget"], "none applies"),
     category("Topology spread", ["TopologySpread"], "unaffected"),
@@ -189,6 +207,22 @@ function buildChecks(detail: StepDetailData): Check[] {
       "satisfied",
     ),
     category("Taints & tolerations", ["Taint"], "satisfied"),
+    ...(slowest
+      ? [
+          {
+            label: "Recovery, last time",
+            // The worst case is the one worth surfacing: a two-minute
+            // recovery on a single-replica workload is a two-minute outage,
+            // and the median would hide it behind the workloads that are fine.
+            value: `${fmtSeconds(slowest.worstSeconds)} worst`,
+            rating: (slowest.worstSeconds >= 60 ? "Yellow" : "Green") as Check["rating"],
+            detail:
+              slowest.observations === 1
+                ? `Seen once: ${slowest.workload} took ${fmtSeconds(slowest.worstSeconds)} to become Ready. One drain is an anecdote, not a rate.`
+                : `Across ${slowest.observations} drains, ${slowest.workload} typically took ${fmtSeconds(slowest.typicalSeconds)} and at worst ${fmtSeconds(slowest.worstSeconds)} to become Ready.`,
+          },
+        ]
+      : []),
     {
       label: "Single-replica workloads",
       value: singles > 0 ? `${singles} found` : "none",


### PR DESCRIPTION
Closes #146. The predictive half; #161 shipped the measuring half.

The executor times how long each workload takes to become Ready and names the slowest in the Verify event — then forgot the number the moment the event scrolled.

## Storage

Schema v12 keeps them. One row per workload per drain — a handful a day on a busy cluster, nothing like the per-node timeline from #164 — and retained far longer, because recovery time is a property of a workload's image and probes, which change on a release cadence rather than a daily one.

## Where it appears

A Safety Guard check on the step detail, beside the constraint ones, because that's where approval happens:

> **Recovery, last time** — `2m 10s worst`
> Across 6 drains, shop/Deployment/payments typically took 12s and at worst 2m 10s to become Ready.

**Worst rather than median**, because a two-minute recovery on a single-replica workload is a two-minute outage and the median would hide it behind the workloads that are fine. Yellow above a minute — that's where "3 pods move" stops being an adequate description of what is about to happen.

## Median rather than mean, throughout

With observations of 5s, 7s, 9s and 4m the mean is 63s, which describes **none** of the four drains that actually happened. Asserted in a test.

## Two honesty guards

- A workload never drained is **absent** from the response, not present with zeroes. Never observed and instantaneous are different claims.
- **One observation says so**: *"Seen once … One drain is an anecdote, not a rate"* rather than quoting it as a figure.

## Verification

```
--- PASS: TestRecoveryReportsTypicalAndWorst   (typical 9s, worst 240s from 5/7/9/240)
--- PASS: TestRecoveryOmitsWorkloadsNeverSeen
--- PASS: TestRecoveryHandlesNoWorkloads
```

`gofmt`, `go test ./...`, `make lint`, UI typecheck/build/density all green.

**This closes the last issue from the 2026-08-07 GKE run.**