### PR TITLE
Stop the top bar saying "Fresh" about a cluster nobody has looked at

### DIFF
--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -381,18 +381,29 @@ func (s *Store) Save(ctx context.Context, rec store.Record) (bool, error) {
 			return false, fmt.Errorf("encode snapshot: %w", encErr)
 		}
 		touched, err = s.db.ExecContext(ctx,
-			`UPDATE plans SET stored_at = ?, pack_ceiling = ?, snapshot = ?
+			`UPDATE plans SET stored_at = ?, pack_ceiling = ?, nodes_before = ?, nodes_after = ?, snapshot = ?
 			 WHERE id = ? AND id = (SELECT id FROM plans ORDER BY stored_at DESC, rowid DESC LIMIT 1)`,
-			storedAt.UTC().Format(time.RFC3339Nano), rec.Plan.PackCeiling, snapshotJSON, rec.Plan.ID)
+			storedAt.UTC().Format(time.RFC3339Nano), rec.Plan.PackCeiling,
+			rec.Plan.NodesBefore, rec.Plan.NodesAfter, snapshotJSON, rec.Plan.ID)
 	} else {
 		// pack_ceiling rides the touch for the same reason stored_at does:
 		// an upgraded planner re-verifying an identical plan under a new
 		// ceiling must not leave the stored row describing the old policy —
 		// found live, the Wells lens drawing no ceiling after the upgrade.
+		//
+		// nodes_before and nodes_after ride it for a sharper version of the
+		// same problem. planID hashes the steps and nothing else, which is
+		// right — a plan is its steps — but it means an empty plan keeps its
+		// identity while the fleet changes size underneath it. On a real GKE
+		// cluster the CLI reported "6 nodes now, 6 after" for twelve minutes
+		// after two were removed, while the planner logged nodesBefore:4 on
+		// every cycle. Fresh by timestamp and stale by content is the worst
+		// of the available failures: the reader has no reason to doubt it.
 		touched, err = s.db.ExecContext(ctx,
-			`UPDATE plans SET stored_at = ?, pack_ceiling = ?
+			`UPDATE plans SET stored_at = ?, pack_ceiling = ?, nodes_before = ?, nodes_after = ?
 			 WHERE id = ? AND id = (SELECT id FROM plans ORDER BY stored_at DESC, rowid DESC LIMIT 1)`,
-			storedAt.UTC().Format(time.RFC3339Nano), rec.Plan.PackCeiling, rec.Plan.ID)
+			storedAt.UTC().Format(time.RFC3339Nano), rec.Plan.PackCeiling,
+			rec.Plan.NodesBefore, rec.Plan.NodesAfter, rec.Plan.ID)
 	}
 	if err != nil {
 		return false, fmt.Errorf("touch plan: %w", err)

--- a/internal/store/sqlite/staleness_test.go
+++ b/internal/store/sqlite/staleness_test.go
@@ -1,0 +1,71 @@
+package sqlite_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/atedgimo/k8s-dencer/internal/model"
+	"github.com/atedgimo/k8s-dencer/internal/store"
+	"github.com/atedgimo/k8s-dencer/internal/store/sqlite"
+)
+
+func planStore(t *testing.T) *sqlite.Store {
+	t.Helper()
+	db, err := sqlite.Open(filepath.Join(t.TempDir(), "p.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := db.Migrate(context.Background()); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+// planID hashes the steps and nothing else, which is right — a plan is its
+// steps. But it means an empty plan keeps its identity while the fleet
+// changes size underneath it, and the dedup touch used to leave the stored
+// counts describing a cluster that no longer existed.
+//
+// On a real GKE cluster the CLI reported "6 nodes now, 6 after" for twelve
+// minutes after two nodes were removed, while the planner logged
+// nodesBefore:4 every cycle. Fresh by timestamp, stale by content.
+func TestDedupTouchRefreshesTheFleetSize(t *testing.T) {
+	db := planStore(t)
+	ctx := context.Background()
+
+	// The same empty plan, seen first on six nodes and then on four.
+	empty := func(before, after int) store.Record {
+		return store.Record{
+			Plan: &model.Plan{
+				ID: "same-id", Steps: []model.PlanStep{},
+				NodesBefore: before, NodesAfter: after,
+			},
+			Snapshot: &model.ClusterSnapshot{TakenAt: time.Now().UTC()},
+		}
+	}
+
+	if changed, err := db.Save(ctx, empty(6, 6)); err != nil || !changed {
+		t.Fatalf("first save: changed=%v err=%v", changed, err)
+	}
+	// The second save dedups — same steps, same id — which is the path that
+	// used to leave the counts alone.
+	changed, err := db.Save(ctx, empty(4, 4))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed {
+		t.Fatal("an identical plan was stored as new; the dedup path is not being exercised")
+	}
+
+	rec, err := db.Latest(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rec.Plan.NodesBefore != 4 || rec.Plan.NodesAfter != 4 {
+		t.Errorf("stored plan says %d nodes now, %d after — want 4/4; the fleet shrank and the row did not",
+			rec.Plan.NodesBefore, rec.Plan.NodesAfter)
+	}
+}

--- a/ui/src/components/TopBar.tsx
+++ b/ui/src/components/TopBar.tsx
@@ -144,6 +144,14 @@ export default function TopBar({ planId, strategy, confirmedAt, stale, onRecompu
  * stopped clock is the thing it is trying to replace. Re-renders on a
  * 10-second tick; the confirmation itself is polled by useVersion.
  */
+/**
+ * Three resyncs at the chart's default of 30s. Hard-coded rather than plumbed
+ * from config because the number only has to be roughly right: the claim is
+ * "nobody has looked at your cluster in minutes", and being wrong by one
+ * cycle either way does not change whether that is worth saying.
+ */
+const STALE_AFTER_MS = 90_000;
+
 function Freshness({ confirmedAt, stale }: { confirmedAt?: string | null; stale?: boolean }) {
   const [, setTick] = useState(0);
   useEffect(() => {
@@ -162,6 +170,24 @@ function Freshness({ confirmedAt, stale }: { confirmedAt?: string | null; stale?
   if (!confirmedAt) return null;
 
   const age = Math.max(0, Date.now() - Date.parse(confirmedAt));
+
+  // The planner confirms the plan against the cluster on every resync. Past
+  // three of them it has stopped, and the screen is describing a cluster
+  // nobody has looked at since — which is the one state where "Fresh" is a
+  // lie rather than a reassurance.
+  //
+  // Three rather than one: a single missed cycle is a slow snapshot, not a
+  // dead planner, and crying wolf on every hiccup would train people to
+  // ignore the dot that matters.
+  if (age > STALE_AFTER_MS) {
+    return (
+      <span className="topbar-fresh is-unconfirmed" role="status">
+        <span className="topbar-dot topbar-dot-unconfirmed" aria-hidden="true" />
+        The planner has not confirmed this for {relative(age)} — it may be down
+      </span>
+    );
+  }
+
   return (
     <span className="topbar-fresh">
       <span className="topbar-dot" aria-hidden="true" />

--- a/ui/src/styles/chrome.css
+++ b/ui/src/styles/chrome.css
@@ -47,3 +47,14 @@
 .topbar-window.is-open {
   color: var(--safe);
 }
+
+/* The planner has stopped confirming. Amber rather than red: the plan on
+   screen was true when it was made, and may still be — what is unknown is
+   whether anything has changed since. */
+.topbar-fresh.is-unconfirmed {
+  color: var(--caution-text);
+}
+
+.topbar-dot-unconfirmed {
+  background: var(--caution);
+}


### PR DESCRIPTION
Closes #120. Two halves of the same lie; the GKE run showed both.

## The stored plan went stale without changing its mind

`planID` hashes the steps and nothing else, which is **right** — a plan is its steps. But it means an empty plan keeps its identity while the fleet changes size underneath it, and the dedup touch refreshed `stored_at` and `pack_ceiling` while leaving the node counts alone.

The CLI reported **"6 nodes now, 6 after" for twelve minutes** after two nodes were removed, while the planner logged `nodesBefore:4` on every cycle. Fresh by timestamp and stale by content is the worst available failure: the reader has no reason to doubt it.

The counts now ride the touch, for exactly the reason the `pack_ceiling` comment already gives beside them.

## The top bar had one tone for two states

It said `Fresh · confirmed 19m ago` in the same colour whether the planner was working or dead. Past three resyncs it now says, in amber:

> The planner has not confirmed this for 19m — it may be down

Naming what is actually unknown. Not that the plan is wrong — it was true when made — but that nobody has checked the cluster since. Amber rather than red for the same reason.

**Three cycles rather than one.** A single missed resync is a slow snapshot, not a dead planner, and crying wolf on every hiccup teaches people to ignore the dot that matters.

## Verification

The store test reproduces the exact sequence — same empty plan seen at six nodes then four — and was **watched failing before the fix existed**:

```
--- FAIL: TestDedupTouchRefreshesTheFleetSize
    stored plan says 6 nodes now, 6 after — want 4/4;
    the fleet shrank and the row did not
```

and passing after. It also asserts the dedup path is genuinely exercised, so it cannot pass by accidentally storing a new row.

`gofmt`, `go test ./...`, `make lint`, UI typecheck/build/density all green.