### PR TITLE
Teach the store Postgres, and make a real server test it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,27 @@ jobs:
   go:
     name: go test
     runs-on: ubuntu-latest
+
+    # The store speaks to SQLite or to Postgres, and the promise it makes is
+    # that the two behave identically. A real server is the only thing that
+    # can check that promise: the first time this store met one it failed
+    # fourteen tests, thirteen from placeholders never rewritten and one from
+    # a claim that let two executors take the same run — a double drain. None
+    # of it was visible against SQLite.
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: dencer
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
@@ -43,6 +64,15 @@ jobs:
         # -race because the planner, executor and HTTP servers all run
         # concurrently in production and the tests exercise that.
         run: go test -race -count=1 ./...
+
+      - name: store tests against postgres
+        # The same suite, not a second one: DENCER_TEST_POSTGRES redirects
+        # openTemp, so every assertion already written runs again over the
+        # other backend. A separate Postgres suite would only prove that the
+        # tests someone remembered to write twice agree.
+        env:
+          DENCER_TEST_POSTGRES: postgres://postgres:test@localhost:5432/dencer?sslmode=disable
+        run: go test -race -count=1 ./internal/store/...
 
       - name: gofmt
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,13 @@ ui/dist/
 # version named in the filename, kept so the migration path an operator
 # actually takes is tested rather than assumed.
 !test/fixtures/stores/*.db
+# The WAL sidecars are not part of a fixture — they appear the moment anything
+# opens one and are regenerated on the next open. Committed once by accident,
+# and worth excluding by name: a stale -wal sitting beside a fixture can change
+# what that fixture reads as, which would be a very quiet way to break the
+# upgrade test.
+*.db-wal
+*.db-shm
 *.sqlite
 .DS_Store
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/atedgimo/k8s-dencer
 go 1.26.5
 
 require (
+	github.com/jackc/pgx/v5 v5.10.0
 	github.com/modelcontextprotocol/go-sdk v1.7.0
 	github.com/prometheus/client_golang v1.24.1
 	github.com/robfig/cron/v3 v3.0.1
@@ -32,6 +33,9 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
+	github.com/jackc/pgpassfile v1.0.0 // indirect
+	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
+	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,14 @@ github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5T
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674/go.mod h1:r4w70xmWCQKmi1ONH4KIaBptdivuRPyosB9RmPlGEwA=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
+github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
+github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
+github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
+github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
+github.com/jackc/pgx/v5 v5.10.0 h1:VhSvgU2jSli8o3AqIEOTJr7rZwAEUVo4E4XhR94Zfr0=
+github.com/jackc/pgx/v5 v5.10.0/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
+github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
+github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
@@ -124,6 +132,7 @@ github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpE
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=

--- a/internal/store/sqlstore/dialect.go
+++ b/internal/store/sqlstore/dialect.go
@@ -65,6 +65,42 @@ func rebind(d dialect, query string) string {
 	return b.String()
 }
 
+// ddlReplacements is the whole of the type-level difference between the two
+// servers, and it is deliberately a short list rather than a translation
+// layer. Anything longer would mean the schema had grown a SQLite accent, and
+// the honest fix for that is to change the schema, not to teach a translator
+// another word.
+//
+// Ordered longest-first where one pattern contains another, so a replacement
+// cannot eat the prefix of the next.
+var ddlReplacements = []struct{ sqlite, postgres string }{
+	// SQLite stores arbitrary bytes in BLOB; Postgres calls it BYTEA. Every
+	// use is a gzipped or JSON payload the store already marshals itself.
+	{"BLOB", "BYTEA"},
+	// REAL is 4-byte float in Postgres and 8-byte in SQLite. The one column
+	// using it is the packing ceiling, a fraction compared against computed
+	// capacity, so the narrower type would quietly change plan output.
+	{"REAL", "DOUBLE PRECISION"},
+	// A SQLite storage optimisation with no Postgres equivalent and no
+	// meaning there — the tables it applies to are keyed by a text primary
+	// key either way.
+	{") WITHOUT ROWID;", ");"},
+}
+
+// translateDDL rewrites schema statements for the target server.
+//
+// Only DDL goes through here. Queries are portable already: the placeholders
+// are handled by rebind, and ON CONFLICT is spelled the same in both.
+func translateDDL(d dialect, ddl string) string {
+	if d != postgresDialect {
+		return ddl
+	}
+	for _, r := range ddlReplacements {
+		ddl = strings.ReplaceAll(ddl, r.sqlite, r.postgres)
+	}
+	return ddl
+}
+
 // The three call shapes every method uses, routed through one place so a
 // query cannot reach a server in the wrong dialect.
 func (s *Store) exec(ctx context.Context, q string, args ...any) (sql.Result, error) {

--- a/internal/store/sqlstore/execution.go
+++ b/internal/store/sqlstore/execution.go
@@ -64,6 +64,23 @@ func (s *Store) Enqueue(ctx context.Context, run store.Run) (string, error) {
 func (s *Store) Claim(ctx context.Context, worker string) (store.Run, error) {
 	now := time.Now().UTC().Format(time.RFC3339Nano)
 
+	// The one place the two servers need genuinely different SQL, and it is
+	// not cosmetic. SQLite is safe as written: a single writer connection
+	// serialises the whole statement, so the subquery and the update cannot
+	// interleave with another claimer.
+	//
+	// Postgres allows the concurrency that is the entire reason for supporting
+	// it, and there two executors read the same pending run before either
+	// updates it — proven by TestClaimIsAtomicUnderConcurrency, which failed
+	// here the first time this store spoke to a real server. A double claim is
+	// two executors draining the same node, so this is a safety property, not
+	// a throughput one. SKIP LOCKED is the standard work-queue idiom: each
+	// claimer takes the oldest run no other claimer holds a lock on.
+	lock := ""
+	if s.d == postgresDialect {
+		lock = " FOR UPDATE SKIP LOCKED"
+	}
+
 	var id string
 	err := s.queryRow(ctx, `
 		UPDATE runs
@@ -72,7 +89,7 @@ func (s *Store) Claim(ctx context.Context, worker string) (store.Run, error) {
 			SELECT id FROM runs
 			WHERE status = ?
 			ORDER BY requested_at, seq
-			LIMIT 1
+			LIMIT 1`+lock+`
 		)
 		RETURNING id`,
 		string(store.RunRunning), worker, now, string(store.RunPending)).Scan(&id)

--- a/internal/store/sqlstore/rebind_guard_test.go
+++ b/internal/store/sqlstore/rebind_guard_test.go
@@ -1,0 +1,99 @@
+package sqlstore
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"strings"
+	"testing"
+)
+
+// Every query in this package is written with `?` placeholders and rewritten
+// for Postgres by rebind, which only runs if the call goes through exec,
+// query, queryRow or txExec. A statement handed straight to the driver keeps
+// its `?` and Postgres rejects it — "syntax error at end of input", pointing
+// at nothing in particular.
+//
+// Two calls did exactly that, and neither was caught by review or by the
+// SQLite suite; they surfaced only when the store first spoke to a real
+// Postgres, as thirteen failures with one cause. The cost of finding them that
+// way is what this test exists to avoid: it is a compile-time-shaped question
+// — does a placeholder reach the driver unrewritten — so it should not need a
+// server to answer.
+//
+// Raw calls are still allowed. DDL is already translated by the time it is
+// executed, the seq backfill is SQLite-only, and PRAGMA takes no parameters —
+// what none of them may contain is a `?`.
+func TestNoPlaceholderBypassesRebind(t *testing.T) {
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, ".", func(fi fs.FileInfo) bool {
+		return !strings.HasSuffix(fi.Name(), "_test.go")
+	}, 0)
+	if err != nil {
+		t.Fatalf("parse package: %v", err)
+	}
+
+	// The driver-level methods. Reaching one of these means rebind was
+	// skipped, whatever the receiver is called.
+	raw := map[string]bool{"ExecContext": true, "QueryContext": true, "QueryRowContext": true}
+
+	var checked int
+	for _, pkg := range pkgs {
+		for name, file := range pkg.Files {
+			// dialect.go is where the helpers wrap the driver; those calls are
+			// the rewrite, not a bypass of it.
+			if strings.HasSuffix(name, "dialect.go") {
+				continue
+			}
+			ast.Inspect(file, func(n ast.Node) bool {
+				call, ok := n.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				sel, ok := call.Fun.(*ast.SelectorExpr)
+				if !ok || !raw[sel.Sel.Name] || len(call.Args) < 2 {
+					return true
+				}
+				checked++
+				if !containsPlaceholder(call.Args[1]) {
+					return true
+				}
+				pos := fset.Position(call.Pos())
+				t.Errorf("%s:%d: %s is called directly with a query containing `?`, so rebind never runs and Postgres will reject it — route it through s.exec/s.query/s.queryRow/s.txExec",
+					pos.Filename, pos.Line, sel.Sel.Name)
+				return true
+			})
+		}
+	}
+
+	// A test that silently inspects nothing would pass forever after a
+	// refactor renamed the methods it looks for.
+	if checked == 0 {
+		t.Fatal("found no direct driver calls at all; this guard is no longer looking at anything")
+	}
+}
+
+// containsPlaceholder reports whether a query expression has a `?` in any of
+// its literal parts. Concatenation is handled because the claim query builds
+// its locking clause that way.
+func containsPlaceholder(e ast.Expr) bool {
+	switch v := e.(type) {
+	case *ast.BasicLit:
+		return v.Kind == token.STRING && strings.Contains(v.Value, "?")
+	case *ast.BinaryExpr:
+		return containsPlaceholder(v.X) || containsPlaceholder(v.Y)
+	case *ast.Ident:
+		// A constant holding a query. Resolve it if it is declared in this
+		// file, so schema constants and query constants are both covered.
+		if v.Obj == nil {
+			return false
+		}
+		spec, ok := v.Obj.Decl.(*ast.ValueSpec)
+		if !ok || len(spec.Values) == 0 {
+			return false
+		}
+		return containsPlaceholder(spec.Values[0])
+	}
+	return false
+}

--- a/internal/store/sqlstore/sqlstore.go
+++ b/internal/store/sqlstore/sqlstore.go
@@ -1,13 +1,22 @@
-// Package sqlite implements the plan store on SQLite.
+// Package sqlstore implements the plan store, on SQLite or on Postgres.
 //
-// modernc.org/sqlite is used rather than mattn/go-sqlite3 because it is pure
-// Go: the components ship on distroless/static with a CGO-free build, and a
-// cgo driver would break that.
+// One implementation over both, differing only where the servers genuinely
+// differ: placeholder spelling (rebind), a handful of DDL types
+// (translateDDL), and where the schema version is kept. Every query, every
+// migration and every test is shared, because a store is the product's memory
+// and two memories that drift are worse than one that is a little more
+// general.
 //
-// SQLite is single-writer. The chart enforces the consequences — ui-backend
+// Both drivers are pure Go — modernc.org/sqlite rather than mattn/go-sqlite3,
+// and pgx's database/sql driver — because the components ship on
+// distroless/static with a CGO-free build, and a cgo driver would break that.
+//
+// SQLite is single-writer, and the chart enforces the consequences: ui-backend
 // pinned to one replica, Recreate rollout strategy, planner co-scheduled onto
-// the same node as the ReadWriteOnce volume — and values.schema.json rejects a
-// configuration that would violate them.
+// the same node as the ReadWriteOnce volume, with values.schema.json rejecting
+// a configuration that would violate them. Postgres is the reason those
+// constraints can be lifted — it is not a second way to store the same data so
+// much as the way to stop pinning the product to one node.
 package sqlstore
 
 import (
@@ -20,6 +29,7 @@ import (
 	"fmt"
 	"time"
 
+	_ "github.com/jackc/pgx/v5/stdlib"
 	_ "modernc.org/sqlite"
 
 	"github.com/atedgimo/k8s-dencer/internal/model"
@@ -54,16 +64,56 @@ func Open(path string) (*Store, error) {
 	return &Store{db: db, d: sqliteDialect}, nil
 }
 
+// OpenPostgres connects to the Postgres server named by dsn.
+//
+// The DSN is passed through to the driver rather than assembled from parts,
+// so sslmode, connect_timeout and the rest are the operator's to set and this
+// code has no opinion it could get wrong. It carries a password, so it is
+// never logged: the errors below name the failure, not the string.
+func OpenPostgres(ctx context.Context, dsn string) (*Store, error) {
+	db, err := sql.Open("pgx", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("open postgres: %w", err)
+	}
+	// Unlike SQLite there is no single-writer rule to honour, which is the
+	// point of supporting it. The pool is left small because this store's
+	// traffic is one planner writing and a handful of readers, not because it
+	// has to be.
+	db.SetMaxOpenConns(10)
+	db.SetMaxIdleConns(2)
+	db.SetConnMaxLifetime(time.Hour)
+
+	if err := db.PingContext(ctx); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("ping postgres: %w", err)
+	}
+	return &Store{db: db, d: postgresDialect}, nil
+}
+
 // Close releases the database handle.
 func (s *Store) Close() error { return s.db.Close() }
 
 const schemaVersion = 14
 
+// migrations are the schema versions in order; index i holds the statements
+// that take the database from version i to i+1.
+//
+// A table rather than fourteen near-identical if-blocks, so adding v15 is one
+// line and cannot be got subtly wrong — the previous shape had the version
+// number written three times per step, which is three chances to typo a
+// number that decides whether an operator's database is upgraded or skipped.
+func migrations() []string {
+	return []string{
+		schemaV1, schemaV2, schemaV3, schemaV4, schemaV5, schemaV6, schemaV7,
+		schemaV8, schemaV9, schemaV10, schemaV11, schemaV12, schemaV13, schemaV14,
+	}
+}
+
 // Migrate creates or upgrades the schema.
 func (s *Store) Migrate(ctx context.Context) error {
-	var current int
-	if err := s.queryRow(ctx, "PRAGMA user_version").Scan(&current); err != nil {
-		return fmt.Errorf("read schema version: %w", err)
+	current, err := s.schemaVersionOf(ctx)
+	if err != nil {
+		return err
 	}
 	if current >= schemaVersion {
 		return nil
@@ -75,91 +125,86 @@ func (s *Store) Migrate(ctx context.Context) error {
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	if current < 1 {
-		if _, err := tx.ExecContext(ctx, schemaV1); err != nil {
-			return fmt.Errorf("apply schema v1: %w", err)
+	for i, ddl := range migrations() {
+		v := i + 1
+		if current >= v {
+			continue
 		}
-	}
-	if current < 2 {
-		if _, err := tx.ExecContext(ctx, schemaV2); err != nil {
-			return fmt.Errorf("apply schema v2: %w", err)
+		if _, err := tx.ExecContext(ctx, translateDDL(s.d, ddl)); err != nil {
+			return fmt.Errorf("apply schema v%d: %w", v, err)
 		}
-	}
-	if current < 3 {
-		if _, err := tx.ExecContext(ctx, schemaV3); err != nil {
-			return fmt.Errorf("apply schema v3: %w", err)
-		}
-	}
-	if current < 4 {
-		if _, err := tx.ExecContext(ctx, schemaV4); err != nil {
-			return fmt.Errorf("apply schema v4: %w", err)
-		}
-	}
-	if current < 5 {
-		if _, err := tx.ExecContext(ctx, schemaV5); err != nil {
-			return fmt.Errorf("apply schema v5: %w", err)
-		}
-	}
-	if current < 6 {
-		if _, err := tx.ExecContext(ctx, schemaV6); err != nil {
-			return fmt.Errorf("apply schema v6: %w", err)
-		}
-	}
-	if current < 7 {
-		if _, err := tx.ExecContext(ctx, schemaV7); err != nil {
-			return fmt.Errorf("apply schema v7: %w", err)
-		}
-	}
-	if current < 8 {
-		if _, err := tx.ExecContext(ctx, schemaV8); err != nil {
-			return fmt.Errorf("apply schema v8: %w", err)
-		}
-	}
-	if current < 9 {
-		if _, err := tx.ExecContext(ctx, schemaV9); err != nil {
-			return fmt.Errorf("apply schema v9: %w", err)
-		}
-	}
-	if current < 10 {
-		if _, err := tx.ExecContext(ctx, schemaV10); err != nil {
-			return fmt.Errorf("apply schema v10: %w", err)
-		}
-	}
-	if current < 11 {
-		if _, err := tx.ExecContext(ctx, schemaV11); err != nil {
-			return fmt.Errorf("apply schema v11: %w", err)
-		}
-	}
-	if current < 12 {
-		if _, err := tx.ExecContext(ctx, schemaV12); err != nil {
-			return fmt.Errorf("apply schema v12: %w", err)
-		}
-	}
-	if current < 13 {
-		if _, err := tx.ExecContext(ctx, schemaV13); err != nil {
-			return fmt.Errorf("apply schema v13: %w", err)
-		}
-	}
-	if current < 14 {
-		if _, err := tx.ExecContext(ctx, schemaV14); err != nil {
-			return fmt.Errorf("apply schema v14: %w", err)
-		}
-		// Existing rows get their order from the one SQLite already knows.
-		// Backfilling from rowid preserves the exact sequence the old queries
-		// were sorting by, so an upgrade cannot silently reorder history.
-		if _, err := tx.ExecContext(ctx, `UPDATE plans SET seq = rowid WHERE seq = 0`); err != nil {
-			return fmt.Errorf("backfill plans.seq: %w", err)
-		}
-		if _, err := tx.ExecContext(ctx, `UPDATE runs SET seq = rowid WHERE seq = 0`); err != nil {
-			return fmt.Errorf("backfill runs.seq: %w", err)
+		if v == 14 {
+			if err := s.backfillSeq(ctx, tx); err != nil {
+				return err
+			}
 		}
 	}
 
-	// PRAGMA does not accept a bound parameter.
-	if _, err := tx.ExecContext(ctx, fmt.Sprintf("PRAGMA user_version = %d", schemaVersion)); err != nil {
-		return fmt.Errorf("set schema version: %w", err)
+	if err := s.setSchemaVersion(ctx, tx, schemaVersion); err != nil {
+		return err
 	}
 	return tx.Commit()
+}
+
+// backfillSeq gives rows that predate v14 the order the old queries sorted
+// them by, so an upgrade cannot silently reorder anybody's history.
+//
+// SQLite-only, and not as an optimisation: `rowid` is not a column in
+// Postgres, so the statement fails when the query is parsed — on an empty
+// table as readily as a full one. It is never needed there. A Postgres
+// database is created by this code at the current version and cannot predate
+// the column, so there is nothing older to backfill from.
+func (s *Store) backfillSeq(ctx context.Context, tx *sql.Tx) error {
+	if s.d == postgresDialect {
+		return nil
+	}
+	for _, t := range []string{"plans", "runs"} {
+		if _, err := tx.ExecContext(ctx, "UPDATE "+t+" SET seq = rowid WHERE seq = 0"); err != nil {
+			return fmt.Errorf("backfill %s.seq: %w", t, err)
+		}
+	}
+	return nil
+}
+
+// schemaVersionOf reads the version the database is currently at.
+//
+// SQLite keeps it in the file header, which is free and needs no table.
+// Postgres has no equivalent, so the version lives in a table of its own —
+// created here, because it has to exist before the first migration can ask
+// what version the database is.
+func (s *Store) schemaVersionOf(ctx context.Context) (int, error) {
+	if s.d == postgresDialect {
+		if _, err := s.exec(ctx, `CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL)`); err != nil {
+			return 0, fmt.Errorf("create schema_version: %w", err)
+		}
+		var v sql.NullInt64
+		if err := s.queryRow(ctx, `SELECT MAX(version) FROM schema_version`).Scan(&v); err != nil {
+			return 0, fmt.Errorf("read schema version: %w", err)
+		}
+		return int(v.Int64), nil
+	}
+	var current int
+	if err := s.queryRow(ctx, "PRAGMA user_version").Scan(&current); err != nil {
+		return 0, fmt.Errorf("read schema version: %w", err)
+	}
+	return current, nil
+}
+
+func (s *Store) setSchemaVersion(ctx context.Context, tx *sql.Tx, v int) error {
+	if s.d == postgresDialect {
+		if _, err := s.txExec(ctx, tx, `DELETE FROM schema_version`); err != nil {
+			return fmt.Errorf("set schema version: %w", err)
+		}
+		if _, err := s.txExec(ctx, tx, `INSERT INTO schema_version (version) VALUES (?)`, v); err != nil {
+			return fmt.Errorf("set schema version: %w", err)
+		}
+		return nil
+	}
+	// PRAGMA does not accept a bound parameter.
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf("PRAGMA user_version = %d", v)); err != nil {
+		return fmt.Errorf("set schema version: %w", err)
+	}
+	return nil
 }
 
 // v8: the plan records the packing ceiling it was computed under, so the
@@ -510,7 +555,7 @@ func (s *Store) Save(ctx context.Context, rec store.Record) (bool, error) {
 		return false, fmt.Errorf("insert plan: %w", err)
 	}
 
-	if _, err := tx.ExecContext(ctx, `DELETE FROM plan_steps WHERE plan_id = ?`, rec.Plan.ID); err != nil {
+	if _, err := s.txExec(ctx, tx, `DELETE FROM plan_steps WHERE plan_id = ?`, rec.Plan.ID); err != nil {
 		return false, fmt.Errorf("clear steps: %w", err)
 	}
 
@@ -523,7 +568,7 @@ func (s *Store) Save(ctx context.Context, rec store.Record) (bool, error) {
 		if err != nil {
 			return false, fmt.Errorf("encode reasons: %w", err)
 		}
-		if _, err := tx.ExecContext(ctx, `
+		if _, err := s.txExec(ctx, tx, `
 			INSERT INTO plan_steps (plan_id, step_id, sequence_number, target_node, moves,
 			                        impact, rationale, reasons, requires_maintenance_window)
 			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,

--- a/internal/store/sqlstore/sqlstore_test.go
+++ b/internal/store/sqlstore/sqlstore_test.go
@@ -2,12 +2,17 @@ package sqlstore_test
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
 
 	"github.com/atedgimo/k8s-dencer/internal/constraints"
 	"github.com/atedgimo/k8s-dencer/internal/model"
@@ -15,14 +20,84 @@ import (
 	sqlitestore "github.com/atedgimo/k8s-dencer/internal/store/sqlstore"
 )
 
+// openTemp is a migrated, empty store — and the single lever that decides
+// which server the whole suite runs against.
+//
+// With DENCER_TEST_POSTGRES set to a DSN, every test that calls this runs
+// against a real Postgres instead of a temp file. Not a second suite of
+// Postgres tests: the same assertions, because the promise being made is that
+// the two backends behave identically, and a separate suite would only ever
+// prove that the tests someone remembered to write twice agree.
 func openTemp(t *testing.T) *sqlitestore.Store {
 	t.Helper()
+	if dsn := os.Getenv("DENCER_TEST_POSTGRES"); dsn != "" {
+		return openTempPostgres(t, dsn)
+	}
 	s, err := sqlitestore.Open(filepath.Join(t.TempDir(), "test.db"))
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
 	t.Cleanup(func() { _ = s.Close() })
 	if err := s.Migrate(context.Background()); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return s
+}
+
+// openTempPostgres gives each test its own schema on the shared server, which
+// is what t.TempDir() buys the SQLite path: tests that cannot see each other's
+// rows, and can therefore run in any order.
+func openTempPostgres(t *testing.T, dsn string) *sqlitestore.Store {
+	t.Helper()
+	ctx := context.Background()
+
+	// Derived from the test name so a failure names the schema it left
+	// behind, and sanitised because test names contain slashes and spaces
+	// that are not identifier characters.
+	schema := "t_" + strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			return r
+		case r >= 'A' && r <= 'Z':
+			return r + 32
+		default:
+			return '_'
+		}
+	}, t.Name())
+	if len(schema) > 60 {
+		schema = schema[:60]
+	}
+
+	admin, err := sql.Open("pgx", dsn)
+	if err != nil {
+		t.Fatalf("open postgres: %v", err)
+	}
+	defer func() { _ = admin.Close() }()
+	if _, err := admin.ExecContext(ctx, `DROP SCHEMA IF EXISTS `+schema+` CASCADE`); err != nil {
+		t.Fatalf("reset schema: %v", err)
+	}
+	if _, err := admin.ExecContext(ctx, `CREATE SCHEMA `+schema); err != nil {
+		t.Fatalf("create schema: %v", err)
+	}
+
+	sep := "?"
+	if strings.Contains(dsn, "?") {
+		sep = "&"
+	}
+	s, err := sqlitestore.OpenPostgres(ctx, dsn+sep+"search_path="+schema)
+	if err != nil {
+		t.Fatalf("open postgres: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = s.Close()
+		// Best effort: a left-behind schema costs nothing but a name, and
+		// failing cleanup would mask the assertion that actually failed.
+		if db, err := sql.Open("pgx", dsn); err == nil {
+			_, _ = db.ExecContext(ctx, `DROP SCHEMA IF EXISTS `+schema+` CASCADE`)
+			_ = db.Close()
+		}
+	})
+	if err := s.Migrate(ctx); err != nil {
 		t.Fatalf("migrate: %v", err)
 	}
 	return s


### PR DESCRIPTION
Part C+D of #175. **Stacked on #177** — retarget to `main` once that merges.

Postgres is not really a second way to store the same data; it is the way to stop pinning the product to one node. SQLite's single writer is what forces the replica pin, the Recreate strategy and the co-scheduling affinity, and part E lifts those.

## How much of the two servers actually differs

Less than expected, which is the argument for one store rather than two:

| SQLite | Postgres |
|---|---|
| `BLOB` | `BYTEA` |
| `REAL` | `DOUBLE PRECISION` |
| `WITHOUT ROWID` | dropped |
| `PRAGMA user_version` | a `schema_version` table |
| claim serialised by the single writer | `FOR UPDATE SKIP LOCKED` |

`REAL` is not cosmetic: Postgres `REAL` is 4-byte, and the one column using it is the packing ceiling, compared against computed capacity — the narrower type would quietly change plan output.

`Migrate` is now a table of versions rather than fourteen near-identical if-blocks, which had the version number written three times per step. The v14 `seq` backfill is SQLite-only and not as an optimisation: `rowid` is not a column in Postgres, so the statement fails when the query is *parsed*, empty table or not. Nothing there can predate the column.

## The same suite, over both backends

`DENCER_TEST_POSTGRES` redirects `openTemp`, so all 23 existing store tests run again against a real server — the same assertions, because the promise being made is that the two backends behave identically, and a separate Postgres suite would only ever prove that the tests someone remembered to write twice agree. Each test gets its own schema, which is what `t.TempDir()` buys the SQLite path.

CI runs it against a `postgres:16-alpine` service.

## It found two real bugs on the first run — fourteen failures, two causes

**Thirteen were one cause.** Two statements called `tx.ExecContext` directly, so `rebind` never ran and the `?` reached Postgres verbatim (`syntax error at end of input`, pointing at nothing in particular). Both now go through `s.txExec`.

`TestNoPlaceholderBypassesRebind` walks the package AST and fails on any direct driver call whose query contains a `?`, so the next one is caught without needing a server — it is a compile-time-shaped question. Raw calls are still allowed where they are correct (already-translated DDL, the SQLite-only backfill, `PRAGMA`); what none of them may contain is a placeholder.

**One was a safety bug.** `Claim` selects the oldest pending run and updates it. SQLite serialises that on its single writer connection, but Postgres let two executors read the same row before either wrote — *two executors draining the same node*. `TestClaimIsAtomicUnderConcurrency` caught it, having passed on SQLite since the day it was written. Fixed with `FOR UPDATE SKIP LOCKED`, applied only where there is concurrency to guard against.

## Verification

- Both guard tests confirmed to **fail when their bug is reintroduced**, not merely to pass.
- Full suite green on SQLite.
- Store suite green against a real Postgres 16 — three consecutive runs (the claim test is the race-sensitive one) and once under `-race`.

Still to come in #175: part E, the chart wiring, where the replica pin and PriorityClass become conditional on the backend.