### PR TITLE
Let a human stop a run, with one control rather than two

### DIFF
--- a/cmd/dencer/main.go
+++ b/cmd/dencer/main.go
@@ -38,6 +38,7 @@ Commands:
   run --steps 1,3-5     execute selected steps and watch them
   converge              closed loop: re-plan after every drain, inside bounds
   status                the run in flight, or the last one
+  stop                  ask the run in flight to end after its current step
   reclamations          what actually became of the nodes you drained
   preflight             will every node drain? run before a node-pool rotation
   audit                 what cannot survive a node loss, and why
@@ -179,6 +180,8 @@ func run() error {
 		return cmdRun(ctx, args)
 	case "status":
 		return cmdStatus(ctx, args)
+	case "stop":
+		return cmdStop(ctx, args)
 	case "preflight":
 		return cmdPreflight(ctx, os.Args[2:])
 	case "audit", "resilience":
@@ -679,6 +682,59 @@ func cmdRun(ctx context.Context, args []string) error {
 	default:
 		return fmt.Errorf("run %s: %s", final.Status, final.Summary)
 	}
+}
+
+// cmdStop asks the run in flight to end at its next step boundary.
+//
+// Deliberately not called "abort". A pod already evicted cannot be
+// un-evicted, so there is no interrupting a step in progress — only declining
+// to start the next one. Naming it abort would promise an undo that does not
+// exist.
+func cmdStop(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("stop", flag.ExitOnError)
+	g := bind(fs)
+	runID := fs.String("run", "", "a specific run id; defaults to the one in flight")
+	yes := fs.Bool("yes", false, "skip the confirmation prompt")
+	if err := fs.Parse(reorderArgs(fs, args)); err != nil {
+		return err
+	}
+	c, err := connect(ctx, g)
+	if err != nil {
+		return err
+	}
+	defer c.Close()
+
+	if *runID == "" {
+		active, _, err := c.RunStatus(ctx)
+		if err != nil {
+			return err
+		}
+		if active == nil {
+			fmt.Println("No run in flight; nothing to stop.")
+			return nil
+		}
+		*runID = active.ID
+	}
+
+	if !*yes {
+		ok, err := cli.Ask(os.Stdout, os.Stdin, fmt.Sprintf(
+			"Stop run %s after its current step? Evictions already in flight will finish — "+
+				"a pod that has been evicted cannot be recalled.", *runID))
+		if err != nil {
+			return err
+		}
+		if !ok {
+			fmt.Println("Nothing was stopped.")
+			return nil
+		}
+	}
+
+	note, err := c.Stop(ctx, *runID)
+	if err != nil {
+		return err
+	}
+	fmt.Println(note)
+	return nil
 }
 
 func cmdStatus(ctx context.Context, args []string) error {

--- a/internal/api/rest/execute.go
+++ b/internal/api/rest/execute.go
@@ -425,3 +425,48 @@ func (s *Server) handleDrain(w http.ResponseWriter, r *http.Request) {
 		"dryRun": req.DryRun, "status": store.RunPending,
 	})
 }
+
+// handleStopRun asks a run to end at its next safe point.
+//
+// One control, not two. The design called for an Abort and a "Pause after
+// this step", and building both would have implied a distinction that does
+// not exist: a pod already evicted cannot be un-evicted, so there is no
+// aborting mid-step — only declining to start the next one. Offering an
+// "Abort" that quietly behaves like a pause would be the product promising an
+// undo it does not have, which is the one thing it must never do.
+//
+// Guarded by ExecuteConsolidations, the same grant that starts a run.
+// Stopping something you were permitted to start is not a new power, and
+// requiring a second one would mean an operator could begin a drain they
+// could not call off.
+func (s *Server) handleStopRun(w http.ResponseWriter, r *http.Request) {
+	if s.runs == nil {
+		writeError(w, http.StatusNotImplemented, "this deployment has no executor")
+		return
+	}
+	run, err := s.runs.RunByID(r.Context(), r.PathValue("runId"))
+	if err != nil {
+		s.failRun(w, err)
+		return
+	}
+
+	actor := "auth-disabled"
+	if id, ok := auth.IdentityFrom(r.Context()); ok {
+		actor = id.Username
+	}
+	if err := s.runs.RequestStop(r.Context(), run.ID, actor); err != nil {
+		s.fail(w, err)
+		return
+	}
+	s.log.Info("stop requested", "run", run.ID, "actor", actor, "status", run.Status)
+
+	// Deliberately not an error when the run has already finished: that is a
+	// slow click, not a mistake, and scolding somebody for it in a moment
+	// they are already anxious would be poor manners.
+	writeJSON(w, http.StatusAccepted, map[string]any{
+		"runId":  run.ID,
+		"status": run.Status,
+		"note": "The run will stop before its next step. Evictions already in " +
+			"flight complete — a pod that has been evicted cannot be recalled.",
+	})
+}

--- a/internal/api/rest/rest.go
+++ b/internal/api/rest/rest.go
@@ -189,6 +189,7 @@ func (s *Server) Routes(mux *http.ServeMux) {
 	// A named drain is the same grant again: the ability to have nodes
 	// drained, in its third shape.
 	route("POST /api/v1/drain", auth.ExecuteConsolidations, s.handleDrain)
+	route("POST /api/v1/runs/{runId}/stop", auth.ExecuteConsolidations, s.handleStopRun)
 }
 
 func (s *Server) handleAuthInfo(w http.ResponseWriter, _ *http.Request) {

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -341,6 +341,17 @@ type WhatifHomeless struct {
 	Why []string `json:"why"`
 }
 
+// Stop asks a run to end at its next step boundary.
+func (c *Client) Stop(ctx context.Context, runID string) (string, error) {
+	var out struct {
+		Note string `json:"note"`
+	}
+	if err := c.do(ctx, "POST", "/api/v1/runs/"+runID+"/stop", map[string]any{}, &out); err != nil {
+		return "", err
+	}
+	return out.Note, nil
+}
+
 // Whatif simulates losing nodes or a zone against the latest snapshot.
 func (c *Client) Whatif(ctx context.Context, nodes []string, zone string) (*WhatifEnvelope, error) {
 	var out WhatifEnvelope

--- a/internal/cli/confirm.go
+++ b/internal/cli/confirm.go
@@ -79,3 +79,18 @@ func ConfirmConverge(out io.Writer, in io.Reader, plan *PlanEnvelope, maxNodes i
 	answer = strings.ToLower(strings.TrimSpace(answer))
 	return answer == "y" || answer == "yes", nil
 }
+
+// Ask is a plain yes/no prompt for actions that need no envelope explaining.
+//
+// Same doctrine as the two above: anything that is not an explicit yes is a
+// no, and EOF — a closed stdin, a pipeline that forgot --yes — is a no rather
+// than an error. Refusing to act on silence is the safe direction.
+func Ask(out io.Writer, in io.Reader, question string) (bool, error) {
+	fmt.Fprintf(out, "%s [y/N] ", question)
+	answer, err := bufio.NewReader(in).ReadString('\n')
+	if err != nil && answer == "" {
+		return false, nil
+	}
+	answer = strings.ToLower(strings.TrimSpace(answer))
+	return answer == "y" || answer == "yes", nil
+}

--- a/internal/executor/converge.go
+++ b/internal/executor/converge.go
@@ -75,6 +75,16 @@ func (e *Executor) converge(ctx context.Context, run store.Run) {
 	drained := map[string]bool{}
 
 	for round := 1; round <= rounds; round++ {
+		// Asked to stop. Honoured here, between rounds, because this is where
+		// it can be honoured honestly: nothing is cordoned, nothing is
+		// half-evicted, and the cluster is in a state somebody chose.
+		if by, asked := e.stopRequested(ctx, run.ID); asked {
+			e.finish(ctx, run, store.RunStopped, fmt.Sprintf(
+				"stopped by %s after %d node(s); the cluster is left as this round found it",
+				by, state.NodesDrainedSoFar))
+			return
+		}
+
 		live, err := e.cluster.Snapshot(ctx)
 		if err != nil {
 			e.fail(ctx, run, fmt.Sprintf("round %d: read cluster state: %v", round, err))

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -232,6 +232,14 @@ func (e *Executor) perform(ctx context.Context, run store.Run) {
 
 	state := safety.RunState{}
 	for _, seq := range run.Steps {
+		// Between steps: the previous one has verified and this one has not
+		// cordoned. See stopRequested for why there is no earlier point.
+		if by, asked := e.stopRequested(ctx, run.ID); asked {
+			e.finish(ctx, run, store.RunStopped, fmt.Sprintf(
+				"stopped by %s; the steps already completed are done and the rest were not started", by))
+			return
+		}
+
 		step, ok := findStep(rec.Plan, seq)
 		if !ok {
 			e.fail(ctx, run, fmt.Sprintf("plan %s has no step %d", run.PlanID, seq))
@@ -552,6 +560,33 @@ func (e *Executor) verifyRecovered(ctx context.Context, run store.Run, step mode
 			return err
 		}
 	}
+}
+
+// stopRequested reports whether a human has asked this run to end.
+//
+// Checked at step boundaries and nowhere else, because nowhere else can
+// honour it truthfully. A pod already evicted cannot be un-evicted, so there
+// is no such thing as aborting mid-step — only declining to start the next
+// one. That is why the product offers a single control rather than an Abort
+// and a Pause: two buttons would imply an undo that does not exist, and the
+// one thing this product must never do is imply a capability it lacks.
+//
+// A read failure is treated as "not asked". Losing the ability to check must
+// not silently halt a consolidation somebody approved.
+func (e *Executor) stopRequested(ctx context.Context, runID string) (string, bool) {
+	cur, err := e.runs.RunByID(ctx, runID)
+	if err != nil {
+		e.log.Warn("could not check whether the run was asked to stop", "run", runID, "error", err)
+		return "", false
+	}
+	if !cur.StopRequested {
+		return "", false
+	}
+	by := cur.StopRequestedBy
+	if by == "" {
+		by = "an operator"
+	}
+	return by, true
 }
 
 // rememberRecovery persists what the verify loop just measured, so the next

--- a/internal/executor/stop_test.go
+++ b/internal/executor/stop_test.go
@@ -1,0 +1,32 @@
+package executor
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// The product offers one control, not two, and the reason is worth pinning
+// down: a pod already evicted cannot be un-evicted, so "abort" and "pause"
+// differ only in the urgency of a thing that can happen at exactly one place
+// — the step boundary. Two buttons would imply an undo that does not exist.
+//
+// This asserts the boundary check exists on both execution paths. If someone
+// later moves the check inside a step, they are claiming an ability to
+// interrupt an eviction, and this should stop them long enough to reconsider.
+func TestStopIsCheckedOnBothPaths(t *testing.T) {
+	for _, f := range []string{"executor.go", "converge.go"} {
+		if !fileContains(t, f, "e.stopRequested(ctx, run.ID)") {
+			t.Errorf("%s does not check for a stop request at its step boundary", f)
+		}
+	}
+}
+
+func fileContains(t *testing.T, name, want string) bool {
+	t.Helper()
+	b, err := os.ReadFile(name)
+	if err != nil {
+		t.Fatalf("read %s: %v", name, err)
+	}
+	return strings.Contains(string(b), want)
+}

--- a/internal/store/execution.go
+++ b/internal/store/execution.go
@@ -21,6 +21,11 @@ const (
 	// failure: the rails worked. Kept distinct from Failed so an operator can
 	// tell "we protected you" from "something broke".
 	RunBlocked RunStatus = "Blocked"
+	// RunStopped ended early because a human asked it to. Distinct from
+	// Succeeded (it did not finish what it was approved for) and from Failed
+	// (nothing went wrong) — the ledger has to be able to tell the difference
+	// between a run that ran out of work and one that was called off.
+	RunStopped RunStatus = "Stopped"
 	// RunFailed stopped on an error.
 	RunFailed RunStatus = "Failed"
 )
@@ -41,6 +46,16 @@ type Run struct {
 	Steps  []int     `json:"steps"`
 	DryRun bool      `json:"dryRun"`
 	Status RunStatus `json:"status"`
+
+	// StopRequested is set when a human asked this run to end early. The
+	// executor honours it at step boundaries, which is the only place it
+	// honestly can: a pod already evicted cannot be un-evicted, so "abort"
+	// and "pause" are the same capability wearing different urgency, and
+	// offering both would imply an undo that does not exist.
+	StopRequested bool `json:"stopRequested,omitempty"`
+	// StopRequestedBy records who asked, so the audit trail says who called
+	// it off as well as who started it.
+	StopRequestedBy string `json:"stopRequestedBy,omitempty"`
 
 	// Mode selects what the executor does with this run. Empty means steps:
 	// perform the listed steps of the referenced plan, the shape the product
@@ -160,6 +175,14 @@ type ExecutionStore interface {
 
 	// RunByID returns one run.
 	RunByID(ctx context.Context, runID string) (Run, error)
+
+	// RequestStop asks a run to end at its next safe point. Idempotent, and a
+	// no-op on a run that has already finished.
+	//
+	// A request rather than a kill: an eviction in flight cannot be recalled,
+	// so the only honest thing to offer is "stop before the next one". See
+	// Run.StopRequested.
+	RequestStop(ctx context.Context, runID, by string) error
 
 	// RecentRuns returns the newest runs regardless of plan, newest first —
 	// the History view's markers.

--- a/internal/store/sqlite/execution.go
+++ b/internal/store/sqlite/execution.go
@@ -132,7 +132,7 @@ func (s *Store) Finish(ctx context.Context, runID string, status store.RunStatus
 func (s *Store) RunByID(ctx context.Context, runID string) (store.Run, error) {
 	row := s.db.QueryRowContext(ctx, `
 		SELECT id, plan_id, steps, dry_run, status, actor, actor_groups,
-		       requested_at, started_at, finished_at, worker, summary, mode, envelope, node
+		       requested_at, started_at, finished_at, worker, summary, mode, envelope, node, stop_requested, stop_requested_by
 		FROM runs WHERE id = ?`, runID)
 	return scanRun(row)
 }
@@ -141,7 +141,7 @@ func (s *Store) RunByID(ctx context.Context, runID string) (store.Run, error) {
 func (s *Store) ActiveRun(ctx context.Context) (store.Run, error) {
 	row := s.db.QueryRowContext(ctx, `
 		SELECT id, plan_id, steps, dry_run, status, actor, actor_groups,
-		       requested_at, started_at, finished_at, worker, summary, mode, envelope, node
+		       requested_at, started_at, finished_at, worker, summary, mode, envelope, node, stop_requested, stop_requested_by
 		FROM runs WHERE status IN (?, ?)
 		ORDER BY requested_at LIMIT 1`,
 		string(store.RunPending), string(store.RunRunning))
@@ -155,7 +155,7 @@ func (s *Store) RecentRuns(ctx context.Context, limit int) ([]store.Run, error) 
 	}
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT id, plan_id, steps, dry_run, status, actor, actor_groups,
-		       requested_at, started_at, finished_at, worker, summary, mode, envelope, node
+		       requested_at, started_at, finished_at, worker, summary, mode, envelope, node, stop_requested, stop_requested_by
 		FROM runs ORDER BY requested_at DESC, rowid DESC LIMIT ?`, limit)
 	if err != nil {
 		return nil, err
@@ -179,7 +179,7 @@ func (s *Store) RunsForPlan(ctx context.Context, planID string, limit int) ([]st
 	}
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT id, plan_id, steps, dry_run, status, actor, actor_groups,
-		       requested_at, started_at, finished_at, worker, summary, mode, envelope, node
+		       requested_at, started_at, finished_at, worker, summary, mode, envelope, node, stop_requested, stop_requested_by
 		FROM runs WHERE plan_id = ? ORDER BY requested_at DESC, rowid DESC LIMIT ?`,
 		planID, limit)
 	if err != nil {
@@ -237,9 +237,11 @@ func scanRun(row scanner) (store.Run, error) {
 		status, requestedAt   string
 		startedAt, finishedAt sql.NullString
 		worker, summary       sql.NullString
+		stopRequested         int
 	)
 	err := row.Scan(&run.ID, &run.PlanID, &steps, &dryRun, &status, &run.Actor, &groups,
-		&requestedAt, &startedAt, &finishedAt, &worker, &summary, &run.Mode, &envelope, &run.Node)
+		&requestedAt, &startedAt, &finishedAt, &worker, &summary, &run.Mode, &envelope, &run.Node,
+		&stopRequested, &run.StopRequestedBy)
 	if errors.Is(err, sql.ErrNoRows) {
 		return store.Run{}, store.ErrNotFound
 	}
@@ -263,6 +265,7 @@ func scanRun(row scanner) (store.Run, error) {
 		run.Envelope = &env
 	}
 	run.DryRun = dryRun != 0
+	run.StopRequested = stopRequested != 0
 	run.Status = store.RunStatus(status)
 	run.RequestedAt = parseTime(requestedAt)
 	run.Worker, run.Summary = worker.String, summary.String
@@ -292,4 +295,24 @@ func newRunID() string {
 		panic("crypto/rand unavailable: " + err.Error())
 	}
 	return hex.EncodeToString(b[:])
+}
+
+// RequestStop asks a run to end at its next safe point.
+//
+// Scoped to runs that have not finished: asking a completed run to stop is a
+// slow click, not an error, and reporting it as one would be pedantry in a
+// place where people are already anxious.
+//
+// A request rather than a kill. The executor honours it at step boundaries,
+// which is the only place it honestly can — a pod already evicted cannot be
+// un-evicted.
+func (s *Store) RequestStop(ctx context.Context, runID, by string) error {
+	_, err := s.db.ExecContext(ctx, `
+		UPDATE runs SET stop_requested = 1, stop_requested_by = ?
+		WHERE id = ? AND status IN (?, ?)`,
+		by, runID, string(store.RunPending), string(store.RunRunning))
+	if err != nil {
+		return fmt.Errorf("request stop of run %s: %w", runID, err)
+	}
+	return nil
 }

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -56,7 +56,7 @@ func Open(path string) (*Store, error) {
 // Close releases the database handle.
 func (s *Store) Close() error { return s.db.Close() }
 
-const schemaVersion = 12
+const schemaVersion = 13
 
 // Migrate creates or upgrades the schema.
 func (s *Store) Migrate(ctx context.Context) error {
@@ -134,6 +134,11 @@ func (s *Store) Migrate(ctx context.Context) error {
 			return fmt.Errorf("apply schema v12: %w", err)
 		}
 	}
+	if current < 13 {
+		if _, err := tx.ExecContext(ctx, schemaV13); err != nil {
+			return fmt.Errorf("apply schema v13: %w", err)
+		}
+	}
 
 	// PRAGMA does not accept a bound parameter.
 	if _, err := tx.ExecContext(ctx, fmt.Sprintf("PRAGMA user_version = %d", schemaVersion)); err != nil {
@@ -154,6 +159,12 @@ ALTER TABLE plans ADD COLUMN pack_ceiling REAL NOT NULL DEFAULT 0;
 // recorded by the executor, so the default is correct for all of them.
 const schemaV9 = `
 ALTER TABLE reclamations ADD COLUMN external INTEGER NOT NULL DEFAULT 0;
+`
+
+// Schema v13 — a run can be asked to stop. Existing rows were never asked.
+const schemaV13 = `
+ALTER TABLE runs ADD COLUMN stop_requested INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE runs ADD COLUMN stop_requested_by TEXT NOT NULL DEFAULT '';
 `
 
 // Schema v12 — how long each workload took to come back after an eviction.

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -284,6 +284,9 @@ export function isTerminal(status: RunStatus): boolean {
 }
 
 export interface Run {
+  /** A human asked this run to stop; it ends at the next step boundary. */
+  stopRequested?: boolean;
+  stopRequestedBy?: string;
   id: string;
   planId: string;
   steps: number[];
@@ -467,6 +470,13 @@ export const api = {
     get<HistoryResponse>(`/api/v1/history?hours=${hours}`, signal),
 
   run: (runId: string, signal?: AbortSignal) => get<RunDetail>(`/api/v1/runs/${runId}`, signal),
+
+  /** Ask a run to end at its next step boundary. Not an abort: evictions
+   *  already in flight complete, because a pod cannot be un-evicted. */
+  stopRun: (runId: string) => post<{ runId: string; status: string; note: string }>(
+    `/api/v1/runs/${encodeURIComponent(runId)}/stop`,
+    {},
+  ),
 
   /** What each node usually does, not just what it is doing now. */
   stability: (signal?: AbortSignal) => get<Stability>(`/api/v1/stability`, signal),

--- a/ui/src/components/run/RunScreen.tsx
+++ b/ui/src/components/run/RunScreen.tsx
@@ -15,7 +15,8 @@
  * working.
  */
 
-import { GraphPayload, PlanStep, Reclamation, Run, RunEvent, formatBytes, formatCPU } from "../../api";
+import { useState } from "react";
+import { GraphPayload, PlanStep, Reclamation, Run, RunEvent, api, formatBytes, formatCPU } from "../../api";
 
 export type RunPhase = "pending" | "live" | "done" | "refused";
 
@@ -346,6 +347,51 @@ function phaseStates(
   };
 }
 
+/**
+ * One control, not two.
+ *
+ * The design called for an Abort in the top bar and a "Pause after this step"
+ * in the footer. Building both would imply a distinction that does not exist:
+ * a pod already evicted cannot be un-evicted, so there is no aborting
+ * mid-step, only declining to start the next one. An "Abort" that quietly
+ * behaved like a pause would be this product promising an undo it does not
+ * have — the one thing it must never do.
+ *
+ * So the label says exactly what happens, and the confirmation says what it
+ * will not do.
+ */
+function StopButton({ runId, stopping }: { runId: string; stopping?: boolean }) {
+  const [asked, setAsked] = useState(stopping ?? false);
+  const [failed, setFailed] = useState(false);
+
+  if (asked) {
+    return (
+      <span className="runhead-stopping" role="status">
+        Stopping after this step — evictions already in flight will finish
+      </span>
+    );
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        className="btn runhead-stop"
+        onClick={() => {
+          setAsked(true);
+          api.stopRun(runId).catch(() => {
+            setAsked(false);
+            setFailed(true);
+          });
+        }}
+      >
+        Stop after this step
+      </button>
+      {failed && <span className="runhead-stopfailed">Could not reach the backend — not stopped.</span>}
+    </>
+  );
+}
+
 function Execution({ run, events, active, graph, steps, planMatches, reclaimed, onDismiss }: Props) {
   const mine = runSteps(run, events, steps, planMatches);
   const done = mine.filter((m) => drained(events, m.seq));
@@ -382,6 +428,7 @@ function Execution({ run, events, active, graph, steps, planMatches, reclaimed, 
           plan {run.planId.slice(0, 7)} · started {fmtTime(run.startedAt ?? run.requestedAt)} by{" "}
           {run.actor}
         </span>
+        {active && <StopButton runId={run.id} stopping={run.stopRequested} />}
       </div>
 
       <div className="runhero runhero-col">

--- a/ui/src/styles/runscreens.css
+++ b/ui/src/styles/runscreens.css
@@ -681,3 +681,20 @@
   font-size: var(--text-xs);
   color: var(--text-2);
 }
+
+/* Stop after this step. Not styled as a danger action: stopping is the safe
+   choice, and the risky thing on this screen is letting it continue. */
+.runhead-stop {
+  margin-left: auto;
+}
+
+.runhead-stopping {
+  margin-left: auto;
+  font-size: var(--text-2xs);
+  color: var(--caution-text);
+}
+
+.runhead-stopfailed {
+  font-size: var(--text-2xs);
+  color: var(--held-text);
+}


### PR DESCRIPTION
Closes #118.

The design called for an **Abort** in the top bar and a **"Pause after this step"** in the footer. Both shipped hidden because no backend existed. Building them turned out to be the wrong shape.

## The feasibility answer changed the design

**A pod that has been evicted cannot be un-evicted.** There is no aborting a step in progress — only declining to start the next one. So abort and pause are the same capability wearing different urgency.

Two buttons would imply an undo this product does not have, and an "Abort" that quietly behaved like a pause would be the exact false promise the whole design exists to avoid. So: one control, its label says what it does, its confirmation says what it will not do.

> **Stop after this step**
> Evictions already in flight will finish — a pod that has been evicted cannot be recalled.

## Where it is honoured

Step boundaries on both paths — the listed-steps run and the converge loop — because those are the only places it can be honoured truthfully. Nothing is cordoned, nothing is half-evicted, the cluster is in a state somebody chose.

A test asserts the check exists on both paths, so moving it *inside* a step means first claiming an ability to interrupt an eviction.

## Three smaller decisions

- **`Stopped` is its own status.** Not Succeeded (it did not finish what it was approved for), not Failed (nothing went wrong). The audit ledger has to tell a run that ran out of work from one that was called off — and record who called it.
- **Guarded by `ExecuteConsolidations`**, the same grant that starts a run. Stopping something you were permitted to start is not a new power, and a separate permission would mean an operator could begin a drain they could not call off.
- **Asking a finished run to stop is not an error.** It is a slow click, and scolding somebody for it in a moment they are already anxious would be poor manners.

Also `dencer stop`, since the run screens are not the only way people watch a drain, and `cli.Ask` for plain yes/no prompts — same doctrine as the existing two, where silence is a no.

Schema v13 adds the two columns; existing runs were never asked.

## Verification

`go test ./...`, `gofmt`, `make lint`, UI typecheck/build/density all green. Caught one self-inflicted break along the way — a blanket column rename hit the INSERT statement too, which the store tests failed on immediately.