### PR TITLE
One store that speaks two dialects, rather than two stores

### DIFF
--- a/cmd/executor/main.go
+++ b/cmd/executor/main.go
@@ -28,7 +28,7 @@ import (
 	"github.com/atedgimo/k8s-dencer/internal/planner"
 	"github.com/atedgimo/k8s-dencer/internal/safety"
 	"github.com/atedgimo/k8s-dencer/internal/store"
-	sqlitestore "github.com/atedgimo/k8s-dencer/internal/store/sqlite"
+	sqlitestore "github.com/atedgimo/k8s-dencer/internal/store/sqlstore"
 	"github.com/atedgimo/k8s-dencer/internal/telemetry"
 	"github.com/atedgimo/k8s-dencer/internal/window"
 )

--- a/cmd/planner/main.go
+++ b/cmd/planner/main.go
@@ -25,7 +25,7 @@ import (
 	"github.com/atedgimo/k8s-dencer/internal/impact"
 	"github.com/atedgimo/k8s-dencer/internal/planner"
 	"github.com/atedgimo/k8s-dencer/internal/publish"
-	sqlitestore "github.com/atedgimo/k8s-dencer/internal/store/sqlite"
+	sqlitestore "github.com/atedgimo/k8s-dencer/internal/store/sqlstore"
 	"github.com/atedgimo/k8s-dencer/internal/telemetry"
 )
 

--- a/cmd/ui-backend/main.go
+++ b/cmd/ui-backend/main.go
@@ -30,7 +30,7 @@ import (
 	"github.com/atedgimo/k8s-dencer/internal/auth"
 	"github.com/atedgimo/k8s-dencer/internal/httpserver"
 	"github.com/atedgimo/k8s-dencer/internal/pricing"
-	sqlitestore "github.com/atedgimo/k8s-dencer/internal/store/sqlite"
+	sqlitestore "github.com/atedgimo/k8s-dencer/internal/store/sqlstore"
 	"github.com/atedgimo/k8s-dencer/internal/telemetry"
 	"github.com/atedgimo/k8s-dencer/internal/window"
 )

--- a/internal/api/agenttools/agenttools_test.go
+++ b/internal/api/agenttools/agenttools_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/atedgimo/k8s-dencer/internal/constraints"
 	"github.com/atedgimo/k8s-dencer/internal/model"
 	"github.com/atedgimo/k8s-dencer/internal/store"
-	sqlitestore "github.com/atedgimo/k8s-dencer/internal/store/sqlite"
+	sqlitestore "github.com/atedgimo/k8s-dencer/internal/store/sqlstore"
 )
 
 // connect starts the MCP endpoint over HTTP and returns a real MCP client

--- a/internal/api/rest/execute_test.go
+++ b/internal/api/rest/execute_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/atedgimo/k8s-dencer/internal/auth"
 	"github.com/atedgimo/k8s-dencer/internal/model"
 	"github.com/atedgimo/k8s-dencer/internal/store"
-	sqlitestore "github.com/atedgimo/k8s-dencer/internal/store/sqlite"
+	sqlitestore "github.com/atedgimo/k8s-dencer/internal/store/sqlstore"
 )
 
 // denyExecute authorizes reads and refuses execution, so the two permissions

--- a/internal/api/rest/guarded_test.go
+++ b/internal/api/rest/guarded_test.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/atedgimo/k8s-dencer/internal/api/rest"
 	"github.com/atedgimo/k8s-dencer/internal/auth"
-	sqlitestore "github.com/atedgimo/k8s-dencer/internal/store/sqlite"
+	sqlitestore "github.com/atedgimo/k8s-dencer/internal/store/sqlstore"
 )
 
 // openRoutes are the only endpoints permitted to bypass the guard.

--- a/internal/api/rest/rest_test.go
+++ b/internal/api/rest/rest_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/atedgimo/k8s-dencer/internal/constraints"
 	"github.com/atedgimo/k8s-dencer/internal/model"
 	"github.com/atedgimo/k8s-dencer/internal/store"
-	sqlitestore "github.com/atedgimo/k8s-dencer/internal/store/sqlite"
+	sqlitestore "github.com/atedgimo/k8s-dencer/internal/store/sqlstore"
 )
 
 func testServer(t *testing.T, records ...store.Record) *httptest.Server {

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/atedgimo/k8s-dencer/internal/model"
 	"github.com/atedgimo/k8s-dencer/internal/safety"
 	"github.com/atedgimo/k8s-dencer/internal/store"
-	sqlitestore "github.com/atedgimo/k8s-dencer/internal/store/sqlite"
+	sqlitestore "github.com/atedgimo/k8s-dencer/internal/store/sqlstore"
 )
 
 // fakeCluster is an in-memory stand-in that records every mutation in order.

--- a/internal/planner/scale_bench_test.go
+++ b/internal/planner/scale_bench_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/atedgimo/k8s-dencer/internal/model"
 	"github.com/atedgimo/k8s-dencer/internal/planner"
 	"github.com/atedgimo/k8s-dencer/internal/store"
-	sqlitestore "github.com/atedgimo/k8s-dencer/internal/store/sqlite"
+	sqlitestore "github.com/atedgimo/k8s-dencer/internal/store/sqlstore"
 )
 
 // Scale benchmarks over synthesised clusters.

--- a/internal/publish/external_test.go
+++ b/internal/publish/external_test.go
@@ -10,14 +10,14 @@ import (
 
 	"github.com/atedgimo/k8s-dencer/internal/model"
 	"github.com/atedgimo/k8s-dencer/internal/store"
-	"github.com/atedgimo/k8s-dencer/internal/store/sqlite"
+	"github.com/atedgimo/k8s-dencer/internal/store/sqlstore"
 )
 
 // A real store, so the schema migration this needs is exercised too — a fake
 // would have happily accepted a column that does not exist.
-func newStore(t *testing.T) *sqlite.Store {
+func newStore(t *testing.T) *sqlstore.Store {
 	t.Helper()
-	db, err := sqlite.Open(filepath.Join(t.TempDir(), "test.db"))
+	db, err := sqlstore.Open(filepath.Join(t.TempDir(), "test.db"))
 	if err != nil {
 		t.Fatalf("open store: %v", err)
 	}

--- a/internal/publish/publish_test.go
+++ b/internal/publish/publish_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/atedgimo/k8s-dencer/internal/planner"
 	"github.com/atedgimo/k8s-dencer/internal/publish"
 	"github.com/atedgimo/k8s-dencer/internal/store"
-	sqlitestore "github.com/atedgimo/k8s-dencer/internal/store/sqlite"
+	sqlitestore "github.com/atedgimo/k8s-dencer/internal/store/sqlstore"
 	"github.com/atedgimo/k8s-dencer/internal/telemetry"
 )
 

--- a/internal/store/sqlstore/dialect.go
+++ b/internal/store/sqlstore/dialect.go
@@ -1,0 +1,86 @@
+package sqlstore
+
+import (
+	"context"
+	"database/sql"
+	"strconv"
+	"strings"
+)
+
+// dialect is the difference between the two servers this store speaks to.
+//
+// One implementation rather than two. The alternative — a parallel package
+// with its own copy of thirty-two methods — is the mistake this project has
+// now made twice and fixed twice: two things that must agree, kept apart, and
+// discovered to disagree by a user. A store is the product's memory, and two
+// memories that drift are worse than one that is a little more general.
+type dialect int
+
+const (
+	sqliteDialect dialect = iota
+	postgresDialect
+)
+
+func (d dialect) String() string {
+	if d == postgresDialect {
+		return "postgres"
+	}
+	return "sqlite"
+}
+
+// rebind turns the `?` placeholders every query is written with into the
+// `$1, $2` form Postgres requires.
+//
+// Queries are authored once, in SQLite's spelling, because that is what the
+// existing thirteen schema versions and their tests are written against.
+// Rewriting them all to `$N` would have made the SQLite path the translated
+// one, and the translated path is the one that rots.
+//
+// Literals are respected: a `?` inside a quoted string is data, not a
+// placeholder, and rewriting one would corrupt a query in a way no type
+// checker would notice.
+func rebind(d dialect, query string) string {
+	if d != postgresDialect || !strings.ContainsRune(query, '?') {
+		return query
+	}
+	var b strings.Builder
+	b.Grow(len(query) + 8)
+	n := 0
+	inSingle, inDouble := false, false
+	for i := 0; i < len(query); i++ {
+		c := query[i]
+		switch {
+		case c == '\'' && !inDouble:
+			inSingle = !inSingle
+		case c == '"' && !inSingle:
+			inDouble = !inDouble
+		case c == '?' && !inSingle && !inDouble:
+			n++
+			b.WriteByte('$')
+			b.WriteString(strconv.Itoa(n))
+			continue
+		}
+		b.WriteByte(c)
+	}
+	return b.String()
+}
+
+// The three call shapes every method uses, routed through one place so a
+// query cannot reach a server in the wrong dialect.
+func (s *Store) exec(ctx context.Context, q string, args ...any) (sql.Result, error) {
+	return s.db.ExecContext(ctx, rebind(s.d, q), args...)
+}
+
+func (s *Store) query(ctx context.Context, q string, args ...any) (*sql.Rows, error) {
+	return s.db.QueryContext(ctx, rebind(s.d, q), args...)
+}
+
+func (s *Store) queryRow(ctx context.Context, q string, args ...any) *sql.Row {
+	return s.db.QueryRowContext(ctx, rebind(s.d, q), args...)
+}
+
+// txExec is the same for statements inside a transaction, which migrations
+// and Save both use.
+func (s *Store) txExec(ctx context.Context, tx *sql.Tx, q string, args ...any) (sql.Result, error) {
+	return tx.ExecContext(ctx, rebind(s.d, q), args...)
+}

--- a/internal/store/sqlstore/dialect_test.go
+++ b/internal/store/sqlstore/dialect_test.go
@@ -1,0 +1,21 @@
+package sqlstore
+
+import "testing"
+
+func TestRebind(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"SELECT 1", "SELECT 1"},
+		{"SELECT * FROM t WHERE a = ? AND b = ?", "SELECT * FROM t WHERE a = $1 AND b = $2"},
+		{"UPDATE t SET a = ? WHERE id = ? AND s IN (?, ?)", "UPDATE t SET a = $1 WHERE id = $2 AND s IN ($3, $4)"},
+		// A question mark inside a literal is data, not a placeholder.
+		{"SELECT * FROM t WHERE note = 'why?' AND id = ?", "SELECT * FROM t WHERE note = 'why?' AND id = $1"},
+	}
+	for _, c := range cases {
+		if got := rebind(postgresDialect, c.in); got != c.want {
+			t.Errorf("postgres: %q\n got %q\nwant %q", c.in, got, c.want)
+		}
+		if got := rebind(sqliteDialect, c.in); got != c.in {
+			t.Errorf("sqlite must not rewrite: %q -> %q", c.in, got)
+		}
+	}
+}

--- a/internal/store/sqlstore/execution.go
+++ b/internal/store/sqlstore/execution.go
@@ -1,4 +1,4 @@
-package sqlite
+package sqlstore
 
 import (
 	"context"
@@ -42,7 +42,7 @@ func (s *Store) Enqueue(ctx context.Context, run store.Run) (string, error) {
 		}
 	}
 
-	_, err = s.db.ExecContext(ctx, `
+	_, err = s.exec(ctx, `
 		INSERT INTO runs (id, plan_id, steps, dry_run, status, actor, actor_groups, requested_at, mode, envelope, node)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		run.ID, run.PlanID, steps, boolToInt(run.DryRun), string(run.Status),
@@ -64,7 +64,7 @@ func (s *Store) Claim(ctx context.Context, worker string) (store.Run, error) {
 	now := time.Now().UTC().Format(time.RFC3339Nano)
 
 	var id string
-	err := s.db.QueryRowContext(ctx, `
+	err := s.queryRow(ctx, `
 		UPDATE runs
 		SET status = ?, worker = ?, started_at = ?
 		WHERE id = (
@@ -95,7 +95,7 @@ func (s *Store) AppendEvent(ctx context.Context, ev store.RunEvent) error {
 	if ev.Level == "" {
 		ev.Level = store.EventInfo
 	}
-	_, err := s.db.ExecContext(ctx, `
+	_, err := s.exec(ctx, `
 		INSERT INTO run_events (run_id, sequence, at, level, step, node, pod, action, rule, message)
 		VALUES (
 			?,
@@ -116,7 +116,7 @@ func (s *Store) Finish(ctx context.Context, runID string, status store.RunStatus
 	if !status.Terminal() {
 		return fmt.Errorf("cannot finish run %s with non-terminal status %s", runID, status)
 	}
-	res, err := s.db.ExecContext(ctx, `
+	res, err := s.exec(ctx, `
 		UPDATE runs SET status = ?, summary = ?, finished_at = ? WHERE id = ?`,
 		string(status), summary, time.Now().UTC().Format(time.RFC3339Nano), runID)
 	if err != nil {
@@ -130,7 +130,7 @@ func (s *Store) Finish(ctx context.Context, runID string, status store.RunStatus
 
 // RunByID returns one run.
 func (s *Store) RunByID(ctx context.Context, runID string) (store.Run, error) {
-	row := s.db.QueryRowContext(ctx, `
+	row := s.queryRow(ctx, `
 		SELECT id, plan_id, steps, dry_run, status, actor, actor_groups,
 		       requested_at, started_at, finished_at, worker, summary, mode, envelope, node, stop_requested, stop_requested_by
 		FROM runs WHERE id = ?`, runID)
@@ -139,7 +139,7 @@ func (s *Store) RunByID(ctx context.Context, runID string) (store.Run, error) {
 
 // ActiveRun returns the pending or running execution, if any.
 func (s *Store) ActiveRun(ctx context.Context) (store.Run, error) {
-	row := s.db.QueryRowContext(ctx, `
+	row := s.queryRow(ctx, `
 		SELECT id, plan_id, steps, dry_run, status, actor, actor_groups,
 		       requested_at, started_at, finished_at, worker, summary, mode, envelope, node, stop_requested, stop_requested_by
 		FROM runs WHERE status IN (?, ?)
@@ -153,7 +153,7 @@ func (s *Store) RecentRuns(ctx context.Context, limit int) ([]store.Run, error) 
 	if limit <= 0 {
 		limit = 100
 	}
-	rows, err := s.db.QueryContext(ctx, `
+	rows, err := s.query(ctx, `
 		SELECT id, plan_id, steps, dry_run, status, actor, actor_groups,
 		       requested_at, started_at, finished_at, worker, summary, mode, envelope, node, stop_requested, stop_requested_by
 		FROM runs ORDER BY requested_at DESC, rowid DESC LIMIT ?`, limit)
@@ -177,7 +177,7 @@ func (s *Store) RunsForPlan(ctx context.Context, planID string, limit int) ([]st
 	if limit <= 0 {
 		limit = 50
 	}
-	rows, err := s.db.QueryContext(ctx, `
+	rows, err := s.query(ctx, `
 		SELECT id, plan_id, steps, dry_run, status, actor, actor_groups,
 		       requested_at, started_at, finished_at, worker, summary, mode, envelope, node, stop_requested, stop_requested_by
 		FROM runs WHERE plan_id = ? ORDER BY requested_at DESC, rowid DESC LIMIT ?`,
@@ -200,7 +200,7 @@ func (s *Store) RunsForPlan(ctx context.Context, planID string, limit int) ([]st
 
 // Events returns a run's audit trail in order.
 func (s *Store) Events(ctx context.Context, runID string) ([]store.RunEvent, error) {
-	rows, err := s.db.QueryContext(ctx, `
+	rows, err := s.query(ctx, `
 		SELECT sequence, at, level, step, node, pod, action, rule, message
 		FROM run_events WHERE run_id = ? ORDER BY sequence`, runID)
 	if err != nil {
@@ -307,7 +307,7 @@ func newRunID() string {
 // which is the only place it honestly can — a pod already evicted cannot be
 // un-evicted.
 func (s *Store) RequestStop(ctx context.Context, runID, by string) error {
-	_, err := s.db.ExecContext(ctx, `
+	_, err := s.exec(ctx, `
 		UPDATE runs SET stop_requested = 1, stop_requested_by = ?
 		WHERE id = ? AND status IN (?, ?)`,
 		by, runID, string(store.RunPending), string(store.RunRunning))

--- a/internal/store/sqlstore/execution_test.go
+++ b/internal/store/sqlstore/execution_test.go
@@ -1,4 +1,4 @@
-package sqlite_test
+package sqlstore_test
 
 import (
 	"context"

--- a/internal/store/sqlstore/node_samples.go
+++ b/internal/store/sqlstore/node_samples.go
@@ -1,4 +1,4 @@
-package sqlite
+package sqlstore
 
 import (
 	"context"
@@ -55,7 +55,7 @@ func (s *Store) SaveNodeSamples(ctx context.Context, samples []store.NodeSample)
 // capacity was not recorded produces no percentage, which is the honest
 // answer, instead of an infinity.
 func (s *Store) NodeStabilitySince(ctx context.Context, since time.Time) ([]store.NodeStability, error) {
-	rows, err := s.db.QueryContext(ctx, `
+	rows, err := s.query(ctx, `
 		WITH pct AS (
 			SELECT node, taken_at,
 			       (cpu_used_milli * 100.0) / cpu_alloc_milli AS p
@@ -99,7 +99,7 @@ func (s *Store) NodeStabilitySince(ctx context.Context, since time.Time) ([]stor
 
 // PruneNodeSamples removes per-node points older than before.
 func (s *Store) PruneNodeSamples(ctx context.Context, before time.Time) (int, error) {
-	res, err := s.db.ExecContext(ctx,
+	res, err := s.exec(ctx,
 		`DELETE FROM node_samples WHERE taken_at < ?`,
 		before.UTC().Format(time.RFC3339Nano))
 	if err != nil {

--- a/internal/store/sqlstore/node_samples_test.go
+++ b/internal/store/sqlstore/node_samples_test.go
@@ -1,4 +1,4 @@
-package sqlite_test
+package sqlstore_test
 
 import (
 	"context"
@@ -7,12 +7,12 @@ import (
 	"time"
 
 	"github.com/atedgimo/k8s-dencer/internal/store"
-	"github.com/atedgimo/k8s-dencer/internal/store/sqlite"
+	"github.com/atedgimo/k8s-dencer/internal/store/sqlstore"
 )
 
-func nodeStore(t *testing.T) *sqlite.Store {
+func nodeStore(t *testing.T) *sqlstore.Store {
 	t.Helper()
-	db, err := sqlite.Open(filepath.Join(t.TempDir(), "n.db"))
+	db, err := sqlstore.Open(filepath.Join(t.TempDir(), "n.db"))
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}

--- a/internal/store/sqlstore/reclamation.go
+++ b/internal/store/sqlstore/reclamation.go
@@ -1,4 +1,4 @@
-package sqlite
+package sqlstore
 
 import (
 	"context"
@@ -15,7 +15,7 @@ import (
 
 // RecordDrain notes that a node was drained and now awaits reclamation.
 func (s *Store) RecordDrain(ctx context.Context, r store.Reclamation) error {
-	_, err := s.db.ExecContext(ctx, `
+	_, err := s.exec(ctx, `
 		INSERT INTO reclamations (node, drained_at, run_id, plan_id, step, cpu_milli, mem_bytes,
 		                          external, instance_type, capacity_type)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -54,7 +54,7 @@ func (s *Store) Reclamations(ctx context.Context, limit int) ([]store.Reclamatio
 // attributing a fresh event to a stale record.
 func (s *Store) ResolveReclamation(ctx context.Context, node string, drainedAt time.Time,
 	outcome store.ReclamationOutcome, at time.Time) error {
-	res, err := s.db.ExecContext(ctx, `
+	res, err := s.exec(ctx, `
 		UPDATE reclamations SET resolved_at = ?, outcome = ?
 		WHERE node = ? AND drained_at = ? AND resolved_at IS NULL`,
 		at.UTC().Format(time.RFC3339Nano), string(outcome),
@@ -79,13 +79,13 @@ func (s *Store) ReclamationSummary(ctx context.Context, since time.Time) (store.
 	// months ago and still sitting there is the single most interesting row in
 	// this table, and windowing it out would hide exactly the failure this
 	// mechanism exists to surface.
-	if err := s.db.QueryRowContext(ctx,
+	if err := s.queryRow(ctx,
 		`SELECT COUNT(*) FROM reclamations WHERE resolved_at IS NULL`).Scan(&out.Awaiting); err != nil {
 		return out, fmt.Errorf("count pending reclamations: %w", err)
 	}
 
 	cutoff := since.UTC().Format(time.RFC3339Nano)
-	rows, err := s.db.QueryContext(ctx, `
+	rows, err := s.query(ctx, `
 		SELECT outcome, drained_at, resolved_at, cpu_milli, mem_bytes, external FROM reclamations
 		WHERE resolved_at IS NOT NULL AND resolved_at >= ?`, cutoff)
 	if err != nil {
@@ -157,7 +157,7 @@ func median(d []time.Duration) time.Duration {
 }
 
 func (s *Store) queryReclamations(ctx context.Context, query string, args ...any) ([]store.Reclamation, error) {
-	rows, err := s.db.QueryContext(ctx, query, args...)
+	rows, err := s.query(ctx, query, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/store/sqlstore/reclamation_test.go
+++ b/internal/store/sqlstore/reclamation_test.go
@@ -1,4 +1,4 @@
-package sqlite_test
+package sqlstore_test
 
 import (
 	"context"
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/atedgimo/k8s-dencer/internal/store"
-	sqlitestore "github.com/atedgimo/k8s-dencer/internal/store/sqlite"
+	sqlitestore "github.com/atedgimo/k8s-dencer/internal/store/sqlstore"
 )
 
 func reclamationStore(t *testing.T) *sqlitestore.Store {

--- a/internal/store/sqlstore/recoveries.go
+++ b/internal/store/sqlstore/recoveries.go
@@ -1,4 +1,4 @@
-package sqlite
+package sqlstore
 
 import (
 	"context"
@@ -14,7 +14,7 @@ import (
 
 // RecordRecovery notes one workload's time to Ready after an eviction.
 func (s *Store) RecordRecovery(ctx context.Context, workload string, at time.Time, took time.Duration) error {
-	_, err := s.db.ExecContext(ctx, `
+	_, err := s.exec(ctx, `
 		INSERT INTO recoveries (workload, observed_at, took_seconds)
 		VALUES (?, ?, ?)
 		ON CONFLICT (workload, observed_at) DO NOTHING`,
@@ -45,7 +45,7 @@ func (s *Store) RecoveryFor(ctx context.Context, workloads []string) (map[string
 	// Median via window function, the same shape as node stability: the
 	// typical case is what to expect and the worst is what to plan for, and
 	// a mean would let one pathological restart speak for both.
-	rows, err := s.db.QueryContext(ctx, `
+	rows, err := s.query(ctx, `
 		WITH ranked AS (
 			SELECT workload, took_seconds,
 			       ROW_NUMBER()      OVER (PARTITION BY workload ORDER BY took_seconds) AS rn,
@@ -81,7 +81,7 @@ func (s *Store) RecoveryFor(ctx context.Context, workloads []string) (map[string
 // image and probes, which change on a release cadence rather than a daily
 // one, so old observations stay useful far longer than a utilisation point.
 func (s *Store) PruneRecoveries(ctx context.Context, before time.Time) (int, error) {
-	res, err := s.db.ExecContext(ctx,
+	res, err := s.exec(ctx,
 		`DELETE FROM recoveries WHERE observed_at < ?`,
 		before.UTC().Format(time.RFC3339Nano))
 	if err != nil {

--- a/internal/store/sqlstore/recoveries_test.go
+++ b/internal/store/sqlstore/recoveries_test.go
@@ -1,4 +1,4 @@
-package sqlite_test
+package sqlstore_test
 
 import (
 	"context"
@@ -6,12 +6,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/atedgimo/k8s-dencer/internal/store/sqlite"
+	"github.com/atedgimo/k8s-dencer/internal/store/sqlstore"
 )
 
-func recStore(t *testing.T) *sqlite.Store {
+func recStore(t *testing.T) *sqlstore.Store {
 	t.Helper()
-	db, err := sqlite.Open(filepath.Join(t.TempDir(), "r.db"))
+	db, err := sqlstore.Open(filepath.Join(t.TempDir(), "r.db"))
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}

--- a/internal/store/sqlstore/samples.go
+++ b/internal/store/sqlstore/samples.go
@@ -1,4 +1,4 @@
-package sqlite
+package sqlstore
 
 import (
 	"context"
@@ -9,7 +9,7 @@ import (
 )
 
 func (s *Store) SaveSample(ctx context.Context, sm store.Sample) error {
-	_, err := s.db.ExecContext(ctx, `
+	_, err := s.exec(ctx, `
 		INSERT INTO samples (taken_at, nodes, pods,
 			cpu_req_milli, cpu_alloc_milli, mem_req_bytes, mem_alloc_bytes,
 			cpu_used_milli, mem_used_bytes, has_usage, reclaimable)
@@ -24,7 +24,7 @@ func (s *Store) SaveSample(ctx context.Context, sm store.Sample) error {
 }
 
 func (s *Store) Samples(ctx context.Context, since time.Time) ([]store.Sample, error) {
-	rows, err := s.db.QueryContext(ctx, `
+	rows, err := s.query(ctx, `
 		SELECT taken_at, nodes, pods,
 		       cpu_req_milli, cpu_alloc_milli, mem_req_bytes, mem_alloc_bytes,
 		       cpu_used_milli, mem_used_bytes, has_usage, reclaimable
@@ -53,7 +53,7 @@ func (s *Store) Samples(ctx context.Context, since time.Time) ([]store.Sample, e
 }
 
 func (s *Store) PruneSamples(ctx context.Context, before time.Time) (int, error) {
-	res, err := s.db.ExecContext(ctx, `DELETE FROM samples WHERE taken_at < ?`,
+	res, err := s.exec(ctx, `DELETE FROM samples WHERE taken_at < ?`,
 		before.UTC().Format(time.RFC3339Nano))
 	if err != nil {
 		return 0, fmt.Errorf("prune samples: %w", err)

--- a/internal/store/sqlstore/sqlstore.go
+++ b/internal/store/sqlstore/sqlstore.go
@@ -8,7 +8,7 @@
 // pinned to one replica, Recreate rollout strategy, planner co-scheduled onto
 // the same node as the ReadWriteOnce volume — and values.schema.json rejects a
 // configuration that would violate them.
-package sqlite
+package sqlstore
 
 import (
 	"bytes"
@@ -26,9 +26,10 @@ import (
 	"github.com/atedgimo/k8s-dencer/internal/store"
 )
 
-// Store is a SQLite-backed plan store.
+// Store is the plan store, over SQLite or Postgres.
 type Store struct {
 	db *sql.DB
+	d  dialect
 }
 
 // Open connects to the database at path, creating it if absent.
@@ -50,7 +51,7 @@ func Open(path string) (*Store, error) {
 		_ = db.Close()
 		return nil, fmt.Errorf("ping %s: %w", path, err)
 	}
-	return &Store{db: db}, nil
+	return &Store{db: db, d: sqliteDialect}, nil
 }
 
 // Close releases the database handle.
@@ -61,7 +62,7 @@ const schemaVersion = 13
 // Migrate creates or upgrades the schema.
 func (s *Store) Migrate(ctx context.Context) error {
 	var current int
-	if err := s.db.QueryRowContext(ctx, "PRAGMA user_version").Scan(&current); err != nil {
+	if err := s.queryRow(ctx, "PRAGMA user_version").Scan(&current); err != nil {
 		return fmt.Errorf("read schema version: %w", err)
 	}
 	if current >= schemaVersion {
@@ -391,7 +392,7 @@ func (s *Store) Save(ctx context.Context, rec store.Record) (bool, error) {
 		if encErr != nil {
 			return false, fmt.Errorf("encode snapshot: %w", encErr)
 		}
-		touched, err = s.db.ExecContext(ctx,
+		touched, err = s.exec(ctx,
 			`UPDATE plans SET stored_at = ?, pack_ceiling = ?, nodes_before = ?, nodes_after = ?, snapshot = ?
 			 WHERE id = ? AND id = (SELECT id FROM plans ORDER BY stored_at DESC, rowid DESC LIMIT 1)`,
 			storedAt.UTC().Format(time.RFC3339Nano), rec.Plan.PackCeiling,
@@ -410,7 +411,7 @@ func (s *Store) Save(ctx context.Context, rec store.Record) (bool, error) {
 		// after two were removed, while the planner logged nodesBefore:4 on
 		// every cycle. Fresh by timestamp and stale by content is the worst
 		// of the available failures: the reader has no reason to doubt it.
-		touched, err = s.db.ExecContext(ctx,
+		touched, err = s.exec(ctx,
 			`UPDATE plans SET stored_at = ?, pack_ceiling = ?, nodes_before = ?, nodes_after = ?
 			 WHERE id = ? AND id = (SELECT id FROM plans ORDER BY stored_at DESC, rowid DESC LIMIT 1)`,
 			storedAt.UTC().Format(time.RFC3339Nano), rec.Plan.PackCeiling,
@@ -505,7 +506,7 @@ func (s *Store) Save(ctx context.Context, rec store.Record) (bool, error) {
 // Latest returns the most recently stored record.
 func (s *Store) Latest(ctx context.Context) (store.Record, error) {
 	var id string
-	err := s.db.QueryRowContext(ctx,
+	err := s.queryRow(ctx,
 		`SELECT id FROM plans ORDER BY stored_at DESC, rowid DESC LIMIT 1`).Scan(&id)
 	if errors.Is(err, sql.ErrNoRows) {
 		return store.Record{}, store.ErrNotFound
@@ -526,7 +527,7 @@ func (s *Store) ByID(ctx context.Context, id string) (store.Record, error) {
 		nodesBefore, nodesAfter      int
 		packCeiling                  float64
 	)
-	err := s.db.QueryRowContext(ctx, `
+	err := s.queryRow(ctx, `
 		SELECT generated_at, snapshot_taken_at, status, strategy,
 		       nodes_before, nodes_after, pack_ceiling, snapshot, analysis, stored_at
 		FROM plans WHERE id = ?`, id).
@@ -573,7 +574,7 @@ func (s *Store) stepsFor(ctx context.Context, planID string) ([]model.PlanStep, 
 	// consolidated cluster.
 	steps := []model.PlanStep{}
 
-	rows, err := s.db.QueryContext(ctx, `
+	rows, err := s.query(ctx, `
 		SELECT step_id, sequence_number, target_node, moves, impact, rationale, reasons,
 		       executed_at, executed_by, result
 		FROM plan_steps WHERE plan_id = ? ORDER BY sequence_number`, planID)
@@ -620,7 +621,7 @@ func (s *Store) List(ctx context.Context, limit int) ([]store.Summary, error) {
 	if limit <= 0 {
 		limit = 50
 	}
-	rows, err := s.db.QueryContext(ctx, `
+	rows, err := s.query(ctx, `
 		SELECT p.id, p.generated_at, p.snapshot_taken_at, p.status, p.strategy,
 		       p.nodes_before, p.nodes_after, p.stored_at,
 		       (SELECT COUNT(*) FROM plan_steps s WHERE s.plan_id = p.id),
@@ -666,7 +667,7 @@ func (s *Store) Prune(ctx context.Context, keep int) (int, error) {
 	// step IDs that authorized each action — so deleting the plan would leave
 	// the audit trail pointing at nothing, which is worse than keeping a few
 	// extra rows on the volume.
-	res, err := s.db.ExecContext(ctx, `
+	res, err := s.exec(ctx, `
 		DELETE FROM plans WHERE id NOT IN (
 			SELECT id FROM plans ORDER BY stored_at DESC, rowid DESC LIMIT ?
 		)
@@ -746,11 +747,11 @@ func decodeBlob(data []byte, into any) error {
 // ExecForTest runs a statement directly. Test-only: it exists so a test can
 // forge a pre-compression row and prove it is still readable.
 func (s *Store) ExecForTest(ctx context.Context, query string, args ...any) error {
-	_, err := s.db.ExecContext(ctx, query, args...)
+	_, err := s.exec(ctx, query, args...)
 	return err
 }
 
 // QueryRowForTest reads one row directly. Test-only.
 func (s *Store) QueryRowForTest(ctx context.Context, query string, args ...any) *sql.Row {
-	return s.db.QueryRowContext(ctx, query, args...)
+	return s.queryRow(ctx, query, args...)
 }

--- a/internal/store/sqlstore/sqlstore_test.go
+++ b/internal/store/sqlstore/sqlstore_test.go
@@ -1,4 +1,4 @@
-package sqlite_test
+package sqlstore_test
 
 import (
 	"context"
@@ -12,7 +12,7 @@ import (
 	"github.com/atedgimo/k8s-dencer/internal/constraints"
 	"github.com/atedgimo/k8s-dencer/internal/model"
 	"github.com/atedgimo/k8s-dencer/internal/store"
-	sqlitestore "github.com/atedgimo/k8s-dencer/internal/store/sqlite"
+	sqlitestore "github.com/atedgimo/k8s-dencer/internal/store/sqlstore"
 )
 
 func openTemp(t *testing.T) *sqlitestore.Store {

--- a/internal/store/sqlstore/staleness_test.go
+++ b/internal/store/sqlstore/staleness_test.go
@@ -1,4 +1,4 @@
-package sqlite_test
+package sqlstore_test
 
 import (
 	"context"
@@ -8,12 +8,12 @@ import (
 
 	"github.com/atedgimo/k8s-dencer/internal/model"
 	"github.com/atedgimo/k8s-dencer/internal/store"
-	"github.com/atedgimo/k8s-dencer/internal/store/sqlite"
+	"github.com/atedgimo/k8s-dencer/internal/store/sqlstore"
 )
 
-func planStore(t *testing.T) *sqlite.Store {
+func planStore(t *testing.T) *sqlstore.Store {
 	t.Helper()
-	db, err := sqlite.Open(filepath.Join(t.TempDir(), "p.db"))
+	db, err := sqlstore.Open(filepath.Join(t.TempDir(), "p.db"))
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}

--- a/internal/store/sqlstore/upgrade_test.go
+++ b/internal/store/sqlstore/upgrade_test.go
@@ -1,4 +1,4 @@
-package sqlite_test
+package sqlstore_test
 
 import (
 	"context"
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/atedgimo/k8s-dencer/internal/store"
-	"github.com/atedgimo/k8s-dencer/internal/store/sqlite"
+	"github.com/atedgimo/k8s-dencer/internal/store/sqlstore"
 )
 
 // Every other test in this package migrates an empty file, which exercises
@@ -33,7 +33,7 @@ func TestUpgradeFromV040(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	db, err := sqlite.Open(path)
+	db, err := sqlstore.Open(path)
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}


### PR DESCRIPTION
Groundwork for #175. **No second backend yet and no behaviour change** — this is the shape that makes Postgres possible without duplicating the product's memory.

## Why not a second package

A parallel `postgres` package would mean its own copy of thirty-two methods and thirteen schema versions. That is the mistake this project has made twice and fixed twice in the last week: two things that must agree, kept apart, discovered to disagree by a user. Two memories that drift are worse than one that is slightly more general.

So: one store, one set of queries, a dialect.

## What changed

- **`internal/store/sqlite` → `internal/store/sqlstore`.** A Postgres backend inside a package called `sqlite` would be a lie told by a directory name.
- **`Store` gains a dialect**, and every query goes through `exec`/`query`/`queryRow` so a statement cannot reach a server in the wrong spelling.
- **`rebind`** turns the `?` placeholders each query is written with into Postgres's `$1, $2`. Queries stay authored in SQLite's spelling, because that is what thirteen schema versions and their tests are written against — whichever path is the translated one is the path that rots. Literals are respected: a `?` inside a quoted string is data, and rewriting one would corrupt a query in a way no type checker would catch.

## The safety net proved itself immediately

Routing the call sites mechanically rewrote the helpers' own bodies into calls to themselves. The `publish` tests caught it on the first run as a stack overflow — exactly the hazard I flagged when sizing this work on the issue.

## What this does not do

It does not add Postgres. Three things are now known to stand between here and that, and they are recorded on #175 rather than guessed at:

1. **`rowid`** is used in six places as an insertion-order tiebreaker — including the dedup touch that decides whether a plan changed. Postgres has no equivalent, so this needs an explicit monotonic column in both dialects, which is a schema change rather than a translation.
2. **`WITHOUT ROWID`** on two tables has no Postgres meaning and must be dropped for that dialect.
3. **`BLOB` → `BYTEA`, `REAL` → `DOUBLE PRECISION`**, and `PRAGMA user_version` replaced by a version table.

## Verification

`go test ./...`, `gofmt`, `make lint` all green. A `rebind` test covers both dialects including the literal case.