### PR TITLE
Document v0.5.0, and bump the chart to match

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,12 +274,20 @@ until the next snapshot says where they truly landed.
 execution, and maintenance windows. Phase 4 — hardening toward 1000 nodes and
 50,000 pods — is in progress, with metrics, CI and the release pipeline landed.
 
-**v0.4.0 is published** — images, chart and CLI binaries on `ghcr.io` and the
+**v0.5.0 is published** — images, chart and CLI binaries on `ghcr.io` and the
 [releases page](https://github.com/atedgimo/k8s-dencer/releases), installable by
-the command above. It carries the redesigned UI, the packing ceiling, per-node
-measured usage, a CLI that authenticates against cloud kubeconfigs without being
-handed a token, and an install that can leave the web UI out entirely
-(`uiFrontend.enabled=false`).
+the command above.
+
+It is the release that made the product work on managed clusters. A real GKE
+run found that it could not plan at all there — see below — and fixing that
+brought the rest with it: the savings ledger in money when you say what your
+machines cost, rightsizing and maintenance windows and resilience simulation
+all given screens after being built and never surfaced, an empty plan that
+explains itself rather than rendering blank, per-node history so a node that
+is quietly idle can be told from one that spikes nightly, and a single Stop
+control on a run in flight — one rather than the designed two, because a pod
+that has been evicted cannot be un-evicted and two buttons would promise an
+undo that does not exist.
 
 **The UI has been rebuilt against a full design handoff** (2026-08-01): twelve
 mockup frames, a dual-theme token system with computed-contrast guards, and

--- a/charts/k8s-dencer/Chart.yaml
+++ b/charts/k8s-dencer/Chart.yaml
@@ -10,8 +10,8 @@ type: application
 
 # Chart version tracks the chart; appVersion tracks the images. Component image
 # tags default to appVersion so a chart release pins a coherent image set.
-version: 0.4.0
-appVersion: "0.4.0"
+version: 0.5.0
+appVersion: "0.5.0"
 
 # controller-runtime and the policy/v1 PDB API used here are stable from 1.21,
 # but the chart relies on 1.27-era defaults for restricted Pod Security

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -148,6 +148,30 @@ for an autoscaler that is about to act.
 ### `dencer status`
 
 The run in flight, or a specific one with `--run <id>`, plus its audit trail.
+With nothing running it shows the most recent run and says that is what you
+are looking at.
+
+### `dencer stop`
+
+Asks the run in flight to end after its current step.
+
+```bash
+dencer stop            # the run in flight
+dencer stop --run <id>
+```
+
+Deliberately not called abort. A pod that has been evicted cannot be
+un-evicted, so there is no interrupting a step in progress — only declining to
+start the next one. Evictions already in flight complete; the executor stops
+at the next step boundary, where nothing is cordoned and nothing is
+half-drained.
+
+The run ends with status `Stopped`, which the audit ledger keeps distinct from
+`Succeeded` (it did not finish what it was approved for) and from `Failed`
+(nothing went wrong), and records who asked.
+
+Needs the same permission as starting a run: stopping something you were
+allowed to start is not a new power.
 
 ## Scripting
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -143,9 +143,39 @@ Two things users reasonably look for and should not:
 The demo fabric additionally needs KWOK's `Stage` CRDs, but only for the
 demo — `make demo` installs them; a product install does not.
 
+## Showing savings in money
+
+The ledger measures capacity — cores and bytes actually returned, summed from
+what each node was worth at drain time. To see that in currency, tell the
+chart what your machines cost:
+
+```yaml
+uiBackend:
+  pricing:
+    currency: USD
+    perHour:
+      e2-medium: 0.0335
+      e2-medium/spot: 0.0100
+      n2-standard-4: 0.1942
+```
+
+Keys match most specific first, so spot and on-demand of the same shape can
+differ. There is no built-in price table and there will not be one: list
+prices vary by region, change without notice, and are wrong for anyone with a
+committed-use discount, so a shipped default would be a guess wearing the
+clothes of a measurement. Machine types you have not priced are reported as
+unpriced rather than as free, and the capacity figure is shown either way.
+
+The ledger also counts nodes that left the cluster without k8s-dencer draining
+them — an autoscaler, or someone with kubectl — and reports them separately.
+The cluster saved that money whoever caused it, and the ledger's job is to be
+accurate about what happened rather than flattering about who did it.
+
 ## Known constraints
 
 - **SQLite is single-writer.** `uiBackend.replicaCount` is pinned to 1 and enforced by the schema; the planner is co-scheduled with ui-backend via a `requiredDuringScheduling` podAffinity, because a ReadWriteOnce claim only permits multiple pods on the same node. Both constraints disappear when the Postgres store lands.
+
+  That affinity leaves the planner exactly one node it may occupy, so on a packed cluster it can lose the scheduling race and sit `Pending`. The chart creates a `PriorityClass` for the pair to stop that happening — only when the co-location applies, so a Postgres install gets no cluster-scoped object it has no use for. It is `preemptionPolicy: Never`: winning a queue is worth having, evicting someone else's workload to get there is not. Set `priorityClass.create=false` to opt out, or `planner.priorityClassName` to use your own.
 - **PDBs use `maxUnavailable`, never `minAvailable`.** A `minAvailable` PDB on a single-replica Deployment makes its own pod undrainable — the exact pathology this product exists to detect.
 
 ---

--- a/docs/product-roadmap.md
+++ b/docs/product-roadmap.md
@@ -143,6 +143,30 @@ deciding what to build next and telling users what they get.
   `restricted` enforcing, real ingress, real drains, reclamation observed
 - **Zero-cost demo** — KWOK fake-node fabric, no real workloads needed
 
+### Managed clusters, and the surfaces that were built and never shown (2026-08-07)
+- **It plans on managed clusters at all** — a static pod owned by the node
+  (GKE runs kube-proxy this way) is recognised as pinned. Before this the
+  analyzer tried to reschedule a pod nothing can move, failed, and marked
+  every node undrainable: converge reported nothing to do while the cloud's
+  own autoscaler reclaimed two nodes from the same cluster
+- **Pinned is not blocking** — a DaemonSet pod cannot move but does not hold
+  a drain up, so preflight and audit stopped reporting the worst possible
+  answer on every real cluster
+- **A GKE-shaped fixture** — the whole class of bug reproduced in CI, because
+  KWOK nodes run no system pods at all and never could catch it
+- **The ledger in money** — operator-supplied prices, no built-in table, a
+  rate rather than a total, and nodes reclaimed by something else counted
+  separately rather than claimed
+- **Rightsizing, maintenance windows, what-if and preflight** — four
+  capabilities the backend already had and the UI never called
+- **An empty plan explains itself** — the state a healthy cluster spends most
+  of its life in used to render blank
+- **Per-node history** — a node stably idle for a fortnight told apart from
+  one that peaks nightly
+- **Stop a run in flight** — one control, not the designed two: a pod already
+  evicted cannot be un-evicted, so abort and pause are the same capability
+  and offering both would promise an undo that does not exist
+
 ## Next
 
 Ordered by intent; items move up when a user need pulls them.


### PR DESCRIPTION
Docs and the version bump for v0.5.0.

## `dencer stop` was shipped undocumented

For a control that changes a running drain, that's the wrong way round. `docs/cli.md` now carries it — including why it isn't called abort, and what `Stopped` means in the ledger as distinct from `Succeeded` and `Failed`.

## Pricing, with its reasoning

`docs/install.md` gains the `uiBackend.pricing` block **and the reason there is no built-in price table**. An operator who reads only the docs should still come away knowing that an unpriced machine type is reported as unpriced rather than as free.

Also the `PriorityClass`, documented under the SQLite constraint that motivates it, with how to opt out.

## README and roadmap

The roadmap records what the GKE run cost and bought. The README status leads with the honest version:

> It is the release that made the product work on managed clusters. A real GKE run found that it could not plan at all there — and fixing that brought the rest with it.

## Version

Chart `version` and `appVersion` both move to 0.5.0. The release workflow hard-fails the publish if they disagree with the tag.

## Verification

`make lint`, `go test ./...`, UI build all green.