### PR TITLE
Remove what nothing uses, and read the cluster config once

### DIFF
--- a/cmd/ui-backend/main.go
+++ b/cmd/ui-backend/main.go
@@ -17,10 +17,12 @@ import (
 	"os/signal"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
 	"k8s.io/client-go/kubernetes"
+	clientrest "k8s.io/client-go/rest"
 	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
 
 	"github.com/atedgimo/k8s-dencer/internal/api/agenttools"
@@ -112,7 +114,7 @@ func run(ctx context.Context, log *slog.Logger) error {
 	// been naming that precondition without any way to check it. The read is
 	// already granted: the chart's -read ClusterRole covers maintenancewindows
 	// and is bound to ui-backend as well as the planner.
-	if cfg, err := ctrlconfig.GetConfig(); err != nil {
+	if cfg, err := clusterConfig(); err != nil {
 		log.Warn("no cluster config; maintenance window state will be unavailable", "error", err)
 	} else if wr, err := window.NewReader(cfg, log); err != nil {
 		log.Warn("could not build the maintenance window reader", "error", err)
@@ -163,6 +165,24 @@ func run(ctx context.Context, log *slog.Logger) error {
 	return httpserver.Run(ctx, log, env("HTTP_ADDR", ":8080"), mux)
 }
 
+// clusterConfig resolves the in-cluster REST config once.
+//
+// Two callers need it — the TokenReview client that answers "who is this?"
+// and the maintenance window reader — and resolving it twice means reading
+// the same service-account files twice to get the same answer. Memoised
+// rather than threaded through, because the alternative is reordering
+// startup around a value neither caller owns.
+var (
+	clusterCfgOnce sync.Once
+	clusterCfgVal  *clientrest.Config
+	clusterCfgErr  error
+)
+
+func clusterConfig() (*clientrest.Config, error) {
+	clusterCfgOnce.Do(func() { clusterCfgVal, clusterCfgErr = ctrlconfig.GetConfig() })
+	return clusterCfgVal, clusterCfgErr
+}
+
 // authConfig reads the authentication configuration the chart supplies.
 //
 // Enabled defaults to true: a component that answers questions about where a
@@ -198,7 +218,7 @@ func buildGuard(cfg auth.Config, log *slog.Logger) (*auth.Middleware, error) {
 		return auth.NewMiddleware(nil, nil, cfg, log), nil
 	}
 
-	restCfg, err := ctrlconfig.GetConfig()
+	restCfg, err := clusterConfig()
 	if err != nil {
 		return nil, err
 	}

--- a/ui/src/styles/frame.css
+++ b/ui/src/styles/frame.css
@@ -340,9 +340,3 @@
    The Cluster destination keeps the old field plus the lens switcher until
    its redesign lands. */
 
-.lensbar {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  padding: var(--space-3) var(--space-6) 0;
-}

--- a/ui/src/styles/review.css
+++ b/ui/src/styles/review.css
@@ -596,17 +596,8 @@
   font-size: var(--text-2xs);
 }
 
-.check-green {
-  color: var(--safe);
-}
 
-.check-yellow {
-  color: var(--caution);
-}
 
-.check-red {
-  color: var(--held);
-}
 
 .check-loading {
   color: var(--text-5);

--- a/ui/src/styles/run.css
+++ b/ui/src/styles/run.css
@@ -181,10 +181,6 @@
   }
 }
 
-.tray-hint {
-  font-size: var(--text-2xs);
-  color: var(--text-5);
-}
 
 .verdict-flag {
   display: block;

--- a/ui/src/styles/sidebar.css
+++ b/ui/src/styles/sidebar.css
@@ -47,6 +47,3 @@
   white-space: pre-line;
 }
 
-.placeholder-error h2 {
-  color: var(--held);
-}


### PR DESCRIPTION
Two findings from reviewing the tree after a long run of changes — a frontend pass, an architecture pass, and a security pass.

## Dead CSS

Six rules defined and never referenced by any component: `.lensbar`, `.placeholder-error h2`, `.tray-hint`, and the `.check-green`/`-yellow`/`-red` trio a redesign left behind.

Distinguished from the many classes that only *look* unused because they're built by concatenation — `"racknode-dot-" + cls` and its relatives are all live, and grep cannot see them. Checking each candidate against the components rather than trusting the list is the whole job here.

## ui-backend resolved the cluster config twice

Once for the TokenReview client that answers "who is this?", and once — added today with the maintenance window reader — for the window reader. Two reads of the same service-account files to get the same answer.

Memoised rather than threaded through the call chain, because the alternative is reordering startup around a value neither caller owns.

## Security review: clean

Every route names the permission it requires, and `TestEveryRouteIsGuarded` fails the build if a handler reaches the mux any other way. The three endpoints added today check out:

| Route | Permission | Why |
|---|---|---|
| `GET /windows` | `ReadPlans` | read-only evaluation |
| `GET /stability` | `ReadPlans` | read-only aggregate |
| `POST /runs/{id}/stop` | `ExecuteConsolidations` | stopping what you may start is not a new power |

`POST /whatif` sits behind `ReadPlans` despite being a POST — it's a simulation with no mutating call in it, so the verb is about the request body, not the effect.

## Two findings deliberately left alone

- **Six polling timers, four always mounted** — about seven requests a minute in steady state. Worth multiplexing if another arrives; not worth the churn today.
- **`ClusterPage` is 719 lines**, holding three lenses plus stability and simulation. Splitting it is a real improvement and a real risk, and doing it in the same breath as a release would make both harder to review.

Both are recorded here rather than silently skipped.

## Verification

`go test ./...`, `gofmt`, `make lint`, UI typecheck/build/density all green.