### PR TITLE
Find the backend by label, and stop calling a live plan stale

### DIFF
--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -238,16 +238,68 @@ func tokenViaTransport(cfg *rest.Config) (string, error) {
 	return tok, nil
 }
 
+// findBackendService locates the ui-backend Service by the labels the chart
+// puts on it, rather than by rebuilding its name.
+//
+// The name was `<release>-ui-backend`, which is right for exactly one release
+// name. The chart derives it from the standard fullname helper —
+// `<release>-<chart>`, collapsing to just `<release>` when the release already
+// contains the chart name — so `helm install dencer` produces
+// `dencer-k8s-dencer-ui-backend` and the CLI could not find its own backend.
+// The error even suggested passing --release, which the user had already done
+// correctly; the value that works is the fullname, which is not a release name
+// at all.
+//
+// Labels are the fix rather than a second copy of the fullname template,
+// because two places that must agree and are kept apart will drift — the
+// lesson this project keeps relearning. The chart already selects its own pods
+// with these labels, so they cannot silently change.
+func findBackendService(ctx context.Context, cs kubernetes.Interface, ns, release string) (*corev1.Service, error) {
+	const base = "app.kubernetes.io/name=k8s-dencer,app.kubernetes.io/component=ui-backend"
+
+	// Scoped to the release first, so a namespace holding two installs picks
+	// the one asked for.
+	scoped := base + ",app.kubernetes.io/instance=" + release
+	for _, sel := range []string{scoped, base} {
+		list, err := cs.CoreV1().Services(ns).List(ctx, metav1.ListOptions{LabelSelector: sel})
+		if err != nil {
+			return nil, fmt.Errorf("list services in %s: %w", ns, err)
+		}
+		switch len(list.Items) {
+		case 0:
+			continue
+		case 1:
+			return &list.Items[0], nil
+		default:
+			names := make([]string, 0, len(list.Items))
+			for i := range list.Items {
+				names = append(names, list.Items[i].Name)
+			}
+			return nil, fmt.Errorf(
+				"found %d k8s-dencer backends in namespace %s (%s)\n"+
+					"Pass --release to choose one", len(list.Items), ns, strings.Join(names, ", "))
+		}
+	}
+
+	// Fall back to the constructed name purely so the error can say what it
+	// looked for; an install predating these labels would still be found.
+	legacy := release + "-ui-backend"
+	if svc, err := cs.CoreV1().Services(ns).Get(ctx, legacy, metav1.GetOptions{}); err == nil {
+		return svc, nil
+	}
+	return nil, fmt.Errorf(
+		"no k8s-dencer ui-backend Service in namespace %s\n"+
+			"Looked for labels %s. Pass --namespace if the release is elsewhere, or\n"+
+			"--server if the backend is reachable directly", ns, base)
+}
+
 // forward opens a port-forward to the ui-backend Service.
 func forward(ctx context.Context, cfg *rest.Config, cs kubernetes.Interface, ns, release string) (int, func(), error) {
-	svcName := release + "-ui-backend"
-	svc, err := cs.CoreV1().Services(ns).Get(ctx, svcName, metav1.GetOptions{})
+	svc, err := findBackendService(ctx, cs, ns, release)
 	if err != nil {
-		return 0, nil, fmt.Errorf(
-			"could not find Service %s/%s: %w\n"+
-				"Pass --namespace/--release if the release is named differently, or --server if the\n"+
-				"backend is reachable directly", ns, svcName, err)
+		return 0, nil, err
 	}
+	svcName := svc.Name
 	port := int32(8080)
 	if len(svc.Spec.Ports) > 0 {
 		port = svc.Spec.Ports[0].Port

--- a/internal/cli/discover_test.go
+++ b/internal/cli/discover_test.go
@@ -1,0 +1,168 @@
+package cli
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/atedgimo/k8s-dencer/internal/model"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func backendSvc(name, ns, instance string) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+			Labels: map[string]string{
+				"app.kubernetes.io/name":      "k8s-dencer",
+				"app.kubernetes.io/component": "ui-backend",
+				"app.kubernetes.io/instance":  instance,
+			},
+		},
+	}
+}
+
+// The CLI used to rebuild the Service name as `<release>-ui-backend`, which is
+// correct for exactly one release name — k8s-dencer, the one in every doc. The
+// chart derives it from the fullname helper, so `helm install dencer` produces
+// dencer-k8s-dencer-ui-backend and the CLI could not find its own backend.
+//
+// Worse, the error told the user to pass --release, which they had already
+// passed correctly; the value that actually worked was the fullname, which is
+// not a release name at all.
+func TestBackendIsFoundWhateverTheReleaseIsCalled(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		svc     string
+		release string
+	}{
+		{"conventional release", "k8s-dencer-ui-backend", "k8s-dencer"},
+		{"release without the chart name", "dencer-k8s-dencer-ui-backend", "dencer"},
+		{"release nothing like the chart", "platform-tools-k8s-dencer-ui-backend", "platform-tools"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cs := fake.NewClientset(backendSvc(tc.svc, "ns", tc.release))
+			got, err := findBackendService(context.Background(), cs, "ns", tc.release)
+			if err != nil {
+				t.Fatalf("could not find the backend: %v", err)
+			}
+			if got.Name != tc.svc {
+				t.Errorf("found %q, want %q", got.Name, tc.svc)
+			}
+		})
+	}
+}
+
+// Two installs in one namespace is unusual but legal, and picking either at
+// random would send commands to the wrong cluster's plan.
+func TestTwoInstallsAreDistinguishedByRelease(t *testing.T) {
+	cs := fake.NewClientset(
+		backendSvc("a-k8s-dencer-ui-backend", "ns", "a"),
+		backendSvc("b-k8s-dencer-ui-backend", "ns", "b"),
+	)
+	got, err := findBackendService(context.Background(), cs, "ns", "b")
+	if err != nil {
+		t.Fatalf("find: %v", err)
+	}
+	if got.Name != "b-k8s-dencer-ui-backend" {
+		t.Errorf("found %q, want the release that was asked for", got.Name)
+	}
+}
+
+// And if the release named does not match either, say so rather than guessing.
+func TestAmbiguousInstallsAreReportedNotGuessed(t *testing.T) {
+	cs := fake.NewClientset(
+		backendSvc("a-k8s-dencer-ui-backend", "ns", "a"),
+		backendSvc("b-k8s-dencer-ui-backend", "ns", "b"),
+	)
+	_, err := findBackendService(context.Background(), cs, "ns", "neither")
+	if err == nil {
+		t.Fatal("two candidate backends were silently narrowed to one")
+	}
+	for _, want := range []string{"a-k8s-dencer-ui-backend", "b-k8s-dencer-ui-backend", "--release"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error should name %q so the user can choose: %v", want, err)
+		}
+	}
+}
+
+// An install predating these labels is still reachable by its old name.
+func TestUnlabelledInstallStillResolves(t *testing.T) {
+	cs := fake.NewClientset(&corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "k8s-dencer-ui-backend", Namespace: "ns"},
+	})
+	got, err := findBackendService(context.Background(), cs, "ns", "k8s-dencer")
+	if err != nil {
+		t.Fatalf("legacy install unreachable: %v", err)
+	}
+	if got.Name != "k8s-dencer-ui-backend" {
+		t.Errorf("found %q", got.Name)
+	}
+}
+
+// Nothing installed is a different message from the wrong release, and it must
+// not repeat advice the user has already followed.
+func TestMissingBackendSaysWhatItLookedFor(t *testing.T) {
+	cs := fake.NewClientset()
+	_, err := findBackendService(context.Background(), cs, "ns", "k8s-dencer")
+	if err == nil {
+		t.Fatal("expected an error with no backend installed")
+	}
+	if !strings.Contains(err.Error(), "app.kubernetes.io/component=ui-backend") {
+		t.Errorf("error does not say what it looked for: %v", err)
+	}
+}
+
+// A plan ID is a content hash, so a stable cluster produces the same plan
+// every cycle and GeneratedAt stays at the moment those steps were first
+// computed. Reporting that as the plan's age tells an operator nobody has
+// planned since yesterday, while the planner is re-confirming it every thirty
+// seconds — and while the UI, reading planConfirmedAt, says "confirmed just
+// now" about the same plan.
+//
+// Observed on a real cluster: "plan 51e99333b1a5  20h33m54s old" seconds after
+// the planner logged that exact plan ID.
+func TestFreshnessSeparatesConfirmedFromUnchanged(t *testing.T) {
+	now := time.Now()
+
+	t.Run("stable cluster reports both", func(t *testing.T) {
+		env := &PlanEnvelope{
+			Plan:     &model.Plan{GeneratedAt: now.Add(-20 * time.Hour)},
+			StoredAt: now.Add(-9 * time.Second),
+		}
+		got := freshness(env)
+		if !strings.Contains(got, "confirmed") {
+			t.Errorf("a plan re-confirmed 9s ago reads as stale: %q", got)
+		}
+		if !strings.Contains(got, "unchanged for 20h") {
+			t.Errorf("how long the plan has been stable is worth keeping: %q", got)
+		}
+	})
+
+	t.Run("changing cluster says it once", func(t *testing.T) {
+		env := &PlanEnvelope{
+			Plan:     &model.Plan{GeneratedAt: now.Add(-12 * time.Second)},
+			StoredAt: now.Add(-12 * time.Second),
+		}
+		got := freshness(env)
+		if strings.Contains(got, "confirmed") {
+			t.Errorf("a freshly computed plan should not need two clauses: %q", got)
+		}
+		if !strings.Contains(got, "old") {
+			t.Errorf("want the plain form: %q", got)
+		}
+	})
+
+	t.Run("no stored time falls back rather than claiming 1970", func(t *testing.T) {
+		env := &PlanEnvelope{Plan: &model.Plan{GeneratedAt: now.Add(-time.Minute)}}
+		got := freshness(env)
+		if strings.Contains(got, "confirmed") {
+			t.Errorf("with no confirmation time there is nothing to report: %q", got)
+		}
+	})
+}

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -123,12 +123,40 @@ func reclaimSummary(env *PlanEnvelope) string {
 	return out + ")"
 }
 
+// freshness describes how current the plan is, in the terms the UI uses.
+//
+// This used to be time.Since(GeneratedAt), which reads as "nobody has planned
+// in 20 hours" for a plan the planner has been re-confirming every 30 seconds.
+// A plan ID is a content hash, so a stable cluster produces the same plan
+// forever and GeneratedAt stays at the moment those steps were first computed;
+// StoredAt is refreshed on every cycle that agrees.
+//
+// The UI already got this right — it reads planConfirmedAt and says "confirmed
+// just now" — so the CLI saying "20h33m old" about the same plan left the two
+// surfaces contradicting each other about the same object, which is the thing
+// this CLI's design goes out of its way to avoid elsewhere.
+//
+// Both facts are kept when they differ, because both are worth knowing: how
+// long ago anything changed, and whether the planner is still running.
+func freshness(env *PlanEnvelope) string {
+	confirmed := time.Since(env.StoredAt).Round(time.Second)
+	computed := time.Since(env.Plan.GeneratedAt).Round(time.Second)
+
+	if env.StoredAt.IsZero() {
+		return fmt.Sprintf("%s old", computed)
+	}
+	// A minute's slack: on a changing cluster the two are the same event, and
+	// printing both would be noise.
+	if computed-confirmed < time.Minute {
+		return fmt.Sprintf("%s old", computed)
+	}
+	return fmt.Sprintf("confirmed %s ago, unchanged for %s", confirmed, computed)
+}
+
 // PrintPlan renders a plan as a table.
 func PrintPlan(w io.Writer, env *PlanEnvelope, awaiting int) {
 	p := env.Plan
-	age := time.Since(p.GeneratedAt).Round(time.Second)
-
-	fmt.Fprintf(w, "%s  %s\n", bold("plan "+p.ID), dim(fmt.Sprintf("%s old, %s", age, env.Strategy)))
+	fmt.Fprintf(w, "%s  %s\n", bold("plan "+p.ID), dim(freshness(env)+", "+env.Strategy))
 	fmt.Fprintf(w, "%d nodes now, %d after, %s\n\n",
 		p.NodesBefore, p.NodesAfter, bold(reclaimSummary(env)))
 


### PR DESCRIPTION
Closes #187. Two CLI bugs, both found by running v0.7.0 against a real cluster rather than by reading it.

## 1. The CLI could not find its own backend (#187)

It built the Service name as `<release>-ui-backend`. The chart derives it from the fullname helper — `<release>-<chart>`, collapsing to just the release when the release already contains the chart name.

Those agree for exactly one release name: `k8s-dencer`, the one in every doc.

```
$ dencer plan -n dencer-pg --release dencer
error: could not find Service dencer-pg/dencer-ui-backend: not found
```

The Service was `dencer-k8s-dencer-ui-backend`. The error then advised passing `--release` — which the user had already passed correctly. The value that works is the *fullname*, which is not a release name at all, and nothing said so.

**Fix:** find the Service by the labels the chart puts on it (`app.kubernetes.io/name=k8s-dencer,component=ui-backend`), scoped to `instance=<release>` first so two installs in one namespace stay distinguishable, reporting ambiguity by name rather than picking one. An unlabelled install is still reachable by its old name.

Rebuilding the fullname template in Go was the other option and is the worse one: a second copy of something that must agree with the chart. That is the mistake this project has now found in the store, in the deployment templates, and here.

## 2. A live plan reported as 20 hours old

Worse, because it was believable.

A plan ID is a content hash, so a stable cluster produces the same plan every cycle: `GeneratedAt` stays at the moment those steps were first computed, while `StoredAt` is refreshed by every cycle that agrees. The header printed `time.Since(GeneratedAt)`.

Observed on OrbStack, seconds after the planner logged that exact plan ID:

```
plan 51e99333b1a5  20h33m54s old, greedy-first-fit-decreasing
```

An operator reads that as "nobody has planned since yesterday" — the opposite of what is happening. **The UI already had this right**, reading `planConfirmedAt` and saying "confirmed just now", so the two surfaces were contradicting each other about the same object. That is precisely what this CLI's design avoids elsewhere: constraint explanations are printed verbatim so a constraint cannot be described two ways.

Now:

```
plan 51e99333b1a5  confirmed 9s ago, unchanged for 20h35m55s, greedy-first-fit-decreasing
```

Both facts when they differ — how long since anything changed, and whether the planner is still alive — collapsing to the plain `Xs old` when they are the same event.

## Verification

Both confirmed against the live OrbStack cluster. The discovery test fails with the old name-building restored, naming the exact Service it could not find. Full suite green.