### PR TITLE
Document v0.8.0, and bump the chart to match

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,11 +274,20 @@ until the next snapshot says where they truly landed.
 execution, and maintenance windows. Phase 4 — hardening toward 1000 nodes and
 50,000 pods — is in progress, with metrics, CI and the release pipeline landed.
 
-**v0.7.0 is published** — images, chart and CLI binaries on `ghcr.io` and the
+**v0.8.0 is published** — images, chart and CLI binaries on `ghcr.io` and the
 [releases page](https://github.com/atedgimo/k8s-dencer/releases), installable by
 the command above.
 
-It repairs the Postgres store that v0.6.0 shipped. **If you are running v0.6.0
+It is the release that went looking. Every fix in it came from running the
+product rather than reading it: the CLI could not find its own backend unless
+the Helm release happened to be named `k8s-dencer`; it reported a plan the
+planner had just re-confirmed as twenty hours old, contradicting the UI about
+the same plan; and a ui-backend whose database had gone away answered every
+request with `internal error`, which named nothing. The API now returns `503
+plan store unavailable`, and the e2e runs against **both** plan stores — the
+gap that let v0.6.0 ship a Postgres backend unable to record a drain.
+
+v0.7.0 before it repaired the Postgres store that v0.6.0 shipped. **If you are running v0.6.0
 on Postgres, upgrade**: the reclamation ledger there could not record a single
 drain, and per-node history was silently dead. Three bugs — a bool bound into
 an integer column, a statement that skipped placeholder rewriting, and SQLite's

--- a/charts/k8s-dencer/Chart.yaml
+++ b/charts/k8s-dencer/Chart.yaml
@@ -10,8 +10,8 @@ type: application
 
 # Chart version tracks the chart; appVersion tracks the images. Component image
 # tags default to appVersion so a chart release pins a coherent image set.
-version: 0.7.0
-appVersion: "0.7.0"
+version: 0.8.0
+appVersion: "0.8.0"
 
 # controller-runtime and the policy/v1 PDB API used here are stable from 1.21,
 # but the chart relies on 1.27-era defaults for restricted Pod Security

--- a/docs/product-roadmap.md
+++ b/docs/product-roadmap.md
@@ -216,6 +216,29 @@ Two guards failed the same way on the same day: one checked three of the four
 ways a query reaches the driver, the other checked the type scale's floor but
 not the scale. A partial guard reads as coverage, which is worse than none.
 
+### What running it found (2026-08-13)
+- **The CLI could not find its own backend** unless the Helm release was named
+  `k8s-dencer`. It rebuilt the Service name; the chart derives it from the
+  fullname helper, and those agree for exactly one release name. It now finds
+  the Service by label, which cannot drift from the chart the way a second copy
+  of a naming template does
+- **A live plan reported as twenty hours old.** A plan ID is a content hash, so
+  a stable cluster produces the same plan every cycle and the first-computed
+  time never moves. The CLI printed that and the UI printed the confirmation
+  time, so the two surfaces contradicted each other about the same plan
+- **`503 plan store unavailable`** replaces `internal error` when the database
+  cannot answer — and deliberately *not* by failing readiness, which would take
+  every replica out of the Service at once and turn a database blip into a
+  total blackout
+- **e2e runs against both plan stores**, including an assertion that a drain
+  reaches the ledger. That is exactly what v0.6.0 got wrong: the drain
+  succeeded, the executor's events looked perfect, and nothing was written
+
+The pattern is the point. The reviews found the store bugs; the cluster found
+everything else, including two flaws in the new test itself — it drained the
+node its own database was on, then drained the pod its own port-forward was
+talking through.
+
 ## Next
 
 Ordered by intent; items move up when a user need pulls them.


### PR DESCRIPTION
The release commit for **v0.8.0**. Zero open issues behind it.

## What's in it

Everything since v0.7.0, and every item came from **running** the product rather than reading it:

| Fix | How it was found |
|---|---|
| CLI finds its backend by label, not by rebuilt name | installing with a release named `dencer` |
| `confirmed 9s ago, unchanged for 20h35m` instead of `20h35m old` | looking at real CLI output on a live cluster |
| `503 plan store unavailable` instead of `500 internal error` | the e2e draining the node its own database was on |
| e2e over **both** plan stores, asserting a drain reaches the ledger | the gap that let v0.6.0 ship a broken Postgres backend |
| e2e port-forward survives the drain | the new test failing on an unrelated PR and framing it |

## One behaviour change you will see immediately

`dencer plan` now prints:

```
plan 51e99333b1a5  confirmed 9s ago, unchanged for 20h35m55s, greedy-first-fit-decreasing
```

rather than `20h35m55s old`. A plan ID is a content hash, so a stable cluster produces the same plan every cycle and the first-computed time never moves — printing it alone said "nobody has planned since yesterday" about a planner that was working perfectly. Deliberate, not a regression.

## The design call worth reading

The obvious fix for "ui-backend serves errors with no schema" was to fail `/readyz` on the store. That was rejected: readiness decides Service membership, so failing it on a dependency every replica shares empties the Service the moment the database blips — "some requests fail with a message" becomes "nothing answers at all", and rolling updates stall.

The failure is named where it is visible instead, and the dependency is reported on `/dependenciesz`, which the kubelet does not read.

## Recorded without flattery

Writing the both-backends e2e produced two flaws of its own, both mine: it drained the node its own database was running on, and then drained the pod its own port-forward was talking through — which made an unrelated PR look like a regression for a full CI cycle.