### PR TITLE
Let an install choose Postgres, and drop what SQLite needed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,27 @@ jobs:
   go:
     name: go test
     runs-on: ubuntu-latest
+
+    # The store speaks to SQLite or to Postgres, and the promise it makes is
+    # that the two behave identically. A real server is the only thing that
+    # can check that promise: the first time this store met one it failed
+    # fourteen tests, thirteen from placeholders never rewritten and one from
+    # a claim that let two executors take the same run — a double drain. None
+    # of it was visible against SQLite.
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: dencer
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
@@ -43,6 +64,15 @@ jobs:
         # -race because the planner, executor and HTTP servers all run
         # concurrently in production and the tests exercise that.
         run: go test -race -count=1 ./...
+
+      - name: store tests against postgres
+        # The same suite, not a second one: DENCER_TEST_POSTGRES redirects
+        # openTemp, so every assertion already written runs again over the
+        # other backend. A separate Postgres suite would only prove that the
+        # tests someone remembered to write twice agree.
+        env:
+          DENCER_TEST_POSTGRES: postgres://postgres:test@localhost:5432/dencer?sslmode=disable
+        run: go test -race -count=1 ./internal/store/...
 
       - name: gofmt
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,13 @@ ui/dist/
 # version named in the filename, kept so the migration path an operator
 # actually takes is tested rather than assumed.
 !test/fixtures/stores/*.db
+# The WAL sidecars are not part of a fixture — they appear the moment anything
+# opens one and are regenerated on the next open. Committed once by accident,
+# and worth excluding by name: a stale -wal sitting beside a fixture can change
+# what that fixture reads as, which would be a very quiet way to break the
+# upgrade test.
+*.db-wal
+*.db-shm
 *.sqlite
 .DS_Store
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ flowchart LR
 
     subgraph dencer["k8s-dencer"]
         P["planner<br/>informers → analyze → plan"]
-        DB[("plan store<br/>SQLite")]
+        DB[("plan store<br/>SQLite or Postgres")]
         B["ui-backend<br/>REST + SSE · authn/authz"]
         F["ui-frontend"]
         E["executor<br/>cordon → evict → verify"]

--- a/charts/k8s-dencer/templates/NOTES.txt
+++ b/charts/k8s-dencer/templates/NOTES.txt
@@ -81,7 +81,14 @@ beyond a private cluster.
 {{- end }}
 
 {{ if eq .Values.database.type "sqlite" -}}
+{{- if eq .Values.database.type "postgres" }}
+Plan store: Postgres at {{ .Values.database.postgres.host }}:{{ .Values.database.postgres.port }}/{{ .Values.database.postgres.database }} (sslmode={{ .Values.database.postgres.sslMode }}). The schema is created on first start; the database itself must already exist.
+{{- if not .Values.database.postgres.existingSecret }}
+  No existingSecret is set, so no password is sent. That works only if the server authenticates this user another way (trust, peer, or a client certificate).
+{{- end }}
+{{- else }}
 Plan store: SQLite at {{ .Values.database.sqlite.path }}{{ if .Values.persistence.enabled }} on PVC {{ include "k8s-dencer.pvcName" . }}{{ else }} on an emptyDir (NOT durable — plan history is lost on restart){{ end }}.
+{{- end }}
 SQLite is single-writer, so ui-backend is pinned to one replica and the planner
 is co-scheduled with it. Switch database.type to postgres in Phase 2 to lift both.
 {{- end }}

--- a/charts/k8s-dencer/templates/_helpers.tpl
+++ b/charts/k8s-dencer/templates/_helpers.tpl
@@ -132,3 +132,56 @@ qualified because the agent may live in a different namespace.
 {{- define "k8s-dencer.uiBackendURL" -}}
 {{- printf "http://%s-ui-backend.%s.svc:%v" (include "k8s-dencer.fullname" .) .Release.Namespace .Values.uiBackend.service.port -}}
 {{- end }}
+
+{{/*
+The plan store environment, shared by planner, executor and ui-backend.
+
+One definition because the three components must agree about which database
+they are talking to. They did not: ui-backend had a postgres branch, planner
+had none, and executor set no DATABASE_TYPE at all — so selecting postgres
+would have left the executor quietly opening a SQLite file nobody else was
+writing to, with no error anywhere. A disagreement about the store is invisible
+at deploy time and looks like lost plans at run time.
+
+The password is never a value and never appears in the rendered manifest; it
+is read from a Secret the operator already has.
+*/}}
+{{- define "k8s-dencer.databaseEnv" -}}
+- name: DATABASE_TYPE
+  value: {{ .Values.database.type | quote }}
+{{- if eq .Values.database.type "sqlite" }}
+- name: DATABASE_PATH
+  value: {{ .Values.database.sqlite.path | quote }}
+{{- else }}
+- name: POSTGRES_HOST
+  value: {{ .Values.database.postgres.host | quote }}
+- name: POSTGRES_PORT
+  value: {{ .Values.database.postgres.port | quote }}
+- name: POSTGRES_DATABASE
+  value: {{ .Values.database.postgres.database | quote }}
+- name: POSTGRES_USER
+  value: {{ .Values.database.postgres.user | quote }}
+- name: POSTGRES_SSLMODE
+  value: {{ .Values.database.postgres.sslMode | quote }}
+{{- with .Values.database.postgres.existingSecret }}
+- name: POSTGRES_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ . }}
+      key: {{ $.Values.database.postgres.existingSecretPasswordKey }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Whether the plan store is a file this pod has to mount.
+
+True only for SQLite. Postgres is reached over the network, so the data
+volume, the claim behind it, the co-scheduling affinity and the Recreate
+strategy all stop being necessary — those exist to keep two writers off one
+file, and there is no file. Mounting a claim anyway would quietly reimpose the
+single-node constraint that choosing Postgres was meant to lift.
+*/}}
+{{- define "k8s-dencer.mountsDataVolume" -}}
+{{- if eq .Values.database.type "sqlite" }}true{{ end -}}
+{{- end -}}

--- a/charts/k8s-dencer/templates/executor/deployment.yaml
+++ b/charts/k8s-dencer/templates/executor/deployment.yaml
@@ -9,8 +9,9 @@ Three properties are deliberate:
   - One replica, always. Two executors would each be making placement
     decisions the other invalidates. The store's atomic claim would stop them
     taking the same run, but not from draining two nodes at once.
-  - Recreate, not RollingUpdate. It shares the SQLite volume with the planner
-    and ui-backend, and an overlap would put two writers on one file.
+  - Recreate, not RollingUpdate, on both backends. On SQLite an overlap would
+    put two writers on one file; on Postgres that reason is gone but the one
+    above is not, and a rolling update is exactly the overlap it forbids.
 */}}
 apiVersion: apps/v1
 kind: Deployment
@@ -63,8 +64,7 @@ spec:
               value: {{ .Values.executor.logLevel | quote }}
             - name: HTTP_ADDR
               value: ":{{ .Values.executor.probePort }}"
-            - name: DATABASE_PATH
-              value: {{ .Values.database.sqlite.path | quote }}
+            {{- include "k8s-dencer.databaseEnv" . | nindent 12 }}
             # Identifies this executor in claims and audit events, so a run can
             # be traced back to a specific pod.
             - name: POD_NAME
@@ -137,14 +137,17 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+            {{- if include "k8s-dencer.mountsDataVolume" . }}
             - name: data
               mountPath: {{ dir .Values.database.sqlite.path }}
+            {{- end }}
             {{- with .Values.executor.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
       volumes:
         - name: tmp
           emptyDir: {}
+        {{- if include "k8s-dencer.mountsDataVolume" . }}
         - name: data
           {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:
@@ -154,6 +157,7 @@ spec:
           # never see a queued run. values.schema.json rejects that combination.
           emptyDir: {}
           {{- end }}
+        {{- end }}
         {{- with .Values.executor.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/k8s-dencer/templates/planner/deployment.yaml
+++ b/charts/k8s-dencer/templates/planner/deployment.yaml
@@ -82,12 +82,7 @@ spec:
               value: {{ .Values.planner.usageSource | quote }}
             - name: RETAIN_PLANS
               value: {{ .Values.planner.retainPlans | quote }}
-            - name: DATABASE_TYPE
-              value: {{ .Values.database.type | quote }}
-            {{- if eq .Values.database.type "sqlite" }}
-            - name: DATABASE_PATH
-              value: {{ .Values.database.sqlite.path | quote }}
-            {{- end }}
+            {{- include "k8s-dencer.databaseEnv" . | nindent 12 }}
             - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -124,14 +119,17 @@ spec:
             # must be an explicit volume.
             - name: tmp
               mountPath: /tmp
+            {{- if include "k8s-dencer.mountsDataVolume" . }}
             - name: data
               mountPath: {{ dir .Values.database.sqlite.path }}
+            {{- end }}
             {{- with .Values.planner.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
       volumes:
         - name: tmp
           emptyDir: {}
+        {{- if include "k8s-dencer.mountsDataVolume" . }}
         - name: data
           {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:
@@ -141,6 +139,7 @@ spec:
           # ephemeral test installs.
           emptyDir: {}
           {{- end }}
+        {{- end }}
         {{- with .Values.planner.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/k8s-dencer/templates/pvc.yaml
+++ b/charts/k8s-dencer/templates/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+{{- if and (include "k8s-dencer.mountsDataVolume" .) .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/charts/k8s-dencer/templates/ui-backend/deployment.yaml
+++ b/charts/k8s-dencer/templates/ui-backend/deployment.yaml
@@ -60,30 +60,7 @@ spec:
               value: {{ .Values.uiBackend.logLevel | quote }}
             - name: HTTP_ADDR
               value: ":{{ .Values.uiBackend.service.port }}"
-            - name: DATABASE_TYPE
-              value: {{ .Values.database.type | quote }}
-            {{- if eq .Values.database.type "sqlite" }}
-            - name: DATABASE_PATH
-              value: {{ .Values.database.sqlite.path | quote }}
-            {{- else }}
-            - name: POSTGRES_HOST
-              value: {{ .Values.database.postgres.host | quote }}
-            - name: POSTGRES_PORT
-              value: {{ .Values.database.postgres.port | quote }}
-            - name: POSTGRES_DATABASE
-              value: {{ .Values.database.postgres.database | quote }}
-            - name: POSTGRES_USER
-              value: {{ .Values.database.postgres.user | quote }}
-            - name: POSTGRES_SSLMODE
-              value: {{ .Values.database.postgres.sslMode | quote }}
-            {{- with .Values.database.postgres.existingSecret }}
-            - name: POSTGRES_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ . }}
-                  key: {{ $.Values.database.postgres.existingSecretPasswordKey }}
-            {{- end }}
-            {{- end }}
+            {{- include "k8s-dencer.databaseEnv" . | nindent 12 }}
             - name: POLL_INTERVAL
               value: {{ .Values.uiBackend.pollInterval | quote }}
             # POD_NAMESPACE is already declared below; it also scopes the
@@ -170,14 +147,17 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+            {{- if include "k8s-dencer.mountsDataVolume" . }}
             - name: data
               mountPath: {{ dir .Values.database.sqlite.path }}
+            {{- end }}
             {{- with .Values.uiBackend.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
       volumes:
         - name: tmp
           emptyDir: {}
+        {{- if include "k8s-dencer.mountsDataVolume" . }}
         - name: data
           {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:
@@ -187,6 +167,7 @@ spec:
           # ephemeral test installs.
           emptyDir: {}
           {{- end }}
+        {{- end }}
         {{- with .Values.uiBackend.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/k8s-dencer/values.schema.json
+++ b/charts/k8s-dencer/values.schema.json
@@ -47,9 +47,10 @@
       "type": "object",
       "properties": {
         "type": {
-          "description": "Plan store backend. Only sqlite is implemented; the postgres Store lands in Phase 2, at which point this enum widens.",
+          "description": "Plan store backend. sqlite is single-writer and pins ui-backend to one replica on a ReadWriteOnce claim; postgres lifts that and is what a multi-replica install needs.",
           "enum": [
-            "sqlite"
+            "sqlite",
+            "postgres"
           ]
         },
         "sqlite": {
@@ -664,6 +665,52 @@
     }
   },
   "allOf": [
+    {
+      "$comment": "A postgres install with no host would start, fail to connect, and crashloop with a message about an empty host. Refusing to render says the same thing before anything is applied.",
+      "if": {
+        "properties": {
+          "database": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "const": "postgres"
+              }
+            },
+            "required": [
+              "type"
+            ]
+          }
+        },
+        "required": [
+          "database"
+        ]
+      },
+      "then": {
+        "properties": {
+          "database": {
+            "type": "object",
+            "properties": {
+              "postgres": {
+                "type": "object",
+                "properties": {
+                  "host": {
+                    "$comment": "database.type=postgres requires database.postgres.host",
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "host"
+                ]
+              }
+            },
+            "required": [
+              "postgres"
+            ]
+          }
+        }
+      }
+    },
     {
       "$comment": "SQLite is a single-writer store on a ReadWriteOnce claim. More than one ui-backend replica risks database corruption, so the chart refuses to render it rather than letting it be discovered in production.",
       "if": {

--- a/charts/k8s-dencer/values.yaml
+++ b/charts/k8s-dencer/values.yaml
@@ -28,9 +28,16 @@ rbac:
 database:
   # sqlite | postgres
   #
-  # postgres is declared for Phase 2 and is NOT implemented yet; selecting it
-  # is rejected by values.schema.json. sqlite is single-writer, which is why
-  # uiBackend is pinned to one replica with a Recreate strategy.
+  # sqlite is single-writer on a ReadWriteOnce claim, which is what pins
+  # uiBackend to one replica, forces a Recreate rollout, and co-schedules the
+  # planner onto the ui-backend's node. Good enough for most installs, and it
+  # needs nothing to exist beforehand.
+  #
+  # postgres reaches the store over the network, so all three of those
+  # constraints disappear and uiBackend can scale. Set database.postgres.host
+  # and supply the password through existingSecret; the chart never takes a
+  # password as a value. The database itself must already exist — the chart
+  # creates the schema, not the server.
   type: sqlite
   sqlite:
     path: /data/dencer.db
@@ -180,7 +187,8 @@ priorityClass:
   preemptionPolicy: Never
 
 uiBackend:
-  # Pinned to 1 while database.type is sqlite. Enforced by values.schema.json.
+  # Pinned to 1 while database.type is sqlite, and enforced by
+  # values.schema.json rather than left as advice. Raise it freely on postgres.
   replicaCount: 1
 
   # Shown in the UI header so an operator can see which cluster they are about

--- a/cmd/executor/main.go
+++ b/cmd/executor/main.go
@@ -50,8 +50,7 @@ func main() {
 }
 
 func run(ctx context.Context, log *slog.Logger) error {
-	path := env("DATABASE_PATH", "/data/dencer.db")
-	db, err := sqlitestore.Open(path)
+	db, dbDesc, err := sqlitestore.OpenFromEnv(ctx)
 	if err != nil {
 		return err
 	}
@@ -60,7 +59,7 @@ func run(ctx context.Context, log *slog.Logger) error {
 	// The ui-backend owns the schema and runs migrations. The executor waits
 	// for the tables rather than creating them, so two writers can never race
 	// to define them differently.
-	if err := waitForSchema(ctx, db, log); err != nil {
+	if err := waitForSchema(ctx, db, dbDesc, log); err != nil {
 		return err
 	}
 
@@ -138,7 +137,7 @@ func run(ctx context.Context, log *slog.Logger) error {
 // On a fresh install all three pods start together and the executor may well
 // win the race. Crashlooping until the tables appear would work but reads as a
 // broken deploy; waiting quietly is the same outcome without the alarm.
-func waitForSchema(ctx context.Context, db *sqlitestore.Store, log *slog.Logger) error {
+func waitForSchema(ctx context.Context, db *sqlitestore.Store, dbDesc string, log *slog.Logger) error {
 	for attempt := 0; ; attempt++ {
 		// ErrNotFound means the query ran and matched nothing, which is
 		// exactly what a migrated but idle database looks like.
@@ -146,7 +145,7 @@ func waitForSchema(ctx context.Context, db *sqlitestore.Store, log *slog.Logger)
 			return nil
 		}
 		if attempt == 0 {
-			log.Info("waiting for ui-backend to migrate the plan store", "path", env("DATABASE_PATH", "/data/dencer.db"))
+			log.Info("waiting for ui-backend to migrate the plan store", "store", dbDesc)
 		}
 		select {
 		case <-ctx.Done():

--- a/cmd/planner/main.go
+++ b/cmd/planner/main.go
@@ -81,10 +81,11 @@ func run(ctx context.Context, log *slog.Logger) error {
 	// The planner writes plans; the ui-backend owns the schema and runs
 	// migrations. Opening read-write here without migrating keeps the
 	// ownership boundary explicit.
-	db, err := sqlitestore.Open(env("DATABASE_PATH", "/data/dencer.db"))
+	db, dbDesc, err := sqlitestore.OpenFromEnv(ctx)
 	if err != nil {
 		return err
 	}
+	log.Info("plan store", "store", dbDesc)
 	defer func() { _ = db.Close() }()
 
 	// The planner may start before the ui-backend has ever run, in which case

--- a/cmd/ui-backend/main.go
+++ b/cmd/ui-backend/main.go
@@ -52,15 +52,7 @@ func main() {
 }
 
 func run(ctx context.Context, log *slog.Logger) error {
-	dbType := env("DATABASE_TYPE", "sqlite")
-	if dbType != "sqlite" {
-		// values.schema.json rejects this too, but a binary launched outside
-		// the chart should fail loudly rather than silently using SQLite.
-		return errUnsupportedDatabase(dbType)
-	}
-
-	path := env("DATABASE_PATH", "/data/dencer.db")
-	db, err := sqlitestore.Open(path)
+	db, dbDesc, err := sqlitestore.OpenFromEnv(ctx)
 	if err != nil {
 		return err
 	}
@@ -69,7 +61,7 @@ func run(ctx context.Context, log *slog.Logger) error {
 	if err := db.Migrate(ctx); err != nil {
 		return err
 	}
-	log.Info("plan store ready", "path", path)
+	log.Info("plan store ready", "store", dbDesc)
 
 	authCfg := authConfig()
 	guard, err := buildGuard(authCfg, log)
@@ -160,7 +152,7 @@ func run(ctx context.Context, log *slog.Logger) error {
 
 	// The schema is migrated and the store is open, so the API can serve.
 	health.SetReady(true)
-	log.Info("starting", "version", version, "database", dbType)
+	log.Info("starting", "version", version, "database", dbDesc)
 
 	return httpserver.Run(ctx, log, env("HTTP_ADDR", ":8080"), mux)
 }
@@ -253,12 +245,6 @@ func buildGuard(cfg auth.Config, log *slog.Logger) (*auth.Middleware, error) {
 var errExecutorWithoutAuth = errors.New(
 	"EXECUTOR_ENABLED is set but AUTH_ENABLED is false; " +
 		"an execute endpoint must never be reachable without authorization")
-
-type errUnsupportedDatabase string
-
-func (e errUnsupportedDatabase) Error() string {
-	return "unsupported database type " + strconv.Quote(string(e)) + "; only sqlite is implemented"
-}
 
 func env(key, fallback string) string {
 	if v, ok := os.LookupEnv(key); ok && v != "" {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,7 +14,7 @@ internal/
   impact/          Green/Yellow/Red classifier + rationale composition
   safety/          the non-negotiable rails; refuses Red, caps blast radius, re-checks PDBs
   executor/        the ONLY package that mutates a cluster: cordon, evict, verify, abort
-  store/           Store interface + SQLite implementation and migrations
+  store/           Store interface + one SQLite/Postgres implementation and migrations
   auth/            TokenReview authn + SubjectAccessReview authz; no credential store of our own
   telemetry/       structured logger + the Prometheus series each component publishes
   api/             rest/ (+ SSE events), graph/ (Cytoscape payload), agenttools/ (MCP)
@@ -112,7 +112,9 @@ Thresholds are chart values (`planner.impact.*`) because doc §10 is explicit th
 
 ## Plan store and API
 
-Plans live in SQLite on the chart's PVC, not in a CRD. Doc §6 makes the case: a plan is refreshed continuously and read almost entirely by the UI, and pushing that write volume through etcd is a well-known way to hurt a cluster. Nothing external *desires* a specific plan, so there is nothing for Kubernetes' reconciliation model to do.
+Plans live in a SQL database — SQLite on the chart's PVC by default, or Postgres — not in a CRD. Doc §6 makes the case: a plan is refreshed continuously and read almost entirely by the UI, and pushing that write volume through etcd is a well-known way to hurt a cluster. Nothing external *desires* a specific plan, so there is nothing for Kubernetes' reconciliation model to do.
+
+**One store speaks both dialects rather than two implementations.** They differ in four places — placeholder spelling, `BLOB`/`BYTEA`, `REAL`/`DOUBLE PRECISION`, and where the schema version is kept — and every query, migration and test is shared. The alternative is two things that must agree, kept apart, and discovered to disagree by a user. The same suite runs against both backends in CI, which is how a claim that let two Postgres executors take the same run was found before it reached anyone.
 
 **Each stored plan carries the snapshot and constraint analysis it was computed from.** The UI needs to draw a graph and explain constraints for the plan it's displaying; pairing them guarantees the three agree. Fetching live state instead would show a graph that has already drifted from the plan drawn over it, and history could never be reviewed at all.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -171,9 +171,46 @@ them — an autoscaler, or someone with kubectl — and reports them separately.
 The cluster saved that money whoever caused it, and the ledger's job is to be
 accurate about what happened rather than flattering about who did it.
 
+## Postgres instead of SQLite
+
+SQLite is the default and needs nothing to exist beforehand. Choose Postgres
+when the single-node constraints below are the ones costing you something —
+principally a planner that cannot be scheduled because the one node holding
+its claim is full.
+
+```bash
+kubectl create secret generic dencer-db \
+  --namespace k8s-dencer --from-literal=password='…'
+
+helm install k8s-dencer oci://ghcr.io/atedgimo/charts/k8s-dencer \
+  --namespace k8s-dencer --create-namespace \
+  --set database.type=postgres \
+  --set database.postgres.host=postgres.databases.svc \
+  --set database.postgres.database=dencer \
+  --set database.postgres.user=dencer \
+  --set database.postgres.existingSecret=dencer-db
+```
+
+The chart creates the **schema**, not the server: the database and the role
+must already exist, and the role needs `CREATE` on the target schema for the
+first migration. `sslMode` defaults to `require` — an operator who says nothing
+gets an encrypted connection. The password is only ever read from a Secret;
+the chart takes no password as a value, and none appears in the rendered
+manifest.
+
+Selecting Postgres removes the PersistentVolumeClaim, the `/data` mount, the
+co-scheduling affinity and the PriorityClass, because all four exist to keep
+two writers off one file. `uiBackend.replicaCount` is then yours to raise.
+
+**There is no migration path from an existing SQLite store.** Plan history and
+the reclamation ledger stay in the file they were written to. Nothing is lost
+by switching — the planner rebuilds its plan on the next resync, and the
+savings ledger starts recording from the switch — but the history before the
+switch does not come with it.
+
 ## Known constraints
 
-- **SQLite is single-writer.** `uiBackend.replicaCount` is pinned to 1 and enforced by the schema; the planner is co-scheduled with ui-backend via a `requiredDuringScheduling` podAffinity, because a ReadWriteOnce claim only permits multiple pods on the same node. Both constraints disappear when the Postgres store lands.
+- **SQLite is single-writer.** `uiBackend.replicaCount` is pinned to 1 and enforced by the schema; the planner is co-scheduled with ui-backend via a `requiredDuringScheduling` podAffinity, because a ReadWriteOnce claim only permits multiple pods on the same node. Both constraints are lifted by `database.type=postgres` (above) — and only by that; they are properties of the file, not preferences.
 
   That affinity leaves the planner exactly one node it may occupy, so on a packed cluster it can lose the scheduling race and sit `Pending`. The chart creates a `PriorityClass` for the pair to stop that happening — only when the co-location applies, so a Postgres install gets no cluster-scoped object it has no use for. It is `preemptionPolicy: Never`: winning a queue is worth having, evicting someone else's workload to get there is not. Set `priorityClass.create=false` to opt out, or `planner.priorityClassName` to use your own.
 - **PDBs use `maxUnavailable`, never `minAvailable`.** A `minAvailable` PDB on a single-replica Deployment makes its own pod undrainable — the exact pathology this product exists to detect.

--- a/docs/product-roadmap.md
+++ b/docs/product-roadmap.md
@@ -192,8 +192,12 @@ consolidation's.
 
 Decisions, not omissions — recorded so they are not re-litigated by accident:
 
-- **High availability / Postgres** — a consolidation planner is not a serving
-  path; the run queue is crash-safe, the planner replans on restart
+- **High availability** — a consolidation planner is not a serving path; the
+  run queue is crash-safe, the planner replans on restart. Still true.
+- **Postgres** — was recorded here alongside HA, and that was a mistake in
+  reasoning rather than a decision that aged: SQLite's ReadWriteOnce claim
+  pins the planner to one node, where a packed cluster can leave it `Pending`.
+  Shipped as `database.type=postgres`; HA remains out
 - **Fully autonomous operation** — the product's premise is that a human
   approves eviction; scheduled unattended execution stays out until the
   closed-loop envelope model proves itself

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -56,10 +56,21 @@ estimated — every milestone here starts from a number in
 | **M24** | The field shows what *is*, not only what *would be* — observed states overlaid on the plan, nodes and pods | **done** |
 | **M25** | Closed-loop consolidation — re-plan from observed state after every step, inside an operator-approved envelope | **done** — engine, CLI and UI |
 
-High availability and a Postgres store were **dropped, not deferred**: a
+High availability was **dropped, not deferred**, and stays dropped: a
 consolidation planner is not a serving path. The run queue is already crash-safe
 and resumes, the planner replans on restart, and a minute of UI downtime costs
 nothing.
+
+**The Postgres store was dropped with it, and that call was reversed** — for a
+reason that has nothing to do with availability, which is why the original
+reasoning did not catch it. SQLite is a file on a ReadWriteOnce claim, and RWO
+permits multiple pods only on the same node, so the chart has to co-schedule
+the planner onto the ui-backend's node. That leaves the planner exactly one
+node it may occupy, and on a packed cluster — the kind of cluster this product
+is installed on — it can lose the scheduling race and sit `Pending`. The
+PriorityClass added in v0.5.0 makes that less likely rather than impossible.
+
+Uptime was never the argument. Being schedulable is.
 
 ### M24 — live reality in the field
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/atedgimo/k8s-dencer
 go 1.26.5
 
 require (
+	github.com/jackc/pgx/v5 v5.10.0
 	github.com/modelcontextprotocol/go-sdk v1.7.0
 	github.com/prometheus/client_golang v1.24.1
 	github.com/robfig/cron/v3 v3.0.1
@@ -32,6 +33,9 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
+	github.com/jackc/pgpassfile v1.0.0 // indirect
+	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
+	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,14 @@ github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5T
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674/go.mod h1:r4w70xmWCQKmi1ONH4KIaBptdivuRPyosB9RmPlGEwA=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
+github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
+github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
+github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
+github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
+github.com/jackc/pgx/v5 v5.10.0 h1:VhSvgU2jSli8o3AqIEOTJr7rZwAEUVo4E4XhR94Zfr0=
+github.com/jackc/pgx/v5 v5.10.0/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
+github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
+github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
@@ -124,6 +132,7 @@ github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpE
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=

--- a/hack/lint-chart.sh
+++ b/hack/lint-chart.sh
@@ -284,11 +284,69 @@ if [ "$sqlite_prio" -ne 2 ]; then
 fi
 # Postgres removes the co-location, so the cluster-scoped object should not
 # exist at all: no install gets a PriorityClass it has no use for.
-if helm template dencer "$CHART" --set database.type=postgres \
-     | grep -q '^kind: PriorityClass'; then
+#
+# Rendered into a variable first, and the render is required to succeed. The
+# previous form piped `helm template` straight into grep, and because a
+# Postgres install did not render at all back then, the pipeline produced no
+# output, grep matched nothing, and the check passed without ever looking at a
+# manifest. An assertion about a configuration that cannot render is not an
+# assertion.
+if ! pg="$(helm template dencer "$CHART" \
+             --set database.type=postgres \
+             --set database.postgres.host=pg.example \
+             --set database.postgres.existingSecret=pg-secret \
+             --set executor.enabled=true --set auth.enabled=true 2>&1)"; then
+  fail "a Postgres install does not render: $pg"
+fi
+if grep -q '^kind: PriorityClass' <<<"$pg"; then
   fail "a Postgres install created a PriorityClass it does not need"
 fi
 green "  planner and ui-backend prioritised under SQLite, nothing created under Postgres"
+
+bold "==> contract: Postgres install carries no trace of the SQLite volume"
+# The whole point of the Postgres backend is lifting the single-node
+# constraints. A ReadWriteOnce claim still mounted into the pods would quietly
+# reimpose exactly the constraint the operator chose Postgres to escape, and
+# nothing would report an error — the pods would simply be unschedulable
+# across nodes for a reason nobody wrote down.
+for artefact in \
+  'kind: PersistentVolumeClaim' \
+  'claimName:' \
+  'mountPath: /data' \
+  'name: DATABASE_PATH' \
+  'podAffinity'
+do
+  if grep -q "$artefact" <<<"$pg"; then
+    fail "a Postgres install still carries '$artefact', which exists only to serve a SQLite file"
+  fi
+done
+# And the connection details must actually reach every component, including
+# the executor — which set no DATABASE_TYPE at all before this was checked,
+# so it would have opened a SQLite file while the other two used Postgres.
+pg_types="$(grep -c 'name: DATABASE_TYPE' <<<"$pg" || true)"
+if [ "$pg_types" -ne 3 ]; then
+  fail "expected planner, executor and ui-backend to each be told the database type, found $pg_types"
+fi
+if ! grep -q 'name: POSTGRES_PASSWORD' <<<"$pg"; then
+  fail "the password is not wired from the Secret"
+fi
+if grep -qE 'value: .*(password|PASSWORD)' <<<"$pg"; then
+  fail "a password appears as a literal value in the rendered manifest"
+fi
+green "  no claim, no mount, no affinity; all three components pointed at Postgres"
+
+bold "==> contract: SQLite install still gets its volume"
+# The mirror of the check above: gating the volume on the backend must not
+# have gated it away for everybody.
+sq="$(helm template dencer "$CHART" --set executor.enabled=true --set auth.enabled=true)"
+sq_mounts="$(grep -c 'mountPath: /data' <<<"$sq" || true)"
+if [ "$sq_mounts" -ne 3 ]; then
+  fail "expected all three components to mount the SQLite volume, found $sq_mounts"
+fi
+if ! grep -q '^kind: PersistentVolumeClaim' <<<"$sq"; then
+  fail "a SQLite install no longer creates its claim"
+fi
+green "  claim created and mounted by all three components"
 
 bold "==> contract: chart packages without the ci/ fixtures"
 tmp="$(mktemp -d)"

--- a/internal/store/sqlstore/dialect.go
+++ b/internal/store/sqlstore/dialect.go
@@ -65,6 +65,42 @@ func rebind(d dialect, query string) string {
 	return b.String()
 }
 
+// ddlReplacements is the whole of the type-level difference between the two
+// servers, and it is deliberately a short list rather than a translation
+// layer. Anything longer would mean the schema had grown a SQLite accent, and
+// the honest fix for that is to change the schema, not to teach a translator
+// another word.
+//
+// Ordered longest-first where one pattern contains another, so a replacement
+// cannot eat the prefix of the next.
+var ddlReplacements = []struct{ sqlite, postgres string }{
+	// SQLite stores arbitrary bytes in BLOB; Postgres calls it BYTEA. Every
+	// use is a gzipped or JSON payload the store already marshals itself.
+	{"BLOB", "BYTEA"},
+	// REAL is 4-byte float in Postgres and 8-byte in SQLite. The one column
+	// using it is the packing ceiling, a fraction compared against computed
+	// capacity, so the narrower type would quietly change plan output.
+	{"REAL", "DOUBLE PRECISION"},
+	// A SQLite storage optimisation with no Postgres equivalent and no
+	// meaning there — the tables it applies to are keyed by a text primary
+	// key either way.
+	{") WITHOUT ROWID;", ");"},
+}
+
+// translateDDL rewrites schema statements for the target server.
+//
+// Only DDL goes through here. Queries are portable already: the placeholders
+// are handled by rebind, and ON CONFLICT is spelled the same in both.
+func translateDDL(d dialect, ddl string) string {
+	if d != postgresDialect {
+		return ddl
+	}
+	for _, r := range ddlReplacements {
+		ddl = strings.ReplaceAll(ddl, r.sqlite, r.postgres)
+	}
+	return ddl
+}
+
 // The three call shapes every method uses, routed through one place so a
 // query cannot reach a server in the wrong dialect.
 func (s *Store) exec(ctx context.Context, q string, args ...any) (sql.Result, error) {

--- a/internal/store/sqlstore/execution.go
+++ b/internal/store/sqlstore/execution.go
@@ -64,6 +64,23 @@ func (s *Store) Enqueue(ctx context.Context, run store.Run) (string, error) {
 func (s *Store) Claim(ctx context.Context, worker string) (store.Run, error) {
 	now := time.Now().UTC().Format(time.RFC3339Nano)
 
+	// The one place the two servers need genuinely different SQL, and it is
+	// not cosmetic. SQLite is safe as written: a single writer connection
+	// serialises the whole statement, so the subquery and the update cannot
+	// interleave with another claimer.
+	//
+	// Postgres allows the concurrency that is the entire reason for supporting
+	// it, and there two executors read the same pending run before either
+	// updates it — proven by TestClaimIsAtomicUnderConcurrency, which failed
+	// here the first time this store spoke to a real server. A double claim is
+	// two executors draining the same node, so this is a safety property, not
+	// a throughput one. SKIP LOCKED is the standard work-queue idiom: each
+	// claimer takes the oldest run no other claimer holds a lock on.
+	lock := ""
+	if s.d == postgresDialect {
+		lock = " FOR UPDATE SKIP LOCKED"
+	}
+
 	var id string
 	err := s.queryRow(ctx, `
 		UPDATE runs
@@ -72,7 +89,7 @@ func (s *Store) Claim(ctx context.Context, worker string) (store.Run, error) {
 			SELECT id FROM runs
 			WHERE status = ?
 			ORDER BY requested_at, seq
-			LIMIT 1
+			LIMIT 1`+lock+`
 		)
 		RETURNING id`,
 		string(store.RunRunning), worker, now, string(store.RunPending)).Scan(&id)

--- a/internal/store/sqlstore/fromenv.go
+++ b/internal/store/sqlstore/fromenv.go
@@ -1,0 +1,90 @@
+package sqlstore
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"strings"
+)
+
+// OpenFromEnv opens the plan store the deployment is configured for, and
+// returns a description of it safe to log.
+//
+// One function rather than the same twenty lines in planner, executor and
+// ui-backend. Three components must agree about which database they are
+// talking to; if they disagree the planner writes plans the UI cannot see, and
+// nothing reports an error. That is the same argument as one Store over two,
+// applied one level up.
+func OpenFromEnv(ctx context.Context) (*Store, string, error) {
+	switch t := env("DATABASE_TYPE", "sqlite"); t {
+	case "sqlite":
+		path := env("DATABASE_PATH", "/data/dencer.db")
+		s, err := Open(path)
+		if err != nil {
+			return nil, "", err
+		}
+		return s, "sqlite at " + path, nil
+
+	case "postgres":
+		dsn, desc, err := postgresDSN()
+		if err != nil {
+			return nil, "", err
+		}
+		s, err := OpenPostgres(ctx, dsn)
+		if err != nil {
+			return nil, "", err
+		}
+		return s, desc, nil
+
+	default:
+		// A binary launched outside the chart should fail loudly rather than
+		// quietly falling back to a different database than it was asked for.
+		return nil, "", fmt.Errorf("unsupported DATABASE_TYPE %q: want sqlite or postgres", t)
+	}
+}
+
+// postgresDSN assembles the connection string from its parts, and returns a
+// description with no password in it.
+//
+// Assembled here rather than taken whole as one env var so the password can
+// arrive separately from a Secret, and never has to appear in a Helm value or
+// in the rendered Deployment. url.URL does the escaping, because a password
+// containing '@' or '/' silently produces a DSN pointing somewhere else.
+func postgresDSN() (dsn, desc string, err error) {
+	host := env("POSTGRES_HOST", "")
+	if host == "" {
+		return "", "", fmt.Errorf("DATABASE_TYPE is postgres but POSTGRES_HOST is empty")
+	}
+	port := env("POSTGRES_PORT", "5432")
+	name := strings.TrimPrefix(env("POSTGRES_DATABASE", "dencer"), "/")
+	user := env("POSTGRES_USER", "dencer")
+
+	u := url.URL{
+		Scheme: "postgres",
+		Host:   net.JoinHostPort(host, port),
+		Path:   "/" + name,
+	}
+	if pw, ok := os.LookupEnv("POSTGRES_PASSWORD"); ok {
+		u.User = url.UserPassword(user, pw)
+	} else {
+		u.User = url.User(user)
+	}
+
+	q := url.Values{}
+	// Defaulting to require rather than to the driver's default: an operator
+	// who says nothing should get an encrypted connection, not a plaintext
+	// one, and the chart's default matches.
+	q.Set("sslmode", env("POSTGRES_SSLMODE", "require"))
+	u.RawQuery = q.Encode()
+
+	return u.String(), fmt.Sprintf("postgres at %s/%s (sslmode=%s)", u.Host, name, q.Get("sslmode")), nil
+}
+
+func env(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}

--- a/internal/store/sqlstore/fromenv_test.go
+++ b/internal/store/sqlstore/fromenv_test.go
@@ -1,0 +1,147 @@
+package sqlstore
+
+import (
+	"context"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+)
+
+// A password is not a string that can be pasted into a URL. One containing
+// '@' splits the userinfo from the host, and the DSN then names a different
+// server — which either fails to connect or, worse, connects somewhere the
+// operator did not intend. Postgres passwords are frequently generated, and
+// generated passwords contain punctuation.
+func TestPostgresDSNEscapesTheCredentials(t *testing.T) {
+	t.Setenv("POSTGRES_HOST", "pg.internal")
+	t.Setenv("POSTGRES_PORT", "6432")
+	t.Setenv("POSTGRES_DATABASE", "dencer")
+	t.Setenv("POSTGRES_USER", "dencer")
+	t.Setenv("POSTGRES_PASSWORD", "p@ss/w:rd?#x")
+
+	dsn, desc, err := postgresDSN()
+	if err != nil {
+		t.Fatalf("build dsn: %v", err)
+	}
+
+	// The host must survive the password verbatim.
+	if !strings.Contains(dsn, "@pg.internal:6432/dencer") {
+		t.Errorf("the password changed where the DSN points: %s", redact(dsn))
+	}
+	if strings.Contains(dsn, "p@ss/w:rd?#x") {
+		t.Error("the password was interpolated raw rather than escaped")
+	}
+
+	// Whatever is logged must not be the credentials.
+	for _, secret := range []string{"p@ss", "w:rd", "dencer:"} {
+		if strings.Contains(desc, secret) {
+			t.Errorf("the loggable description leaks part of the credentials: %q", desc)
+		}
+	}
+	if !strings.Contains(desc, "pg.internal:6432") {
+		t.Errorf("the description does not say where it connected: %q", desc)
+	}
+}
+
+// sslmode is the difference between an encrypted connection and a plaintext
+// one, and the default has to be the safe one: an operator who says nothing
+// should not silently get plaintext.
+func TestPostgresDSNDefaultsToRequiringTLS(t *testing.T) {
+	t.Setenv("POSTGRES_HOST", "pg.internal")
+
+	dsn, _, err := postgresDSN()
+	if err != nil {
+		t.Fatalf("build dsn: %v", err)
+	}
+	if !strings.Contains(dsn, "sslmode=require") {
+		t.Errorf("default DSN does not require TLS: %s", redact(dsn))
+	}
+}
+
+// A missing host is a misconfiguration that should be named, not turned into
+// a connection attempt against nothing.
+func TestPostgresWithoutAHostIsRefused(t *testing.T) {
+	t.Setenv("POSTGRES_HOST", "")
+
+	if _, _, err := postgresDSN(); err == nil {
+		t.Fatal("a postgres store with no host was accepted")
+	}
+}
+
+// No password set at all is legitimate — trust, peer and certificate
+// authentication all exist — and must not become the literal string "".
+func TestPostgresWithoutAPasswordSendsNone(t *testing.T) {
+	t.Setenv("POSTGRES_HOST", "pg.internal")
+	t.Setenv("POSTGRES_USER", "dencer")
+
+	dsn, _, err := postgresDSN()
+	if err != nil {
+		t.Fatalf("build dsn: %v", err)
+	}
+	if strings.Contains(dsn, "dencer:@") {
+		t.Errorf("an empty password was sent as a password: %s", redact(dsn))
+	}
+	if !strings.Contains(dsn, "dencer@pg.internal") {
+		t.Errorf("the user is not in the DSN: %s", redact(dsn))
+	}
+}
+
+func redact(dsn string) string {
+	at := strings.LastIndex(dsn, "@")
+	if at < 0 {
+		return dsn
+	}
+	return "postgres://…" + dsn[at:]
+}
+
+// The env names in OpenFromEnv and the env names the chart emits are two
+// lists that have to match, and nothing in Go checks a Helm template. This at
+// least proves the Go half works end to end against a real server: the same
+// variables, through the same function the three binaries call, to a database
+// that migrates.
+//
+// The chart half is checked by hack/lint-chart.sh, which asserts all three
+// components are told the type and that the password arrives from a Secret.
+func TestOpenFromEnvConnectsToPostgres(t *testing.T) {
+	dsn := os.Getenv("DENCER_TEST_POSTGRES")
+	if dsn == "" {
+		t.Skip("set DENCER_TEST_POSTGRES to run against a real Postgres")
+	}
+	u, err := url.Parse(dsn)
+	if err != nil {
+		t.Fatalf("DENCER_TEST_POSTGRES is not a URL: %v", err)
+	}
+	host, port := u.Hostname(), u.Port()
+	if port == "" {
+		port = "5432"
+	}
+	pw, _ := u.User.Password()
+
+	t.Setenv("DATABASE_TYPE", "postgres")
+	t.Setenv("POSTGRES_HOST", host)
+	t.Setenv("POSTGRES_PORT", port)
+	t.Setenv("POSTGRES_DATABASE", strings.TrimPrefix(u.Path, "/"))
+	t.Setenv("POSTGRES_USER", u.User.Username())
+	t.Setenv("POSTGRES_PASSWORD", pw)
+	// The container has no TLS; the default is require, and overriding it here
+	// is the same knob an operator turns for an in-cluster server.
+	t.Setenv("POSTGRES_SSLMODE", "disable")
+
+	ctx := context.Background()
+	s, desc, err := OpenFromEnv(ctx)
+	if err != nil {
+		t.Fatalf("OpenFromEnv: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	if strings.Contains(desc, pw) && pw != "" {
+		t.Errorf("the description logged at startup contains the password: %q", desc)
+	}
+	if !strings.HasPrefix(desc, "postgres at ") {
+		t.Errorf("description = %q, want it to say which backend is in use", desc)
+	}
+	if err := s.Migrate(ctx); err != nil {
+		t.Fatalf("migrate through OpenFromEnv: %v", err)
+	}
+}

--- a/internal/store/sqlstore/rebind_guard_test.go
+++ b/internal/store/sqlstore/rebind_guard_test.go
@@ -1,0 +1,99 @@
+package sqlstore
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"strings"
+	"testing"
+)
+
+// Every query in this package is written with `?` placeholders and rewritten
+// for Postgres by rebind, which only runs if the call goes through exec,
+// query, queryRow or txExec. A statement handed straight to the driver keeps
+// its `?` and Postgres rejects it — "syntax error at end of input", pointing
+// at nothing in particular.
+//
+// Two calls did exactly that, and neither was caught by review or by the
+// SQLite suite; they surfaced only when the store first spoke to a real
+// Postgres, as thirteen failures with one cause. The cost of finding them that
+// way is what this test exists to avoid: it is a compile-time-shaped question
+// — does a placeholder reach the driver unrewritten — so it should not need a
+// server to answer.
+//
+// Raw calls are still allowed. DDL is already translated by the time it is
+// executed, the seq backfill is SQLite-only, and PRAGMA takes no parameters —
+// what none of them may contain is a `?`.
+func TestNoPlaceholderBypassesRebind(t *testing.T) {
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, ".", func(fi fs.FileInfo) bool {
+		return !strings.HasSuffix(fi.Name(), "_test.go")
+	}, 0)
+	if err != nil {
+		t.Fatalf("parse package: %v", err)
+	}
+
+	// The driver-level methods. Reaching one of these means rebind was
+	// skipped, whatever the receiver is called.
+	raw := map[string]bool{"ExecContext": true, "QueryContext": true, "QueryRowContext": true}
+
+	var checked int
+	for _, pkg := range pkgs {
+		for name, file := range pkg.Files {
+			// dialect.go is where the helpers wrap the driver; those calls are
+			// the rewrite, not a bypass of it.
+			if strings.HasSuffix(name, "dialect.go") {
+				continue
+			}
+			ast.Inspect(file, func(n ast.Node) bool {
+				call, ok := n.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				sel, ok := call.Fun.(*ast.SelectorExpr)
+				if !ok || !raw[sel.Sel.Name] || len(call.Args) < 2 {
+					return true
+				}
+				checked++
+				if !containsPlaceholder(call.Args[1]) {
+					return true
+				}
+				pos := fset.Position(call.Pos())
+				t.Errorf("%s:%d: %s is called directly with a query containing `?`, so rebind never runs and Postgres will reject it — route it through s.exec/s.query/s.queryRow/s.txExec",
+					pos.Filename, pos.Line, sel.Sel.Name)
+				return true
+			})
+		}
+	}
+
+	// A test that silently inspects nothing would pass forever after a
+	// refactor renamed the methods it looks for.
+	if checked == 0 {
+		t.Fatal("found no direct driver calls at all; this guard is no longer looking at anything")
+	}
+}
+
+// containsPlaceholder reports whether a query expression has a `?` in any of
+// its literal parts. Concatenation is handled because the claim query builds
+// its locking clause that way.
+func containsPlaceholder(e ast.Expr) bool {
+	switch v := e.(type) {
+	case *ast.BasicLit:
+		return v.Kind == token.STRING && strings.Contains(v.Value, "?")
+	case *ast.BinaryExpr:
+		return containsPlaceholder(v.X) || containsPlaceholder(v.Y)
+	case *ast.Ident:
+		// A constant holding a query. Resolve it if it is declared in this
+		// file, so schema constants and query constants are both covered.
+		if v.Obj == nil {
+			return false
+		}
+		spec, ok := v.Obj.Decl.(*ast.ValueSpec)
+		if !ok || len(spec.Values) == 0 {
+			return false
+		}
+		return containsPlaceholder(spec.Values[0])
+	}
+	return false
+}

--- a/internal/store/sqlstore/sqlstore.go
+++ b/internal/store/sqlstore/sqlstore.go
@@ -1,13 +1,22 @@
-// Package sqlite implements the plan store on SQLite.
+// Package sqlstore implements the plan store, on SQLite or on Postgres.
 //
-// modernc.org/sqlite is used rather than mattn/go-sqlite3 because it is pure
-// Go: the components ship on distroless/static with a CGO-free build, and a
-// cgo driver would break that.
+// One implementation over both, differing only where the servers genuinely
+// differ: placeholder spelling (rebind), a handful of DDL types
+// (translateDDL), and where the schema version is kept. Every query, every
+// migration and every test is shared, because a store is the product's memory
+// and two memories that drift are worse than one that is a little more
+// general.
 //
-// SQLite is single-writer. The chart enforces the consequences — ui-backend
+// Both drivers are pure Go — modernc.org/sqlite rather than mattn/go-sqlite3,
+// and pgx's database/sql driver — because the components ship on
+// distroless/static with a CGO-free build, and a cgo driver would break that.
+//
+// SQLite is single-writer, and the chart enforces the consequences: ui-backend
 // pinned to one replica, Recreate rollout strategy, planner co-scheduled onto
-// the same node as the ReadWriteOnce volume — and values.schema.json rejects a
-// configuration that would violate them.
+// the same node as the ReadWriteOnce volume, with values.schema.json rejecting
+// a configuration that would violate them. Postgres is the reason those
+// constraints can be lifted — it is not a second way to store the same data so
+// much as the way to stop pinning the product to one node.
 package sqlstore
 
 import (
@@ -20,6 +29,7 @@ import (
 	"fmt"
 	"time"
 
+	_ "github.com/jackc/pgx/v5/stdlib"
 	_ "modernc.org/sqlite"
 
 	"github.com/atedgimo/k8s-dencer/internal/model"
@@ -54,16 +64,56 @@ func Open(path string) (*Store, error) {
 	return &Store{db: db, d: sqliteDialect}, nil
 }
 
+// OpenPostgres connects to the Postgres server named by dsn.
+//
+// The DSN is passed through to the driver rather than assembled from parts,
+// so sslmode, connect_timeout and the rest are the operator's to set and this
+// code has no opinion it could get wrong. It carries a password, so it is
+// never logged: the errors below name the failure, not the string.
+func OpenPostgres(ctx context.Context, dsn string) (*Store, error) {
+	db, err := sql.Open("pgx", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("open postgres: %w", err)
+	}
+	// Unlike SQLite there is no single-writer rule to honour, which is the
+	// point of supporting it. The pool is left small because this store's
+	// traffic is one planner writing and a handful of readers, not because it
+	// has to be.
+	db.SetMaxOpenConns(10)
+	db.SetMaxIdleConns(2)
+	db.SetConnMaxLifetime(time.Hour)
+
+	if err := db.PingContext(ctx); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("ping postgres: %w", err)
+	}
+	return &Store{db: db, d: postgresDialect}, nil
+}
+
 // Close releases the database handle.
 func (s *Store) Close() error { return s.db.Close() }
 
 const schemaVersion = 14
 
+// migrations are the schema versions in order; index i holds the statements
+// that take the database from version i to i+1.
+//
+// A table rather than fourteen near-identical if-blocks, so adding v15 is one
+// line and cannot be got subtly wrong — the previous shape had the version
+// number written three times per step, which is three chances to typo a
+// number that decides whether an operator's database is upgraded or skipped.
+func migrations() []string {
+	return []string{
+		schemaV1, schemaV2, schemaV3, schemaV4, schemaV5, schemaV6, schemaV7,
+		schemaV8, schemaV9, schemaV10, schemaV11, schemaV12, schemaV13, schemaV14,
+	}
+}
+
 // Migrate creates or upgrades the schema.
 func (s *Store) Migrate(ctx context.Context) error {
-	var current int
-	if err := s.queryRow(ctx, "PRAGMA user_version").Scan(&current); err != nil {
-		return fmt.Errorf("read schema version: %w", err)
+	current, err := s.schemaVersionOf(ctx)
+	if err != nil {
+		return err
 	}
 	if current >= schemaVersion {
 		return nil
@@ -75,91 +125,86 @@ func (s *Store) Migrate(ctx context.Context) error {
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	if current < 1 {
-		if _, err := tx.ExecContext(ctx, schemaV1); err != nil {
-			return fmt.Errorf("apply schema v1: %w", err)
+	for i, ddl := range migrations() {
+		v := i + 1
+		if current >= v {
+			continue
 		}
-	}
-	if current < 2 {
-		if _, err := tx.ExecContext(ctx, schemaV2); err != nil {
-			return fmt.Errorf("apply schema v2: %w", err)
+		if _, err := tx.ExecContext(ctx, translateDDL(s.d, ddl)); err != nil {
+			return fmt.Errorf("apply schema v%d: %w", v, err)
 		}
-	}
-	if current < 3 {
-		if _, err := tx.ExecContext(ctx, schemaV3); err != nil {
-			return fmt.Errorf("apply schema v3: %w", err)
-		}
-	}
-	if current < 4 {
-		if _, err := tx.ExecContext(ctx, schemaV4); err != nil {
-			return fmt.Errorf("apply schema v4: %w", err)
-		}
-	}
-	if current < 5 {
-		if _, err := tx.ExecContext(ctx, schemaV5); err != nil {
-			return fmt.Errorf("apply schema v5: %w", err)
-		}
-	}
-	if current < 6 {
-		if _, err := tx.ExecContext(ctx, schemaV6); err != nil {
-			return fmt.Errorf("apply schema v6: %w", err)
-		}
-	}
-	if current < 7 {
-		if _, err := tx.ExecContext(ctx, schemaV7); err != nil {
-			return fmt.Errorf("apply schema v7: %w", err)
-		}
-	}
-	if current < 8 {
-		if _, err := tx.ExecContext(ctx, schemaV8); err != nil {
-			return fmt.Errorf("apply schema v8: %w", err)
-		}
-	}
-	if current < 9 {
-		if _, err := tx.ExecContext(ctx, schemaV9); err != nil {
-			return fmt.Errorf("apply schema v9: %w", err)
-		}
-	}
-	if current < 10 {
-		if _, err := tx.ExecContext(ctx, schemaV10); err != nil {
-			return fmt.Errorf("apply schema v10: %w", err)
-		}
-	}
-	if current < 11 {
-		if _, err := tx.ExecContext(ctx, schemaV11); err != nil {
-			return fmt.Errorf("apply schema v11: %w", err)
-		}
-	}
-	if current < 12 {
-		if _, err := tx.ExecContext(ctx, schemaV12); err != nil {
-			return fmt.Errorf("apply schema v12: %w", err)
-		}
-	}
-	if current < 13 {
-		if _, err := tx.ExecContext(ctx, schemaV13); err != nil {
-			return fmt.Errorf("apply schema v13: %w", err)
-		}
-	}
-	if current < 14 {
-		if _, err := tx.ExecContext(ctx, schemaV14); err != nil {
-			return fmt.Errorf("apply schema v14: %w", err)
-		}
-		// Existing rows get their order from the one SQLite already knows.
-		// Backfilling from rowid preserves the exact sequence the old queries
-		// were sorting by, so an upgrade cannot silently reorder history.
-		if _, err := tx.ExecContext(ctx, `UPDATE plans SET seq = rowid WHERE seq = 0`); err != nil {
-			return fmt.Errorf("backfill plans.seq: %w", err)
-		}
-		if _, err := tx.ExecContext(ctx, `UPDATE runs SET seq = rowid WHERE seq = 0`); err != nil {
-			return fmt.Errorf("backfill runs.seq: %w", err)
+		if v == 14 {
+			if err := s.backfillSeq(ctx, tx); err != nil {
+				return err
+			}
 		}
 	}
 
-	// PRAGMA does not accept a bound parameter.
-	if _, err := tx.ExecContext(ctx, fmt.Sprintf("PRAGMA user_version = %d", schemaVersion)); err != nil {
-		return fmt.Errorf("set schema version: %w", err)
+	if err := s.setSchemaVersion(ctx, tx, schemaVersion); err != nil {
+		return err
 	}
 	return tx.Commit()
+}
+
+// backfillSeq gives rows that predate v14 the order the old queries sorted
+// them by, so an upgrade cannot silently reorder anybody's history.
+//
+// SQLite-only, and not as an optimisation: `rowid` is not a column in
+// Postgres, so the statement fails when the query is parsed — on an empty
+// table as readily as a full one. It is never needed there. A Postgres
+// database is created by this code at the current version and cannot predate
+// the column, so there is nothing older to backfill from.
+func (s *Store) backfillSeq(ctx context.Context, tx *sql.Tx) error {
+	if s.d == postgresDialect {
+		return nil
+	}
+	for _, t := range []string{"plans", "runs"} {
+		if _, err := tx.ExecContext(ctx, "UPDATE "+t+" SET seq = rowid WHERE seq = 0"); err != nil {
+			return fmt.Errorf("backfill %s.seq: %w", t, err)
+		}
+	}
+	return nil
+}
+
+// schemaVersionOf reads the version the database is currently at.
+//
+// SQLite keeps it in the file header, which is free and needs no table.
+// Postgres has no equivalent, so the version lives in a table of its own —
+// created here, because it has to exist before the first migration can ask
+// what version the database is.
+func (s *Store) schemaVersionOf(ctx context.Context) (int, error) {
+	if s.d == postgresDialect {
+		if _, err := s.exec(ctx, `CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL)`); err != nil {
+			return 0, fmt.Errorf("create schema_version: %w", err)
+		}
+		var v sql.NullInt64
+		if err := s.queryRow(ctx, `SELECT MAX(version) FROM schema_version`).Scan(&v); err != nil {
+			return 0, fmt.Errorf("read schema version: %w", err)
+		}
+		return int(v.Int64), nil
+	}
+	var current int
+	if err := s.queryRow(ctx, "PRAGMA user_version").Scan(&current); err != nil {
+		return 0, fmt.Errorf("read schema version: %w", err)
+	}
+	return current, nil
+}
+
+func (s *Store) setSchemaVersion(ctx context.Context, tx *sql.Tx, v int) error {
+	if s.d == postgresDialect {
+		if _, err := s.txExec(ctx, tx, `DELETE FROM schema_version`); err != nil {
+			return fmt.Errorf("set schema version: %w", err)
+		}
+		if _, err := s.txExec(ctx, tx, `INSERT INTO schema_version (version) VALUES (?)`, v); err != nil {
+			return fmt.Errorf("set schema version: %w", err)
+		}
+		return nil
+	}
+	// PRAGMA does not accept a bound parameter.
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf("PRAGMA user_version = %d", v)); err != nil {
+		return fmt.Errorf("set schema version: %w", err)
+	}
+	return nil
 }
 
 // v8: the plan records the packing ceiling it was computed under, so the
@@ -510,7 +555,7 @@ func (s *Store) Save(ctx context.Context, rec store.Record) (bool, error) {
 		return false, fmt.Errorf("insert plan: %w", err)
 	}
 
-	if _, err := tx.ExecContext(ctx, `DELETE FROM plan_steps WHERE plan_id = ?`, rec.Plan.ID); err != nil {
+	if _, err := s.txExec(ctx, tx, `DELETE FROM plan_steps WHERE plan_id = ?`, rec.Plan.ID); err != nil {
 		return false, fmt.Errorf("clear steps: %w", err)
 	}
 
@@ -523,7 +568,7 @@ func (s *Store) Save(ctx context.Context, rec store.Record) (bool, error) {
 		if err != nil {
 			return false, fmt.Errorf("encode reasons: %w", err)
 		}
-		if _, err := tx.ExecContext(ctx, `
+		if _, err := s.txExec(ctx, tx, `
 			INSERT INTO plan_steps (plan_id, step_id, sequence_number, target_node, moves,
 			                        impact, rationale, reasons, requires_maintenance_window)
 			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,

--- a/internal/store/sqlstore/sqlstore_test.go
+++ b/internal/store/sqlstore/sqlstore_test.go
@@ -2,12 +2,17 @@ package sqlstore_test
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
 
 	"github.com/atedgimo/k8s-dencer/internal/constraints"
 	"github.com/atedgimo/k8s-dencer/internal/model"
@@ -15,14 +20,84 @@ import (
 	sqlitestore "github.com/atedgimo/k8s-dencer/internal/store/sqlstore"
 )
 
+// openTemp is a migrated, empty store — and the single lever that decides
+// which server the whole suite runs against.
+//
+// With DENCER_TEST_POSTGRES set to a DSN, every test that calls this runs
+// against a real Postgres instead of a temp file. Not a second suite of
+// Postgres tests: the same assertions, because the promise being made is that
+// the two backends behave identically, and a separate suite would only ever
+// prove that the tests someone remembered to write twice agree.
 func openTemp(t *testing.T) *sqlitestore.Store {
 	t.Helper()
+	if dsn := os.Getenv("DENCER_TEST_POSTGRES"); dsn != "" {
+		return openTempPostgres(t, dsn)
+	}
 	s, err := sqlitestore.Open(filepath.Join(t.TempDir(), "test.db"))
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
 	t.Cleanup(func() { _ = s.Close() })
 	if err := s.Migrate(context.Background()); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return s
+}
+
+// openTempPostgres gives each test its own schema on the shared server, which
+// is what t.TempDir() buys the SQLite path: tests that cannot see each other's
+// rows, and can therefore run in any order.
+func openTempPostgres(t *testing.T, dsn string) *sqlitestore.Store {
+	t.Helper()
+	ctx := context.Background()
+
+	// Derived from the test name so a failure names the schema it left
+	// behind, and sanitised because test names contain slashes and spaces
+	// that are not identifier characters.
+	schema := "t_" + strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			return r
+		case r >= 'A' && r <= 'Z':
+			return r + 32
+		default:
+			return '_'
+		}
+	}, t.Name())
+	if len(schema) > 60 {
+		schema = schema[:60]
+	}
+
+	admin, err := sql.Open("pgx", dsn)
+	if err != nil {
+		t.Fatalf("open postgres: %v", err)
+	}
+	defer func() { _ = admin.Close() }()
+	if _, err := admin.ExecContext(ctx, `DROP SCHEMA IF EXISTS `+schema+` CASCADE`); err != nil {
+		t.Fatalf("reset schema: %v", err)
+	}
+	if _, err := admin.ExecContext(ctx, `CREATE SCHEMA `+schema); err != nil {
+		t.Fatalf("create schema: %v", err)
+	}
+
+	sep := "?"
+	if strings.Contains(dsn, "?") {
+		sep = "&"
+	}
+	s, err := sqlitestore.OpenPostgres(ctx, dsn+sep+"search_path="+schema)
+	if err != nil {
+		t.Fatalf("open postgres: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = s.Close()
+		// Best effort: a left-behind schema costs nothing but a name, and
+		// failing cleanup would mask the assertion that actually failed.
+		if db, err := sql.Open("pgx", dsn); err == nil {
+			_, _ = db.ExecContext(ctx, `DROP SCHEMA IF EXISTS `+schema+` CASCADE`)
+			_ = db.Close()
+		}
+	})
+	if err := s.Migrate(ctx); err != nil {
 		t.Fatalf("migrate: %v", err)
 	}
 	return s


### PR DESCRIPTION
Part E of #175, the last one. **Stacked on #178** (which is stacked on #177) — retarget as those merge.

The store speaks Postgres after #178. This is the chart that lets someone ask for it, and the removal of everything that existed only to serve a file.

## What selecting Postgres removes

The PersistentVolumeClaim, the `/data` mount, the co-scheduling `podAffinity`, and the PriorityClass. All four exist to keep two writers off one ReadWriteOnce claim. Leaving them in place would quietly reimpose the single-node constraint that choosing Postgres was meant to lift — and nothing would report an error; the pods would simply be unschedulable across nodes for a reason nobody wrote down. `uiBackend.replicaCount` is then free to rise.

`Recreate` stays on planner and executor regardless of backend: two executors draining at once is unsafe whatever the store is, and a rolling update is exactly the overlap that forbids. The executor's comment said the reason was the shared SQLite volume; that reason is now only half true, so it says both.

## Three bugs, one cause

Three deployments each spelled the database environment their own way:

- **executor set no `DATABASE_TYPE` at all** — a Postgres install would have left it opening a SQLite file nobody else was writing to. Silent.
- **planner had no postgres branch** at all.
- **The existing lint-chart assertion was vacuous.** "A Postgres install creates no PriorityClass" has never inspected anything: postgres was rejected by `values.schema.json`, so `helm template | grep -q` rendered nothing, matched nothing, and passed. Verified against `main` before changing it. It now renders into a variable and fails if the render fails.

All three deployments now take the env from one template helper, and all three binaries open the store through one `OpenFromEnv` — the same argument as one store over two: components that must agree about which database they are using should not each be told separately.

## Credentials

The DSN is assembled from parts with `url.URL` rather than formatted, so a generated password containing `@` cannot silently repoint the connection at another host. Asserted, and confirmed to fail when the DSN is built by `fmt.Sprintf`. The password is only ever read from a Secret — the chart takes no password as a value — and the chart contract now checks that no password appears as a literal in the rendered manifest. `sslmode` defaults to `require`.

## A recorded decision, reversed

Both roadmaps listed Postgres as **dropped, not deferred**, so the reversal is written down as one rather than quietly overwritten. The original reasoning was about availability and is still correct — it just was not the argument. SQLite's RWO claim pins the planner to one node, and on a packed cluster (the kind this product gets installed on) that leaves it `Pending`; v0.5.0's PriorityClass made that less likely, not impossible. Uptime was never the point. Being schedulable is.

`docs/install.md` gains a Postgres section, including the part that is easy to leave out: **there is no migration path from an existing SQLite store**, and the chart creates the schema, not the server.

## Verification

- Chart contract green, with new assertions both ways: a Postgres install carries no claim/mount/affinity/`DATABASE_PATH`, and a SQLite install still gets its claim and all three mounts. Confirmed the new check **fails** when the PVC gating is removed.
- All four DSN tests pass; the escaping one confirmed to fail against a formatted DSN.
- `TestOpenFromEnvConnectsToPostgres` runs the real env-var path against a real server.
- Full suite green on SQLite; store suite green against Postgres 16 under `-race`.