### PR TITLE
Name the failure instead of taking the Service down

### DIFF
--- a/cmd/ui-backend/main.go
+++ b/cmd/ui-backend/main.go
@@ -151,15 +151,12 @@ func run(ctx context.Context, log *slog.Logger) error {
 	// volume. The ID is a content hash, so the check is a string comparison.
 	go api.PollStore(ctx, duration(log, "POLL_INTERVAL", 5*time.Second))
 
-	// The schema is migrated and the store is open, so the API can serve —
-	// and it keeps being asked, rather than only being asked once. A store
-	// that migrates cleanly at startup can still stop having the tables in it,
-	// and a ui-backend that reports Ready while answering every request with
-	// "relation does not exist" is worse than one that reports NotReady.
+	// The schema is migrated and the store is open, so the API can serve.
 	//
-	// ActiveRun is the right question: it is a real query against a table the
-	// product needs, and ErrNotFound is its healthy answer on an idle cluster,
-	// so a working store cannot fail this by being quiet.
+	// Reported by /dependenciesz, not by /readyz — see AddCheck. ActiveRun is
+	// the right question: a real query against a table the product needs,
+	// whose ErrNotFound is the healthy answer on an idle cluster, so a working
+	// store cannot fail it by being quiet.
 	health.AddCheck("plan store", func(ctx context.Context) error {
 		if _, err := db.ActiveRun(ctx); err != nil && !errors.Is(err, store.ErrNotFound) {
 			return err

--- a/cmd/ui-backend/main.go
+++ b/cmd/ui-backend/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/atedgimo/k8s-dencer/internal/auth"
 	"github.com/atedgimo/k8s-dencer/internal/httpserver"
 	"github.com/atedgimo/k8s-dencer/internal/pricing"
+	"github.com/atedgimo/k8s-dencer/internal/store"
 	sqlitestore "github.com/atedgimo/k8s-dencer/internal/store/sqlstore"
 	"github.com/atedgimo/k8s-dencer/internal/telemetry"
 	"github.com/atedgimo/k8s-dencer/internal/window"
@@ -150,7 +151,21 @@ func run(ctx context.Context, log *slog.Logger) error {
 	// volume. The ID is a content hash, so the check is a string comparison.
 	go api.PollStore(ctx, duration(log, "POLL_INTERVAL", 5*time.Second))
 
-	// The schema is migrated and the store is open, so the API can serve.
+	// The schema is migrated and the store is open, so the API can serve —
+	// and it keeps being asked, rather than only being asked once. A store
+	// that migrates cleanly at startup can still stop having the tables in it,
+	// and a ui-backend that reports Ready while answering every request with
+	// "relation does not exist" is worse than one that reports NotReady.
+	//
+	// ActiveRun is the right question: it is a real query against a table the
+	// product needs, and ErrNotFound is its healthy answer on an idle cluster,
+	// so a working store cannot fail this by being quiet.
+	health.AddCheck("plan store", func(ctx context.Context) error {
+		if _, err := db.ActiveRun(ctx); err != nil && !errors.Is(err, store.ErrNotFound) {
+			return err
+		}
+		return nil
+	})
 	health.SetReady(true)
 	log.Info("starting", "version", version, "database", dbDesc)
 

--- a/internal/api/rest/execute.go
+++ b/internal/api/rest/execute.go
@@ -242,6 +242,12 @@ func (s *Server) failRun(w http.ResponseWriter, err error) {
 		writeError(w, http.StatusNotFound, "no such run")
 		return
 	}
+	if store.IsUnavailable(err) {
+		s.log.Error("plan store unavailable", "error", err)
+		writeError(w, http.StatusServiceUnavailable,
+			"plan store unavailable — the run may still be executing; the executor owns it, not this request")
+		return
+	}
 	s.log.Error("run request failed", "error", err)
 	writeError(w, http.StatusInternalServerError, "internal error")
 }

--- a/internal/api/rest/rest.go
+++ b/internal/api/rest/rest.go
@@ -484,6 +484,16 @@ func (s *Server) fail(w http.ResponseWriter, err error) {
 		writeError(w, http.StatusNotFound, "no plan available yet")
 		return
 	}
+	// A store that cannot answer is not an internal error, and calling it one
+	// sends an operator looking through the wrong logs. 503 also says the
+	// right thing to anything that retries: this may work shortly, and it is
+	// not the request's fault.
+	if store.IsUnavailable(err) {
+		s.log.Error("plan store unavailable", "error", err)
+		writeError(w, http.StatusServiceUnavailable,
+			"plan store unavailable — the API is up but cannot reach its database")
+		return
+	}
 	s.log.Error("request failed", "error", err)
 	writeError(w, http.StatusInternalServerError, "internal error")
 }

--- a/internal/httpserver/readiness_test.go
+++ b/internal/httpserver/readiness_test.go
@@ -1,0 +1,99 @@
+package httpserver
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func probeReady(t *testing.T, h *Health) *httptest.ResponseRecorder {
+	t.Helper()
+	mux := http.NewServeMux()
+	h.Register(mux)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+	return rec
+}
+
+// Readiness used to be a latch: set once at startup and never asked again. A
+// ui-backend that migrated its database successfully and then had the schema
+// disappear underneath it stayed Ready and served "relation does not exist" to
+// every request, indefinitely, because nothing ever asked the store a question
+// a second time.
+func TestReadinessReflectsTheDependencyNotJustTheLatch(t *testing.T) {
+	var h Health
+	broken := errors.New(`relation "runs" does not exist`)
+	fail := false
+	h.AddCheck("plan store", func(context.Context) error {
+		if fail {
+			return broken
+		}
+		return nil
+	})
+	h.SetReady(true)
+
+	if rec := probeReady(t, &h); rec.Code != http.StatusOK {
+		t.Fatalf("healthy store reported not ready: %d %s", rec.Code, rec.Body)
+	}
+
+	fail = true
+	rec := probeReady(t, &h)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("store is unusable and the pod still reports ready: %d", rec.Code)
+	}
+	// The operator reads this in `kubectl describe`, so it has to say which
+	// dependency and why.
+	for _, want := range []string{"plan store", "relation"} {
+		if !strings.Contains(rec.Body.String(), want) {
+			t.Errorf("readiness failure does not say %q: %s", want, rec.Body.String())
+		}
+	}
+
+	// And it recovers on its own once the dependency does, without a restart.
+	fail = false
+	if rec := probeReady(t, &h); rec.Code != http.StatusOK {
+		t.Errorf("readiness did not recover with the store: %d", rec.Code)
+	}
+}
+
+// The latch still comes first: a component still starting up is not ready
+// however healthy its dependencies are.
+func TestUnstartedComponentIsNotReadyEvenWithHealthyChecks(t *testing.T) {
+	var h Health
+	h.AddCheck("plan store", func(context.Context) error { return nil })
+
+	if rec := probeReady(t, &h); rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("a component that never called SetReady reports ready: %d", rec.Code)
+	}
+}
+
+// Liveness must not follow the dependency. A probe that restarts the container
+// when the database blips turns a small outage into every pod restarting at
+// once.
+func TestLivenessIgnoresDependencies(t *testing.T) {
+	var h Health
+	h.AddCheck("plan store", func(context.Context) error { return errors.New("down") })
+	h.SetReady(true)
+
+	mux := http.NewServeMux()
+	h.Register(mux)
+	for _, path := range []string{"/healthz", "/startupz"} {
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+		if rec.Code != http.StatusOK {
+			t.Errorf("%s failed because a dependency is down (%d); that restarts the container", path, rec.Code)
+		}
+	}
+}
+
+// A component with no dependencies registered behaves exactly as before.
+func TestNoChecksIsTheOldBehaviour(t *testing.T) {
+	var h Health
+	h.SetReady(true)
+	if rec := probeReady(t, &h); rec.Code != http.StatusOK {
+		t.Errorf("a component with no checks is no longer ready: %d", rec.Code)
+	}
+}

--- a/internal/httpserver/readiness_test.go
+++ b/internal/httpserver/readiness_test.go
@@ -18,12 +18,15 @@ func probeReady(t *testing.T, h *Health) *httptest.ResponseRecorder {
 	return rec
 }
 
-// Readiness used to be a latch: set once at startup and never asked again. A
-// ui-backend that migrated its database successfully and then had the schema
-// disappear underneath it stayed Ready and served "relation does not exist" to
-// every request, indefinitely, because nothing ever asked the store a question
-// a second time.
-func TestReadinessReflectsTheDependencyNotJustTheLatch(t *testing.T) {
+// Readiness must NOT follow a dependency every replica shares.
+//
+// The tempting version of this fix failed /readyz when the store was
+// unreachable. That takes every pod out of the Service at the same moment,
+// leaving zero endpoints and a bare 503 from the ingress — "some requests fail
+// with a message" becomes "nothing answers at all", and a rolling update can
+// stall because no pod ever becomes Ready. The store's absence is reported by
+// the API's own 503 and by /dependenciesz instead.
+func TestReadinessIgnoresSharedDependencies(t *testing.T) {
 	var h Health
 	broken := errors.New(`relation "runs" does not exist`)
 	fail := false
@@ -40,28 +43,57 @@ func TestReadinessReflectsTheDependencyNotJustTheLatch(t *testing.T) {
 	}
 
 	fail = true
-	rec := probeReady(t, &h)
-	if rec.Code != http.StatusServiceUnavailable {
-		t.Errorf("store is unusable and the pod still reports ready: %d", rec.Code)
+	if rec := probeReady(t, &h); rec.Code != http.StatusOK {
+		t.Errorf("a shared dependency failure took the pod out of the Service: %d %s", rec.Code, rec.Body)
 	}
-	// The operator reads this in `kubectl describe`, so it has to say which
-	// dependency and why.
+}
+
+// The dependency is still reported — just somewhere the kubelet is not
+// reading, so monitoring and a human with curl can both see it.
+func TestDependenciesEndpointReportsTheFailure(t *testing.T) {
+	var h Health
+	broken := errors.New(`relation "runs" does not exist`)
+	fail := false
+	h.AddCheck("plan store", func(context.Context) error {
+		if fail {
+			return broken
+		}
+		return nil
+	})
+	h.SetReady(true)
+
+	probe := func() *httptest.ResponseRecorder {
+		mux := http.NewServeMux()
+		h.Register(mux)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/dependenciesz", nil))
+		return rec
+	}
+
+	if rec := probe(); rec.Code != http.StatusOK {
+		t.Fatalf("healthy dependency reported down: %d %s", rec.Code, rec.Body)
+	}
+
+	fail = true
+	rec := probe()
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("broken dependency reported healthy: %d", rec.Code)
+	}
 	for _, want := range []string{"plan store", "relation"} {
 		if !strings.Contains(rec.Body.String(), want) {
-			t.Errorf("readiness failure does not say %q: %s", want, rec.Body.String())
+			t.Errorf("report does not say %q: %s", want, rec.Body.String())
 		}
 	}
 
-	// And it recovers on its own once the dependency does, without a restart.
 	fail = false
-	if rec := probeReady(t, &h); rec.Code != http.StatusOK {
-		t.Errorf("readiness did not recover with the store: %d", rec.Code)
+	if rec := probe(); rec.Code != http.StatusOK {
+		t.Errorf("did not recover with the dependency: %d", rec.Code)
 	}
 }
 
 // The latch still comes first: a component still starting up is not ready
 // however healthy its dependencies are.
-func TestUnstartedComponentIsNotReadyEvenWithHealthyChecks(t *testing.T) {
+func TestUnstartedComponentIsNotReady(t *testing.T) {
 	var h Health
 	h.AddCheck("plan store", func(context.Context) error { return nil })
 

--- a/internal/httpserver/server.go
+++ b/internal/httpserver/server.go
@@ -27,21 +27,24 @@ type namedCheck struct {
 	fn   func(context.Context) error
 }
 
-// AddCheck registers a dependency that must be usable for the component to be
-// ready, consulted on every probe rather than latched once at startup.
+// AddCheck registers a dependency reported by /dependenciesz.
 //
-// The latch alone was not enough. A ui-backend that migrated its database
-// successfully and then had the schema disappear underneath it — a restore
-// from before the current version, a failover to a lagging replica, a wrong
-// database name — stayed Ready and served "internal error" to every request
-// indefinitely, because nothing ever asked the store a question again.
+// Explicitly NOT wired into /readyz, and the reasoning is worth keeping,
+// because the obvious thing to do here is the wrong one.
 //
-// Deliberately readiness and not liveness. Liveness restarts the container,
-// and a probe that restarts on a dependency failure turns a brief database
-// blip into every pod restarting at once, which is the standard way to convert
-// a small outage into a large one. Readiness takes the pod out of the Service
-// so a healthy replica serves, and makes the failure visible as 0/1 Ready
-// rather than as HTTP 500s an operator has to go looking for.
+// Readiness decides Service membership. Failing it on a dependency every
+// replica shares means that when the database goes down, every pod goes
+// NotReady at the same moment, the Service drops to zero endpoints, and the
+// ingress returns a bare 503 with no explanation — turning "some requests fail
+// with a message" into "nothing answers at all". It can also stall a rolling
+// update, since no new pod ever becomes Ready.
+//
+// The failure this was written for — a store that has gone away — is therefore
+// handled where it is actually visible: the API answers 503 naming the plan
+// store instead of "internal error", so an operator reads the cause in the
+// response rather than inferring it from an empty endpoint list. This endpoint
+// exists for monitoring and for a human with curl, neither of which should be
+// able to take the Service down by asking a question.
 func (h *Health) AddCheck(name string, fn func(context.Context) error) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
@@ -81,22 +84,29 @@ func (h *Health) Register(mux *http.ServeMux) {
 	}
 	mux.HandleFunc("GET /healthz", alive)
 	mux.HandleFunc("GET /startupz", alive)
-	mux.HandleFunc("GET /readyz", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("GET /readyz", func(w http.ResponseWriter, _ *http.Request) {
 		if !h.ready.Load() {
 			http.Error(w, "not ready", http.StatusServiceUnavailable)
 			return
 		}
-		// Bounded, because a probe that hangs is reported as a failure only
-		// after the kubelet's own timeout, and a database that has stopped
-		// answering is exactly when this runs.
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ready"))
+	})
+
+	// Dependency state, for monitoring and for a human with curl. The kubelet
+	// does not read this, so a database outage cannot empty the Service
+	// through it.
+	mux.HandleFunc("GET /dependenciesz", func(w http.ResponseWriter, r *http.Request) {
+		// Bounded, because a dependency that has stopped answering is exactly
+		// when this runs, and a hanging probe is worse than a failing one.
 		ctx, cancel := context.WithTimeout(r.Context(), 3*time.Second)
 		defer cancel()
 		if name, err := h.probe(ctx); err != nil {
-			http.Error(w, "not ready: "+name+": "+err.Error(), http.StatusServiceUnavailable)
+			http.Error(w, name+": "+err.Error(), http.StatusServiceUnavailable)
 			return
 		}
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte("ready"))
+		_, _ = w.Write([]byte("ok"))
 	})
 }
 

--- a/internal/httpserver/server.go
+++ b/internal/httpserver/server.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"sync"
 	"sync/atomic"
 	"time"
 )
@@ -16,6 +17,50 @@ import (
 // dependencies (informer caches, database migrations) are satisfied.
 type Health struct {
 	ready atomic.Bool
+
+	mu     sync.Mutex
+	checks []namedCheck
+}
+
+type namedCheck struct {
+	name string
+	fn   func(context.Context) error
+}
+
+// AddCheck registers a dependency that must be usable for the component to be
+// ready, consulted on every probe rather than latched once at startup.
+//
+// The latch alone was not enough. A ui-backend that migrated its database
+// successfully and then had the schema disappear underneath it — a restore
+// from before the current version, a failover to a lagging replica, a wrong
+// database name — stayed Ready and served "internal error" to every request
+// indefinitely, because nothing ever asked the store a question again.
+//
+// Deliberately readiness and not liveness. Liveness restarts the container,
+// and a probe that restarts on a dependency failure turns a brief database
+// blip into every pod restarting at once, which is the standard way to convert
+// a small outage into a large one. Readiness takes the pod out of the Service
+// so a healthy replica serves, and makes the failure visible as 0/1 Ready
+// rather than as HTTP 500s an operator has to go looking for.
+func (h *Health) AddCheck(name string, fn func(context.Context) error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.checks = append(h.checks, namedCheck{name: name, fn: fn})
+}
+
+// probe runs every registered check, returning the first failure.
+func (h *Health) probe(ctx context.Context) (string, error) {
+	h.mu.Lock()
+	checks := make([]namedCheck, len(h.checks))
+	copy(checks, h.checks)
+	h.mu.Unlock()
+
+	for _, c := range checks {
+		if err := c.fn(ctx); err != nil {
+			return c.name, err
+		}
+	}
+	return "", nil
 }
 
 // SetReady marks the component ready to serve traffic.
@@ -36,9 +81,18 @@ func (h *Health) Register(mux *http.ServeMux) {
 	}
 	mux.HandleFunc("GET /healthz", alive)
 	mux.HandleFunc("GET /startupz", alive)
-	mux.HandleFunc("GET /readyz", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc("GET /readyz", func(w http.ResponseWriter, r *http.Request) {
 		if !h.ready.Load() {
 			http.Error(w, "not ready", http.StatusServiceUnavailable)
+			return
+		}
+		// Bounded, because a probe that hangs is reported as a failure only
+		// after the kubelet's own timeout, and a database that has stopped
+		// answering is exactly when this runs.
+		ctx, cancel := context.WithTimeout(r.Context(), 3*time.Second)
+		defer cancel()
+		if name, err := h.probe(ctx); err != nil {
+			http.Error(w, "not ready: "+name+": "+err.Error(), http.StatusServiceUnavailable)
 			return
 		}
 		w.WriteHeader(http.StatusOK)

--- a/internal/store/unavailable.go
+++ b/internal/store/unavailable.go
@@ -1,0 +1,67 @@
+package store
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"net"
+	"strings"
+)
+
+// ErrUnavailable means the plan store could not be reached or is not usable —
+// as distinct from a query that ran and found nothing (ErrNotFound), or a bug.
+//
+// The distinction is what an operator sees. A ui-backend whose database has
+// gone away answered every request with "internal error", which says only that
+// something is wrong somewhere in a product with a lot of somewheres. Naming
+// the store turns an investigation into a glance.
+var ErrUnavailable = errors.New("plan store unavailable")
+
+// IsUnavailable reports whether err means the store cannot currently serve.
+//
+// Deliberately here rather than in the SQL implementation, and deliberately
+// without importing either driver: pgconn's error type exposes SQLState()
+// through an interface, so the Postgres codes can be recognised without this
+// package depending on pgx. The two drivers disagree about everything else, so
+// the rest is matched on what they have in common.
+func IsUnavailable(err error) bool {
+	if err == nil || errors.Is(err, ErrNotFound) {
+		return false
+	}
+	if errors.Is(err, ErrUnavailable) ||
+		errors.Is(err, driver.ErrBadConn) ||
+		errors.Is(err, sql.ErrConnDone) {
+		return true
+	}
+
+	// The connection itself never came up, or went away mid-flight.
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return true
+	}
+
+	// Postgres, via any error type carrying a SQLSTATE. Class 08 is
+	// connection exception; the rest are the specific ways a database can be
+	// present but unusable — including a schema that is not there, which is
+	// what a restore from before the current version looks like.
+	var coded interface{ SQLState() string }
+	if errors.As(err, &coded) {
+		code := coded.SQLState()
+		switch {
+		case strings.HasPrefix(code, "08"): // connection exception
+			return true
+		case code == "42P01", // undefined_table
+			code == "3D000", // invalid_catalog_name
+			code == "57P03", // cannot_connect_now
+			code == "53300": // too_many_connections
+			return true
+		}
+	}
+
+	// SQLite has no error codes worth matching on, and its failure here is the
+	// same shape: the file is gone, or was never migrated.
+	msg := err.Error()
+	return strings.Contains(msg, "no such table") ||
+		strings.Contains(msg, "database is locked") ||
+		strings.Contains(msg, "unable to open database")
+}

--- a/internal/store/unavailable_test.go
+++ b/internal/store/unavailable_test.go
@@ -1,0 +1,63 @@
+package store_test
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/atedgimo/k8s-dencer/internal/store"
+)
+
+// A stand-in for pgconn.PgError, which is recognised through its SQLState
+// method rather than its type so this package need not import a driver.
+type pgErr struct{ code, msg string }
+
+func (e pgErr) Error() string    { return "ERROR: " + e.msg + " (SQLSTATE " + e.code + ")" }
+func (e pgErr) SQLState() string { return e.code }
+
+func TestUnavailableRecognisesAStoreThatCannotServe(t *testing.T) {
+	for name, err := range map[string]error{
+		// The one that started this: a schema that is not there, which is what
+		// a restore from before the current version looks like.
+		"postgres missing table":  pgErr{"42P01", `relation "runs" does not exist`},
+		"postgres wrong database": pgErr{"3D000", "database does not exist"},
+		"postgres starting up":    pgErr{"57P03", "the database system is starting up"},
+		"postgres out of conns":   pgErr{"53300", "too many connections"},
+		"postgres connection":     pgErr{"08006", "connection failure"},
+		"connection refused":      fmt.Errorf("dial: %w", &net.OpError{Op: "dial", Err: errors.New("connection refused")}),
+		"bad conn":                fmt.Errorf("query: %w", driver.ErrBadConn),
+		"closed pool":             fmt.Errorf("query: %w", sql.ErrConnDone),
+		"sqlite unmigrated":       errors.New("no such table: runs"),
+		"sqlite file gone":        errors.New("unable to open database file"),
+		"already classified":      fmt.Errorf("wrapped: %w", store.ErrUnavailable),
+	} {
+		t.Run(name, func(t *testing.T) {
+			if !store.IsUnavailable(err) {
+				t.Errorf("not recognised as an unavailable store: %v", err)
+			}
+		})
+	}
+}
+
+// The distinction is the whole point: these must stay "internal error" or
+// "not found", because reporting them as an unreachable database sends an
+// operator to look at Postgres when the problem is here.
+func TestUnavailableDoesNotSwallowRealErrors(t *testing.T) {
+	for name, err := range map[string]error{
+		"nothing wrong":       nil,
+		"empty store":         store.ErrNotFound,
+		"wrapped not found":   fmt.Errorf("latest: %w", store.ErrNotFound),
+		"a bug":               errors.New("nil pointer dereference"),
+		"bad json in a row":   errors.New("unmarshal snapshot: unexpected end of JSON input"),
+		"constraint violated": pgErr{"23505", "duplicate key value violates unique constraint"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if store.IsUnavailable(err) {
+				t.Errorf("misreported as an unavailable store: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #190. **Reworked after review** — the first version of this PR failed `/readyz` on the store, and that was the wrong lever.

## Why the obvious fix was wrong

Readiness decides Service membership. Failing it on a dependency **every replica shares** means that when the database goes down:

- every pod goes NotReady at the same moment
- the Service drops to zero endpoints
- the ingress answers with a bare 503 and no explanation
- a rolling update can stall, because no new pod ever becomes Ready

That converts "some requests fail with a message" into "nothing answers at all". It would only have helped in the partial case — one replica loses the database while the others still have it.

## What it does instead

`store.ErrNotFound` already separated *the query found nothing* from *something went wrong*. `store.IsUnavailable` now separates *the store cannot answer* from *there is a bug here*, and the API returns:

```
503  plan store unavailable — the API is up but cannot reach its database
```

instead of `500 internal error`, which said only that something was wrong somewhere in a product with a lot of somewheres. 503 is also the honest status for anything that retries: this may work shortly, and it is not the request's fault.

The classifier lives in the interface package and **imports neither driver**. `pgconn` exposes `SQLState()` through an interface, so the Postgres codes are recognised without depending on pgx:

| Code | Meaning |
|---|---|
| `42P01` | schema is not there — a restore from before the current version |
| `3D000` | wrong database name (connects happily, has none of the tables) |
| `57P03` | still starting up |
| `53300` | out of connections |
| class `08` | connection exception |

SQLite has no codes worth matching and fails the same way in words.

The dependency is still reported, on **`/dependenciesz`** — which the kubelet does not read, so monitoring and a human with curl can both see it without being able to empty the Service by asking.

## Tests

Both directions, because the real risk is a classifier that swallows genuine errors: a duplicate-key violation and a JSON unmarshal failure must stay `internal error`, or an operator goes to look at Postgres when the problem is here.

`/healthz` and `/startupz` ignore dependencies entirely, asserted directly — liveness must never restart a container because a shared database blipped.