### PR TITLE
Document v0.6.0, and bump the chart to match

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,11 +274,25 @@ until the next snapshot says where they truly landed.
 execution, and maintenance windows. Phase 4 — hardening toward 1000 nodes and
 50,000 pods — is in progress, with metrics, CI and the release pipeline landed.
 
-**v0.5.0 is published** — images, chart and CLI binaries on `ghcr.io` and the
+**v0.6.0 is published** — images, chart and CLI binaries on `ghcr.io` and the
 [releases page](https://github.com/atedgimo/k8s-dencer/releases), installable by
 the command above.
 
-It is the release that made the product work on managed clusters. A real GKE
+It adds a **Postgres plan store**. Set `database.type=postgres` and the
+PersistentVolumeClaim, the `/data` mount, the required pod affinity and the
+PriorityClass all disappear, because all four exist only to keep two writers
+off one file. `uiBackend.replicaCount` becomes an ordinary value.
+
+The reason is not availability, which is what the roadmap had assumed when it
+recorded Postgres as dropped. SQLite's ReadWriteOnce claim permits multiple
+pods only on the same node, so the planner is co-scheduled onto the
+ui-backend's node and has exactly one node it may occupy — on a packed cluster
+it loses the scheduling race and sits `Pending`. It is one store speaking both
+dialects rather than two implementations, and the same test suite runs against
+both backends in CI: that suite failed fourteen tests the first time it met a
+real Postgres, one of which let two executors claim the same run.
+
+v0.5.0 before it is the release that made the product work on managed clusters. A real GKE
 run found that it could not plan at all there — see below — and fixing that
 brought the rest with it: the savings ledger in money when you say what your
 machines cost, rightsizing and maintenance windows and resilience simulation

--- a/charts/k8s-dencer/Chart.yaml
+++ b/charts/k8s-dencer/Chart.yaml
@@ -10,8 +10,8 @@ type: application
 
 # Chart version tracks the chart; appVersion tracks the images. Component image
 # tags default to appVersion so a chart release pins a coherent image set.
-version: 0.5.0
-appVersion: "0.5.0"
+version: 0.6.0
+appVersion: "0.6.0"
 
 # controller-runtime and the policy/v1 PDB API used here are stable from 1.21,
 # but the chart relies on 1.27-era defaults for restricted Pod Security

--- a/docs/product-roadmap.md
+++ b/docs/product-roadmap.md
@@ -167,6 +167,34 @@ deciding what to build next and telling users what they get.
   evicted cannot be un-evicted, so abort and pause are the same capability
   and offering both would promise an undo that does not exist
 
+### A Postgres plan store, so the planner stops being pinned to one node (2026-08-12)
+- **`database.type=postgres`** — the plan store reached over the network
+  instead of through a file, which removes the PersistentVolumeClaim, the
+  `/data` mount, the required pod affinity and the PriorityClass in one move.
+  `uiBackend.replicaCount` becomes an ordinary value
+- **Why, precisely** — not availability. SQLite's ReadWriteOnce claim permits
+  multiple pods only on the same node, so the planner is co-scheduled onto the
+  ui-backend's node and has exactly one node it may occupy. On a packed
+  cluster — the kind this product is installed on — it loses the scheduling
+  race and sits `Pending`. v0.5.0's PriorityClass made that less likely, not
+  impossible. Both roadmaps had recorded Postgres as dropped-not-deferred, and
+  that call is reversed here rather than quietly overwritten
+- **One store, both dialects** — thirty-two methods and fourteen schema
+  versions shared, differing in four places: placeholder spelling, `BLOB`,
+  `REAL`, and where the version is kept. The alternative is two things that
+  must agree, kept apart, and found to disagree by a user
+- **The same test suite runs against both backends** in CI, rather than a
+  second suite written from memory. It failed fourteen tests the first time it
+  met a real server, and one of those was a safety bug: `Claim` relied on
+  SQLite's single writer for atomicity, and Postgres let two executors take
+  the same run — two executors draining the same node
+- **Schema v14** — an insertion order the store declares itself, replacing a
+  dependency on SQLite's `rowid` that six queries had grown, backfilled so no
+  existing history reorders
+
+There is no data path from an existing SQLite store (#181), and e2e still
+runs against SQLite only (#180). Both are recorded rather than implied.
+
 ## Next
 
 Ordered by intent; items move up when a user need pulls them.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -55,6 +55,7 @@ estimated — every milestone here starts from a number in
 | **M23** | Cloud test on GKE — GKE's autoscaler reclaimed a drained node in **11m9s**, observed | **done** |
 | **M24** | The field shows what *is*, not only what *would be* — observed states overlaid on the plan, nodes and pods | **done** |
 | **M25** | Closed-loop consolidation — re-plan from observed state after every step, inside an operator-approved envelope | **done** — engine, CLI and UI |
+| **M26** | A Postgres plan store — the planner stops sharing a volume with the ui-backend, and stops being pinned to its node | **done** — v0.6.0 |
 
 High availability was **dropped, not deferred**, and stays dropped: a
 consolidation planner is not a serving path. The run queue is already crash-safe


### PR DESCRIPTION
The release commit for **v0.6.0**, stacked on #182. Merge last; the tag goes on `main` afterwards.

## What the release is

The Postgres plan store — and the honest headline is not "another backend". It is that the planner stops being pinned to one node.

SQLite's ReadWriteOnce claim permits multiple pods only on the same node, so the chart co-schedules the planner onto the ui-backend's node, leaving it exactly one node it may occupy. On a packed cluster — the kind this product gets installed on — it loses the scheduling race and sits `Pending`. v0.5.0's PriorityClass made that less likely, not impossible.

## The reversal, recorded as one

Both roadmaps had Postgres as **dropped, not deferred**, on the grounds that a consolidation planner is not a serving path. That reasoning is still correct and was never the argument — uptime was not the point, being schedulable is. Written down in both files rather than quietly overwritten, so it is not re-litigated by accident in either direction.

## Contents

- `Chart.yaml` version and appVersion → `0.6.0` (the release workflow refuses to publish if these disagree with the tag)
- README status: what an operator sets, what disappears when they set it, then why
- `docs/product-roadmap.md`: a v0.6.0 section, including what the shared test suite caught on first contact with a real server — "we ran the same tests against both backends" is only worth stating alongside what it found
- `docs/roadmap.md`: M26

The two things v0.6.0 does **not** have are named with their issue numbers rather than left to be discovered: no data path from an existing SQLite store (#181), and e2e still runs against SQLite only (#180).