### PR TITLE
Keep the capture harness, and give the playground a price

### DIFF
--- a/hack/capture/CHECKLIST.md
+++ b/hack/capture/CHECKLIST.md
@@ -1,0 +1,101 @@
+# v0.5.0 on a real managed cluster — what to check
+
+The 2026-08-07 run found that the product could not plan on GKE at all. Every
+fix since was verified against `test/fixtures/gke-managed.yaml` and locally.
+**Nobody has watched v0.5.0 plan on a real managed cluster.** That is what this
+run is for.
+
+If line 1 fails, stop and treat the fixture as wrong about something —
+everything below it is downstream of that one answer.
+
+## 1. The P0 — does it plan at all?
+
+```bash
+go run ./cmd/dencer plan --context gke-play
+go run ./cmd/dencer converge --context gke-play --max-nodes 2 --max-impact Green --dry-run
+```
+
+- **Was:** `nodesUndrainable: 4` every cycle, `steps: 0`, converge reporting
+  "every remaining node is either needed or undrainable" while the cloud's own
+  autoscaler reclaimed two nodes from the same cluster.
+- **Want:** steps proposed, and converge willing to act on them.
+- Cross-check the planner's own view:
+  `kubectl --context gke-play -n k8s-dencer logs -l app.kubernetes.io/component=planner --tail=5`
+  — `nodesUndrainable` should no longer equal the node count.
+
+## 2. Preflight and audit stopped crying wolf
+
+```bash
+go run ./cmd/dencer preflight --context gke-play
+```
+
+- **Was:** "0 of 6 nodes will drain cleanly", 30 of 32 blockers DaemonSets.
+- **Want:** most nodes drainable; no blocker is a DaemonSet or kube-proxy.
+
+## 3. recommend is about workloads you own
+
+```bash
+go run ./cmd/dencer recommend --context gke-play
+```
+
+- **Was:** 15 findings, 11 HIGH, one of them the operator's.
+- **Want:** only `dencer-demo/*`. Nothing from `kube-system`, `gke-managed-*`,
+  `gmp-*`, and nothing about k8s-dencer's own Deployments.
+
+## 4. The screens that were never shown
+
+UI at `http://localhost:8092`.
+
+- **Rightsizing** in the rail — requested against observed, sorted by gap.
+- **Cluster → Rack** — node names distinguishable (`…-0xk4`, not four
+  identical `gke-dencer-play-de…`), clicking a node lists its pods with a
+  visible selection.
+- **"What if this node were gone?"** in the node pane — a real answer.
+- **Top bar** — a maintenance-window chip only if windows exist; expect none.
+- **Pool column** should read `default-pool` from GKE's own label, not the
+  machine type.
+
+## 5. Money
+
+The playground now installs with a price for the machine it drew, so the
+ledger has something to work with.
+
+- **History** should show a monthly rate once anything is reclaimed, and count
+  externally reclaimed nodes separately rather than claiming them.
+- If GKE's autoscaler removes a node on its own — it did last time, 64 seconds
+  from marking to gone — the ledger must say so *without* adding it to the
+  savings this product produced.
+
+## 6. Stop a run
+
+```bash
+go run ./cmd/dencer converge --context gke-play --max-nodes 2 --max-impact Green --yes &
+go run ./cmd/dencer stop --context gke-play
+```
+
+- **Want:** it finishes the step in flight and stops before the next; status
+  `Stopped`, and the ledger records who asked.
+- It must **not** claim to have interrupted an eviction.
+
+## 7. Per-node history
+
+Needs 30 samples, which at a 30s resync is fifteen minutes. Late in the window,
+select a node in the Rack lens: it should say what that node *usually* does,
+or say nothing at all — never invent a trend from six points.
+
+## 8. The receipt
+
+```bash
+./hack/capture/verify-teardown.sh
+```
+
+Nothing billable, and no `gke-play` entries left in the kubeconfig.
+
+---
+
+Capture as you go so the answers survive the window:
+
+```bash
+RUN_DIR=/tmp/gcprun ./hack/capture/capture.sh baseline
+RUN_DIR=/tmp/gcprun ./hack/capture/capture.sh after-converge
+```

--- a/hack/capture/README.md
+++ b/hack/capture/README.md
@@ -1,0 +1,36 @@
+# Capturing a cloud run
+
+Built during the 2026-08-07 GKE run, when the interesting findings turned out
+to be things nobody had thought to look at. A metered cluster is a bad place
+to be writing tooling, so it lives here now.
+
+Everything writes into a numbered, timestamped folder per phase, so the folder
+order is the story order and the gaps between them are real elapsed time.
+
+```bash
+# 1. Launch (yours to run — it prompts for consent and spends money)
+PLAY_MINUTES=45 SCENARIO=a-fragmented GCP_MACHINE=e2-medium REAL_NODES=6 make gcp-play
+
+# 2. Wire up kubectl and wait for the product, in another terminal
+./hack/capture/wait-up.sh
+
+# 3. Snapshot at each phase
+RUN_DIR=/tmp/gcprun ./hack/capture/capture.sh baseline
+RUN_DIR=/tmp/gcprun ./hack/capture/capture.sh after-converge
+
+# 4. UI stills
+DENCER_URL=http://localhost:8092 DENCER_TOKEN="$(kubectl --context gke-play \
+  -n k8s-dencer create token dencer-operator --duration=30m)" \
+  SHOT_DIR=/tmp/gcprun/ui node ui/e2e-demo/shots.mjs
+
+# 5. Confirm nothing is left billing
+./hack/capture/verify-teardown.sh
+```
+
+`overhead.py` is the one worth knowing about: it sums CPU and memory requests
+per node, split system against workload. It is how the "GKE daemons take 29%
+to 82% of a node before your workload is scheduled" figure was measured, and
+it is what `test/fixtures/gke-managed.yaml` was built from.
+
+`watch-reclaim.sh` waits for the cloud's own autoscaler to remove nodes, which
+on the first run took 64 seconds from marking to gone.

--- a/hack/capture/capture.sh
+++ b/hack/capture/capture.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Snapshot the cluster and the product's own view of it, into a phase folder.
+#
+#   ./capture.sh <phase-name>
+#
+# Every call is timestamped, so the folder order is the story order and the
+# gaps between them are real elapsed time — which is what lets us say "the
+# autoscaler took N minutes" afterwards instead of guessing.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+RUN="${RUN_DIR:-$HERE/run}"
+CTX="${KCTX:-gke-play}"
+DENCER="${DENCER_BIN:-$HERE/../dencer}"
+PHASE="${1:?usage: capture.sh <phase-name>}"
+
+N=$(printf '%02d' "$(( $(find "$RUN" -maxdepth 1 -type d -name '[0-9][0-9]-*' 2>/dev/null | wc -l) + 1 ))")
+OUT="$RUN/$N-$PHASE"
+mkdir -p "$OUT"
+
+k() { kubectl --context "$CTX" "$@"; }
+
+date -u +"%Y-%m-%dT%H:%M:%SZ" > "$OUT/timestamp"
+
+# --- the cluster as Kubernetes sees it ---------------------------------
+k get nodes -o wide                       > "$OUT/nodes.txt"          2>&1
+k get nodes -o json                       > "$OUT/nodes.json"         2>&1
+k get pods -A -o wide                     > "$OUT/pods.txt"           2>&1
+k get pods -A -o json                     > "$OUT/pods.json"          2>&1
+k top nodes                               > "$OUT/top-nodes.txt"      2>&1
+k get events -A --sort-by=.lastTimestamp 2>&1 | tail -40 > "$OUT/events.txt"
+
+# The measurement we could not make last time, because the cluster was gone.
+python3 "$HERE/overhead.py" < "$OUT/pods.json" > "$OUT/node-overhead.txt" 2>&1
+
+# --- the cluster as the product sees it --------------------------------
+if [ -x "$DENCER" ]; then
+  "$DENCER" plan --context "$CTX"                         > "$OUT/dencer-plan.txt"    2>&1
+  "$DENCER" plan -o json --context "$CTX"                  > "$OUT/dencer-plan.json"   2>&1
+  "$DENCER" reclamations --context "$CTX"                  > "$OUT/reclamations.txt"   2>&1
+fi
+
+echo "==> $OUT"
+grep -E 'system CPU requests per node' "$OUT/node-overhead.txt" 2>/dev/null || true
+head -3 "$OUT/dencer-plan.txt" 2>/dev/null || true

--- a/hack/capture/overhead.py
+++ b/hack/capture/overhead.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Sum pod CPU/memory *requests* per node, split system vs workload.
+
+This is the measurement that answers "how much does a managed node spend on
+itself before your workload gets any" — the number we could not verify after
+the last playground cluster was torn down.
+
+Reads `kubectl get pods -A -o json` on stdin.
+"""
+import json
+import sys
+from collections import defaultdict
+
+SYSTEM_NS = {
+    "kube-system", "gke-managed-cim", "gke-managed-system", "gmp-system",
+    "gmp-public", "gke-gmp-system", "kube-node-lease", "kube-public",
+    "gke-managed-filestorecsi", "gke-managed-volumepopulator",
+}
+
+
+def cpu_m(v):
+    """Kubernetes CPU quantity -> millicores."""
+    if not v:
+        return 0
+    v = str(v)
+    if v.endswith("m"):
+        return int(float(v[:-1]))
+    if v.endswith("n"):
+        return int(float(v[:-1]) / 1_000_000)
+    return int(float(v) * 1000)
+
+
+def mem_mi(v):
+    if not v:
+        return 0
+    v = str(v)
+    units = {"Ki": 1 / 1024, "Mi": 1, "Gi": 1024, "Ti": 1024 * 1024,
+             "K": 1000 / 1048576, "M": 1000000 / 1048576, "G": 1000000000 / 1048576}
+    for suf, mult in units.items():
+        if v.endswith(suf):
+            return int(float(v[: -len(suf)]) * mult)
+    return int(float(v) / 1048576)
+
+
+pods = json.load(sys.stdin)["items"]
+sysc = defaultdict(int)
+wrkc = defaultdict(int)
+sysm = defaultdict(int)
+wrkm = defaultdict(int)
+sys_pods = defaultdict(list)
+
+for p in pods:
+    node = (p.get("spec") or {}).get("nodeName")
+    if not node or (p.get("status") or {}).get("phase") in ("Succeeded", "Failed"):
+        continue
+    ns = p["metadata"]["namespace"]
+    c = sum(cpu_m(((ct.get("resources") or {}).get("requests") or {}).get("cpu"))
+            for ct in p["spec"].get("containers", []))
+    m = sum(mem_mi(((ct.get("resources") or {}).get("requests") or {}).get("memory"))
+            for ct in p["spec"].get("containers", []))
+    if ns in SYSTEM_NS:
+        sysc[node] += c
+        sysm[node] += m
+        if c:
+            sys_pods[p["metadata"]["name"].rsplit("-", 1)[0]] = [ns, c]
+    else:
+        wrkc[node] += c
+        wrkm[node] += m
+
+nodes = sorted(set(sysc) | set(wrkc))
+print(f"{'node':<48}{'system cpu':>12}{'workload cpu':>14}{'system mem':>13}")
+for n in nodes:
+    print(f"{n:<48}{str(sysc[n]) + 'm':>12}{str(wrkc[n]) + 'm':>14}{str(sysm[n]) + 'Mi':>13}")
+
+if nodes:
+    tot = sum(sysc[n] for n in nodes)
+    print(f"\nsystem CPU requests per node: min {min(sysc[n] for n in nodes)}m  "
+          f"max {max(sysc[n] for n in nodes)}m  mean {tot // len(nodes)}m  "
+          f"across {len(nodes)} nodes")
+
+print("\nsystem pods requesting CPU (by controller):")
+for name, (ns, c) in sorted(sys_pods.items(), key=lambda kv: -kv[1][1]):
+    print(f"  {c:>5}m  {ns}/{name}")

--- a/hack/capture/verify-teardown.sh
+++ b/hack/capture/verify-teardown.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Wait for the playground to delete itself, then audit for anything billable.
+set -uo pipefail
+for i in $(seq 1 90); do
+  s=$(gcloud container clusters list --filter="name=dencer-play" --format='value(status)' 2>/dev/null)
+  [ -z "$s" ] && break
+  sleep 20
+done
+echo "cluster gone at $(date -u +%H:%M:%SZ)"
+make gke-leftovers 2>&1 | tail -12
+echo "--- kubeconfig residue for the playground (should be empty) ---"
+kubectl config get-contexts -o name 2>/dev/null | grep -i play || echo "  no play contexts"
+kubectl config get-clusters 2>/dev/null | grep -i play || echo "  no play clusters"

--- a/hack/capture/wait-up.sh
+++ b/hack/capture/wait-up.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Wait for the playground cluster, wire up a named context, restore the
+# user's default context, then wait for the product to be Ready.
+set -uo pipefail
+ZONE=us-central1-a; NAME=dencer-play
+PREV="$(kubectl config current-context 2>/dev/null || echo orbstack)"
+
+echo "waiting for GKE cluster $NAME to reach RUNNING ..."
+until [ "$(gcloud container clusters list --filter="name=$NAME" --format='value(status)' 2>/dev/null)" = "RUNNING" ]; do
+  sleep 20
+done
+echo "cluster RUNNING"
+
+PROJ="$(gcloud config get-value project 2>/dev/null)"
+gcloud container clusters get-credentials "$NAME" --zone "$ZONE" >/dev/null 2>&1
+kubectl config rename-context "gke_${PROJ}_${ZONE}_${NAME}" gke-play >/dev/null 2>&1
+# get-credentials hijacks the current context; hand it straight back.
+kubectl config use-context "$PREV" >/dev/null 2>&1
+echo "context gke-play ready; default context restored to $PREV"
+
+echo "waiting for nodes ..."
+until [ "$(kubectl --context gke-play get nodes --no-headers 2>/dev/null | grep -c ' Ready')" -ge 1 ]; do sleep 15; done
+kubectl --context gke-play get nodes --no-headers 2>/dev/null | wc -l | xargs echo "nodes present:"
+
+echo "waiting for the product to be Ready (up to ~10m) ..."
+kubectl --context gke-play -n k8s-dencer wait --for=condition=available deploy --all --timeout=600s 2>&1 | tail -4
+kubectl --context gke-play -n k8s-dencer get pods 2>&1
+echo "=== READY ==="

--- a/hack/capture/watch-reclaim.sh
+++ b/hack/capture/watch-reclaim.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Watch until the autoscaler actually removes the cordoned nodes.
+set -uo pipefail
+start=$(date -u +%s)
+echo "watching for node removal; started $(date -u +%H:%M:%SZ) with $(kubectl --context gke-play get nodes --no-headers 2>/dev/null | wc -l | tr -d ' ') nodes"
+for i in $(seq 1 60); do
+  n=$(kubectl --context gke-play get nodes --no-headers 2>/dev/null | wc -l | tr -d ' ')
+  if [ "$n" -lt 6 ]; then
+    echo "NODES REMOVED: now $n at $(date -u +%H:%M:%SZ) after $(( $(date -u +%s) - start ))s"
+    kubectl --context gke-play get nodes --no-headers 2>/dev/null | awk '{print $1, $2}'
+    exit 0
+  fi
+  sleep 20
+done
+echo "still 6 nodes after $(( $(date -u +%s) - start ))s"

--- a/hack/gcp-playground.sh
+++ b/hack/gcp-playground.sh
@@ -68,6 +68,13 @@ case "$GCP_MACHINE" in
   *)         MACHINE_CENTS_H=3.4 ;;
 esac
 
+# The same numbers as dollars, handed to the product so the savings ledger has
+# something to price with. The chart ships no price table and never will —
+# these are the operator supplying one for a cluster they are paying for,
+# which is exactly the intended use. Spot is roughly a third of on-demand.
+MACHINE_USD_H="$(awk -v c="$MACHINE_CENTS_H" 'BEGIN{printf "%.5f", c/100}')"
+MACHINE_USD_H_SPOT="$(awk -v c="$MACHINE_CENTS_H" 'BEGIN{printf "%.5f", c/300}')"
+
 bold()  { printf '\033[1m%s\033[0m\n' "$*"; }
 green() { printf '\033[32m%s\033[0m\n' "$*"; }
 red()   { printf '\033[31m%s\033[0m\n' "$*"; }
@@ -526,6 +533,9 @@ helm --kube-context "$CTX" upgrade --install "$RELEASE" "$REPO/charts/k8s-dencer
   --set-string persistence.storageClass=standard-rwo \
   --set executor.enabled=true \
   --set planner.usageSource=metrics-server \
+  --set-string uiBackend.pricing.currency=USD \
+  --set-string "uiBackend.pricing.perHour.${GCP_MACHINE}=${MACHINE_USD_H}" \
+  --set-string "uiBackend.pricing.perHour.${GCP_MACHINE}/spot=${MACHINE_USD_H_SPOT}" \
   "${READINESS_SET[@]}" \
   "${SAFETY_SET[@]}" \
   --set planner.minNodeAge=30s \


### PR DESCRIPTION
Preparation for tomorrow's confirming run on GKE.

## The harness would not have survived

The tooling that made yesterday's run legible lived in a scratch directory outside the repo. A metered cluster is a bad place to be writing tooling, so it moves in: phase snapshots, the per-node overhead measurement `test/fixtures/gke-managed.yaml` was built from, the wait-for-ready and wait-for-reclaim loops, and the teardown receipt.

## The playground had no price, so the money path could not be tested

It now installs with a price for whatever machine it drew, **derived from the cents-per-hour table it already keeps** for the consent line rather than a second one that could drift from it.

The chart ships no price table and never will — this is the operator supplying one for a cluster they are paying for, which is the intended use. Without it the ledger has nothing to price, and the only cluster where that path can be exercised is the one where it wouldn't be.

Verified the rendering rather than assuming it:

```
- name: PRICING
  value: "{\"currency\":\"USD\",\"perHour\":{\"e2-medium\":\"0.03400\",\"e2-medium/spot\":\"0.01133\"}}"
```

Helm turns those into JSON **strings** — `"0.03400"`, not `0.034` — which is exactly the coercion the price parser was made tolerant of in #158. Good to see it exercised for real.

## A checklist, because tomorrow's point is narrow

Everything in v0.5.0 was verified against the fixture and locally. **Nobody has watched it plan on a real managed cluster.**

`hack/capture/CHECKLIST.md` leads with that question and says to stop if it fails, since the other seven items are all downstream of the one answer. Each carries what the behaviour *was* on 2026-08-07 alongside what it should be now, so a regression reads as a regression rather than as a puzzle.

## Verification

`make lint`, `go test ./...`, `gofmt`, `bash -n` on the playground — all clean.