### PR TITLE
Give the store an insertion order it declares itself (schema v14)

### DIFF
--- a/internal/store/sqlstore/execution.go
+++ b/internal/store/sqlstore/execution.go
@@ -43,8 +43,9 @@ func (s *Store) Enqueue(ctx context.Context, run store.Run) (string, error) {
 	}
 
 	_, err = s.exec(ctx, `
-		INSERT INTO runs (id, plan_id, steps, dry_run, status, actor, actor_groups, requested_at, mode, envelope, node)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		INSERT INTO runs (id, plan_id, steps, dry_run, status, actor, actor_groups, requested_at, mode, envelope, node, seq)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+		        (SELECT COALESCE(MAX(seq), 0) + 1 FROM runs))`,
 		run.ID, run.PlanID, steps, boolToInt(run.DryRun), string(run.Status),
 		run.Actor, groups, run.RequestedAt.UTC().Format(time.RFC3339Nano),
 		run.Mode, envelope, run.Node)
@@ -70,7 +71,7 @@ func (s *Store) Claim(ctx context.Context, worker string) (store.Run, error) {
 		WHERE id = (
 			SELECT id FROM runs
 			WHERE status = ?
-			ORDER BY requested_at, rowid
+			ORDER BY requested_at, seq
 			LIMIT 1
 		)
 		RETURNING id`,
@@ -156,7 +157,7 @@ func (s *Store) RecentRuns(ctx context.Context, limit int) ([]store.Run, error) 
 	rows, err := s.query(ctx, `
 		SELECT id, plan_id, steps, dry_run, status, actor, actor_groups,
 		       requested_at, started_at, finished_at, worker, summary, mode, envelope, node, stop_requested, stop_requested_by
-		FROM runs ORDER BY requested_at DESC, rowid DESC LIMIT ?`, limit)
+		FROM runs ORDER BY requested_at DESC, seq DESC LIMIT ?`, limit)
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +181,7 @@ func (s *Store) RunsForPlan(ctx context.Context, planID string, limit int) ([]st
 	rows, err := s.query(ctx, `
 		SELECT id, plan_id, steps, dry_run, status, actor, actor_groups,
 		       requested_at, started_at, finished_at, worker, summary, mode, envelope, node, stop_requested, stop_requested_by
-		FROM runs WHERE plan_id = ? ORDER BY requested_at DESC, rowid DESC LIMIT ?`,
+		FROM runs WHERE plan_id = ? ORDER BY requested_at DESC, seq DESC LIMIT ?`,
 		planID, limit)
 	if err != nil {
 		return nil, err

--- a/internal/store/sqlstore/sqlstore.go
+++ b/internal/store/sqlstore/sqlstore.go
@@ -57,7 +57,7 @@ func Open(path string) (*Store, error) {
 // Close releases the database handle.
 func (s *Store) Close() error { return s.db.Close() }
 
-const schemaVersion = 13
+const schemaVersion = 14
 
 // Migrate creates or upgrades the schema.
 func (s *Store) Migrate(ctx context.Context) error {
@@ -140,6 +140,20 @@ func (s *Store) Migrate(ctx context.Context) error {
 			return fmt.Errorf("apply schema v13: %w", err)
 		}
 	}
+	if current < 14 {
+		if _, err := tx.ExecContext(ctx, schemaV14); err != nil {
+			return fmt.Errorf("apply schema v14: %w", err)
+		}
+		// Existing rows get their order from the one SQLite already knows.
+		// Backfilling from rowid preserves the exact sequence the old queries
+		// were sorting by, so an upgrade cannot silently reorder history.
+		if _, err := tx.ExecContext(ctx, `UPDATE plans SET seq = rowid WHERE seq = 0`); err != nil {
+			return fmt.Errorf("backfill plans.seq: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, `UPDATE runs SET seq = rowid WHERE seq = 0`); err != nil {
+			return fmt.Errorf("backfill runs.seq: %w", err)
+		}
+	}
 
 	// PRAGMA does not accept a bound parameter.
 	if _, err := tx.ExecContext(ctx, fmt.Sprintf("PRAGMA user_version = %d", schemaVersion)); err != nil {
@@ -160,6 +174,28 @@ ALTER TABLE plans ADD COLUMN pack_ceiling REAL NOT NULL DEFAULT 0;
 // recorded by the executor, so the default is correct for all of them.
 const schemaV9 = `
 ALTER TABLE reclamations ADD COLUMN external INTEGER NOT NULL DEFAULT 0;
+`
+
+// Schema v14 — an explicit insertion order.
+//
+// Six queries sorted by SQLite's rowid to break ties between rows sharing a
+// timestamp, and one of them decides whether a plan has changed at all. That
+// works until the store has to speak to a server without a rowid, and it is
+// not a Postgres problem: an implicit ordering nobody declared is a fragile
+// thing to have been depending on anywhere.
+//
+// Assigned by the INSERT itself — `(SELECT COALESCE(MAX(seq), 0) + 1 …)` —
+// rather than by an identity column, because AUTOINCREMENT and BIGSERIAL
+// differ in spelling and this is the one column whose values must mean the
+// same thing in both. One statement, so no read-then-write window: SQLite
+// serialises writers outright, and on Postgres two inserts racing at the same
+// snapshot would tie rather than skip, which degrades to the arbitrary order
+// these queries already had before the column existed.
+const schemaV14 = `
+ALTER TABLE plans ADD COLUMN seq INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE runs  ADD COLUMN seq INTEGER NOT NULL DEFAULT 0;
+CREATE INDEX IF NOT EXISTS plans_seq ON plans (seq DESC);
+CREATE INDEX IF NOT EXISTS runs_seq  ON runs  (seq DESC);
 `
 
 // Schema v13 — a run can be asked to stop. Existing rows were never asked.
@@ -394,7 +430,7 @@ func (s *Store) Save(ctx context.Context, rec store.Record) (bool, error) {
 		}
 		touched, err = s.exec(ctx,
 			`UPDATE plans SET stored_at = ?, pack_ceiling = ?, nodes_before = ?, nodes_after = ?, snapshot = ?
-			 WHERE id = ? AND id = (SELECT id FROM plans ORDER BY stored_at DESC, rowid DESC LIMIT 1)`,
+			 WHERE id = ? AND id = (SELECT id FROM plans ORDER BY stored_at DESC, seq DESC LIMIT 1)`,
 			storedAt.UTC().Format(time.RFC3339Nano), rec.Plan.PackCeiling,
 			rec.Plan.NodesBefore, rec.Plan.NodesAfter, snapshotJSON, rec.Plan.ID)
 	} else {
@@ -413,7 +449,7 @@ func (s *Store) Save(ctx context.Context, rec store.Record) (bool, error) {
 		// of the available failures: the reader has no reason to doubt it.
 		touched, err = s.exec(ctx,
 			`UPDATE plans SET stored_at = ?, pack_ceiling = ?, nodes_before = ?, nodes_after = ?
-			 WHERE id = ? AND id = (SELECT id FROM plans ORDER BY stored_at DESC, rowid DESC LIMIT 1)`,
+			 WHERE id = ? AND id = (SELECT id FROM plans ORDER BY stored_at DESC, seq DESC LIMIT 1)`,
 			storedAt.UTC().Format(time.RFC3339Nano), rec.Plan.PackCeiling,
 			rec.Plan.NodesBefore, rec.Plan.NodesAfter, rec.Plan.ID)
 	}
@@ -446,17 +482,19 @@ func (s *Store) Save(ctx context.Context, rec store.Record) (bool, error) {
 	// A plan ID is a content hash, so an existing row with this ID describes
 	// the same plan; replace it so the newest occurrence carries the current
 	// timestamp rather than resurfacing a stale one.
-	if _, err := tx.ExecContext(ctx, `
+	if _, err := s.txExec(ctx, tx, `
 		INSERT INTO plans (id, generated_at, snapshot_taken_at, status, strategy,
-		                   nodes_before, nodes_after, pack_ceiling, snapshot, analysis, stored_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		                   nodes_before, nodes_after, pack_ceiling, snapshot, analysis, stored_at, seq)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+		        (SELECT COALESCE(MAX(seq), 0) + 1 FROM plans))
 		ON CONFLICT(id) DO UPDATE SET
 		    generated_at = excluded.generated_at,
 		    stored_at    = excluded.stored_at,
 		    status       = excluded.status,
 		    pack_ceiling = excluded.pack_ceiling,
 		    snapshot     = excluded.snapshot,
-		    analysis     = excluded.analysis`,
+		    analysis     = excluded.analysis,
+		    seq          = excluded.seq`,
 		rec.Plan.ID,
 		rec.Plan.GeneratedAt.UTC().Format(time.RFC3339Nano),
 		rec.Plan.SnapshotTakenAt.UTC().Format(time.RFC3339Nano),
@@ -507,7 +545,7 @@ func (s *Store) Save(ctx context.Context, rec store.Record) (bool, error) {
 func (s *Store) Latest(ctx context.Context) (store.Record, error) {
 	var id string
 	err := s.queryRow(ctx,
-		`SELECT id FROM plans ORDER BY stored_at DESC, rowid DESC LIMIT 1`).Scan(&id)
+		`SELECT id FROM plans ORDER BY stored_at DESC, seq DESC LIMIT 1`).Scan(&id)
 	if errors.Is(err, sql.ErrNoRows) {
 		return store.Record{}, store.ErrNotFound
 	}
@@ -628,7 +666,7 @@ func (s *Store) List(ctx context.Context, limit int) ([]store.Summary, error) {
 		       (SELECT COUNT(*) FROM plan_steps s WHERE s.plan_id = p.id AND s.impact = 'Green'),
 		       (SELECT COUNT(*) FROM plan_steps s WHERE s.plan_id = p.id AND s.impact = 'Yellow'),
 		       (SELECT COUNT(*) FROM plan_steps s WHERE s.plan_id = p.id AND s.impact = 'Red')
-		FROM plans p ORDER BY p.stored_at DESC, p.rowid DESC LIMIT ?`, limit)
+		FROM plans p ORDER BY p.stored_at DESC, p.seq DESC LIMIT ?`, limit)
 	if err != nil {
 		return nil, err
 	}
@@ -669,7 +707,7 @@ func (s *Store) Prune(ctx context.Context, keep int) (int, error) {
 	// extra rows on the volume.
 	res, err := s.exec(ctx, `
 		DELETE FROM plans WHERE id NOT IN (
-			SELECT id FROM plans ORDER BY stored_at DESC, rowid DESC LIMIT ?
+			SELECT id FROM plans ORDER BY stored_at DESC, seq DESC LIMIT ?
 		)
 		AND id NOT IN (SELECT DISTINCT plan_id FROM runs)`, keep)
 	if err != nil {

--- a/internal/store/sqlstore/upgrade_test.go
+++ b/internal/store/sqlstore/upgrade_test.go
@@ -2,9 +2,13 @@ package sqlstore_test
 
 import (
 	"context"
+	"database/sql"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	_ "modernc.org/sqlite"
 
 	"github.com/atedgimo/k8s-dencer/internal/store"
 	"github.com/atedgimo/k8s-dencer/internal/store/sqlstore"
@@ -83,5 +87,101 @@ func TestUpgradeFromV040(t *testing.T) {
 	}
 	if run.StopRequested {
 		t.Error("an old run reads as having been asked to stop; nobody could have asked")
+	}
+}
+
+// Schema v14 replaced SQLite's rowid with an explicit seq column, and
+// migration backfills it from rowid so that upgrading cannot silently reorder
+// anybody's history. That claim is only worth making if something checks it,
+// and the single-row fixture cannot: with one plan every ordering agrees.
+//
+// So the fixture is given a second plan sharing the first one's stored_at —
+// the case the tiebreaker exists for — and the upgrade has to keep the newer
+// one newer. Before v14 that answer came from rowid; after it, from seq; an
+// operator must not be able to tell the difference.
+func TestUpgradePreservesPlanOrder(t *testing.T) {
+	src := filepath.Join("..", "..", "..", "test", "fixtures", "stores", "v0.4.0-schema-v8.db")
+	raw, err := os.ReadFile(src)
+	if err != nil {
+		t.Skipf("fixture not available: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "ordered.db")
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Cloned column-by-column from whatever the fixture actually holds rather
+	// than from a written-out v8 column list, so regenerating the fixture
+	// cannot leave this test asserting against a schema that no longer exists.
+	raw2, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cols, err := raw2.Query(`SELECT name FROM pragma_table_info('plans')`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var names []string
+	for cols.Next() {
+		var n string
+		if err := cols.Scan(&n); err != nil {
+			t.Fatal(err)
+		}
+		names = append(names, n)
+	}
+	if err := cols.Err(); err != nil {
+		t.Fatal(err)
+	}
+	_ = cols.Close()
+
+	// Same row, new id, same stored_at: only insertion order separates them.
+	sel := make([]string, len(names))
+	for i, n := range names {
+		sel[i] = n
+		if n == "id" {
+			sel[i] = `'newer'`
+		}
+	}
+	list := strings.Join(names, ", ")
+	if _, err := raw2.Exec(
+		`INSERT INTO plans (` + list + `) SELECT ` + strings.Join(sel, ", ") + ` FROM plans`,
+	); err != nil {
+		t.Fatalf("seeding a second plan: %v", err)
+	}
+	if err := raw2.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	db, err := sqlstore.Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	ctx := context.Background()
+	if err := db.Migrate(ctx); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	rec, err := db.Latest(ctx)
+	if err != nil {
+		t.Fatalf("latest: %v", err)
+	}
+	if rec.Plan.ID != "newer" {
+		t.Errorf("Latest = %q, want \"newer\" — the backfill reordered history, and an operator would open the upgrade on a plan they had already superseded", rec.Plan.ID)
+	}
+
+	// The list is what the UI's history pane reads, and it sorts by the same
+	// pair; a backfill that satisfied one and not the other would be worse
+	// than either, because the two views would disagree.
+	sums, err := db.List(ctx, 10)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(sums) != 2 {
+		t.Fatalf("List = %d plans, want 2", len(sums))
+	}
+	if sums[0].ID != "newer" {
+		t.Errorf("List newest = %q, want \"newer\"; Latest and List disagree about the same two rows", sums[0].ID)
 	}
 }


### PR DESCRIPTION
Part C of #175, and the part that touches the SQLite path everyone is already running — so it is worth reading on its own rather than as a step in the Postgres port.

## Why this is not just a Postgres chore

Six queries broke timestamp ties with SQLite's `rowid`, including the dedup touch, whose rows-affected decides whether a plan has changed at all. Postgres has no `rowid`, and `ctid` moves when a row is updated, so the port needs a real column either way.

But the more honest framing is that an implicit ordering nobody declared is a fragile thing to have been depending on anywhere. Schema v14 writes it down: `seq` on `plans` and `runs`, indexed, in both dialects.

## The upgrade

`Migrate` backfills `UPDATE plans SET seq = rowid WHERE seq = 0` (and the same for `runs`), chosen so an upgrade cannot silently reorder an existing operator's history — the new column starts out meaning exactly what the old ordering meant.

`seq` is assigned by the INSERT itself:

```sql
VALUES (?, …, (SELECT COALESCE(MAX(seq), 0) + 1 FROM plans))
```

rather than by an identity column, because `AUTOINCREMENT` and `BIGSERIAL` differ in spelling and this is the one column whose values must mean the same thing in both. One statement, so there is no read-then-write window: SQLite serialises writers outright, and two Postgres inserts racing at the same snapshot would tie rather than skip — which degrades to the arbitrary order these queries already had before the column existed.

## Test

`TestUpgradePreservesPlanOrder` gives the real v0.4.0 fixture a second plan sharing the first one's `stored_at` — the exact case a tiebreaker exists for, which the single-row fixture could not exercise — and asserts the upgrade keeps the newer one newer through **both** `Latest` and `List`, since a backfill satisfying one and not the other would leave the two views disagreeing about the same two rows.

The second row is cloned column-by-column from `pragma_table_info` rather than from a written-out v8 column list, so regenerating the fixture cannot leave the test asserting against a schema that no longer exists.

I confirmed the test fails when the backfill is broken (`seq = 1` instead of `seq = rowid`) rather than trusting a green run:

```
--- FAIL: TestUpgradePreservesPlanOrder
    Latest = "oldplan01234", want "newer" — the backfill reordered history…
    List newest = "oldplan01234", want "newer"; Latest and List disagree…
```

Full Go suite green. Next in #175: the Postgres DDL translation and `Open`.