### PR TITLE
Let the co-scheduled pair win the scheduling fights it cannot lose

### DIFF
--- a/charts/k8s-dencer/templates/planner/deployment.yaml
+++ b/charts/k8s-dencer/templates/planner/deployment.yaml
@@ -35,8 +35,13 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.planner.priorityClassName }}
-      priorityClassName: {{ . }}
+      {{- if .Values.planner.priorityClassName }}
+      priorityClassName: {{ .Values.planner.priorityClassName }}
+      {{- else if and .Values.priorityClass.create .Values.persistence.enabled (eq .Values.database.type "sqlite") }}
+      # Co-scheduled with the other half of the SQLite volume, so it
+      # cannot be placed elsewhere under pressure. An explicit
+      # priorityClassName above always wins.
+      priorityClassName: {{ include "k8s-dencer.fullname" . }}
       {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}

--- a/charts/k8s-dencer/templates/priorityclass.yaml
+++ b/charts/k8s-dencer/templates/priorityclass.yaml
@@ -1,0 +1,36 @@
+{{- /*
+A PriorityClass for the components that must be co-scheduled.
+
+SQLite is single-writer on a ReadWriteOnce claim, so the planner carries a
+required pod affinity to the ui-backend's node. That makes the planner
+schedulable on exactly one node, and on a packed cluster it loses to whatever
+got there first — observed twice in one day: a fresh install where the planner
+sat Pending until the helm wait died, and a rolling upgrade that left it
+unschedulable mid-session.
+
+Priority is the interim answer, not the real one. The real one is
+database.type=postgres, which removes the co-location entirely; this exists so
+that installs which have not made that move stop losing scheduling fights they
+cannot afford to lose.
+
+Created only when the constraint actually applies. An install on Postgres has
+no co-location, so it gets no cluster-scoped object it did not ask for.
+*/ -}}
+{{- $coLocated := and .Values.persistence.enabled (eq .Values.database.type "sqlite") -}}
+{{- if and .Values.priorityClass.create $coLocated }}
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: {{ include "k8s-dencer.fullname" . }}
+  labels:
+    {{- include "k8s-dencer.labels" . | nindent 4 }}
+value: {{ .Values.priorityClass.value }}
+# Never the default for the cluster: this is about one product's own pods, and
+# quietly raising the priority of every unannotated workload in the cluster
+# would be an extraordinary thing for a consolidation tool to do.
+globalDefault: false
+preemptionPolicy: {{ .Values.priorityClass.preemptionPolicy }}
+description: >-
+  k8s-dencer's planner and ui-backend share a ReadWriteOnce volume and must be
+  co-scheduled, so they cannot simply be placed elsewhere under pressure.
+{{- end }}

--- a/charts/k8s-dencer/templates/ui-backend/deployment.yaml
+++ b/charts/k8s-dencer/templates/ui-backend/deployment.yaml
@@ -39,8 +39,13 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.uiBackend.priorityClassName }}
-      priorityClassName: {{ . }}
+      {{- if .Values.uiBackend.priorityClassName }}
+      priorityClassName: {{ .Values.uiBackend.priorityClassName }}
+      {{- else if and .Values.priorityClass.create .Values.persistence.enabled (eq .Values.database.type "sqlite") }}
+      # Co-scheduled with the other half of the SQLite volume, so it
+      # cannot be placed elsewhere under pressure. An explicit
+      # priorityClassName above always wins.
+      priorityClassName: {{ include "k8s-dencer.fullname" . }}
       {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}

--- a/charts/k8s-dencer/values.yaml
+++ b/charts/k8s-dencer/values.yaml
@@ -159,6 +159,26 @@ planner:
     enabled: false
     maxUnavailable: 1
 
+# Scheduling priority for the co-scheduled pair.
+#
+# SQLite pins the planner to the ui-backend's node (one RWO volume, one
+# writer), so the planner has exactly one node it may occupy. On a packed
+# cluster it loses to whatever got there first, and a planner that cannot
+# schedule is a product that cannot plan.
+#
+# Created only when that constraint applies — an install on Postgres has no
+# co-location and gets no cluster-scoped object it did not ask for.
+#
+# preemptionPolicy is Never by default: winning a scheduling queue is worth
+# having, evicting somebody else's workload to do it is not. Set it to
+# PreemptLowerPriority only if you mean it.
+priorityClass:
+  create: true
+  # Deliberately below the 2000000000 of system-cluster-critical: this is
+  # important to the product, not to the cluster.
+  value: 1000000
+  preemptionPolicy: Never
+
 uiBackend:
   # Pinned to 1 while database.type is sqlite. Enforced by values.schema.json.
   replicaCount: 1

--- a/hack/lint-chart.sh
+++ b/hack/lint-chart.sh
@@ -273,6 +273,23 @@ if helm template dencer "$CHART" \
 fi
 green "  rejected as expected"
 
+bold "==> contract: the co-scheduled pair outranks the workloads it competes with"
+# SQLite pins the planner to the ui-backend's node, so it has exactly one node
+# it may occupy and loses scheduling fights it cannot afford to lose. The
+# priority is the interim answer; the assertion is that it actually reaches
+# both halves of the pair, and only them.
+sqlite_prio="$(helm template dencer "$CHART" --set database.type=sqlite   | grep -c 'priorityClassName: dencer-k8s-dencer' || true)"
+if [ "$sqlite_prio" -ne 2 ]; then
+  fail "expected the planner and ui-backend to carry the priority class, found $sqlite_prio pod(s)"
+fi
+# Postgres removes the co-location, so the cluster-scoped object should not
+# exist at all: no install gets a PriorityClass it has no use for.
+if helm template dencer "$CHART" --set database.type=postgres \
+     | grep -q '^kind: PriorityClass'; then
+  fail "a Postgres install created a PriorityClass it does not need"
+fi
+green "  planner and ui-backend prioritised under SQLite, nothing created under Postgres"
+
 bold "==> contract: chart packages without the ci/ fixtures"
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT


### PR DESCRIPTION
Refs #117 — the interim half. The real fix is `database.type=postgres`, which removes the co-location entirely.

SQLite is single-writer on a ReadWriteOnce claim, so the planner carries a **required** affinity to the ui-backend's node. That leaves it exactly one node it may occupy, and on a packed cluster it loses to whatever got there first.

Observed twice in one day, per the issue: a fresh install where the planner sat `Pending` until the helm wait died, and a rolling upgrade that left it unschedulable mid-session.

## What was missing

Every component already accepted `priorityClassName`, and every one of them was empty — which is not much use, because the class has to exist before a pod may reference it. The chart now creates one and sets it on the two pods that are actually pinned together.

**Created only when the constraint applies.** A Postgres install has no co-location, so it gets no cluster-scoped object it never asked for.

## Two deliberate restraints

- **`preemptionPolicy: Never`.** Winning a scheduling queue is worth having; evicting somebody else's workload to get there is not — least of all from a product whose entire pitch is that it does not move your pods without asking.
- **`globalDefault: false`.** Quietly raising the priority of every unannotated workload in the cluster would be an extraordinary thing for a consolidation tool to do.

The value (1000000) sits well below `system-cluster-critical`: this is important to the product, not to the cluster. An explicit `planner.priorityClassName` still wins, so an operator with their own scheme keeps it.

## Verification

New contract test, asserting both directions:

```
==> contract: the co-scheduled pair outranks the workloads it competes with
  planner and ui-backend prioritised under SQLite, nothing created under Postgres
```

`make lint`, `go test ./...`, `gofmt` all green.