### PR TITLE
Say the right thing about sslMode=disable

### DIFF
--- a/charts/k8s-dencer/templates/NOTES.txt
+++ b/charts/k8s-dencer/templates/NOTES.txt
@@ -87,7 +87,12 @@ Plan store: Postgres at {{ .Values.database.postgres.host }}:{{ .Values.database
 WARNING: no existingSecret is set, so no password is sent. That works only if the
 server authenticates this user another way (trust, peer, or a client certificate).
 {{- end }}
-{{- if not (has .Values.database.postgres.sslMode (list "verify-ca" "verify-full")) }}
+{{- if eq .Values.database.postgres.sslMode "disable" }}
+
+WARNING: sslMode=disable sends the password and every plan, run and audit
+record over the network in the clear. Use it only against a database reached
+over a trusted path, such as a sidecar or a local test cluster.
+{{- else if not (has .Values.database.postgres.sslMode (list "verify-ca" "verify-full")) }}
 
 NOTE: sslMode={{ .Values.database.postgres.sslMode }} encrypts the connection but does NOT verify the
 server's certificate, so it does not protect against an impostor on the network


### PR DESCRIPTION
Found while installing v0.7.0 against the OrbStack cluster — by running it, not by reading it.

With `sslMode=disable`, the install notes said:

> sslMode=disable encrypts the connection but does NOT verify the server's certificate

Nothing is encrypted with `disable`. The condition matched every mode that isn't `verify-ca`/`verify-full`, so the **weakest** setting received the *milder* of the two warnings — the one about certificate verification rather than the one about plaintext.

`disable` now says what it actually does: the password and every plan, run and audit record cross the network in the clear. It also names the case where that is a reasonable choice, because a local test cluster is precisely where someone will set it, and a warning that reads as absolute gets ignored.

`require` keeps the verification warning unchanged. Both branches verified by rendering.