### PR TITLE
Remove the UI that cannot do anything

### DIFF
--- a/ui/src/components/RunPanel.tsx
+++ b/ui/src/components/RunPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { PlanStep, RunEvent, RunStatus } from "../api";
+import { PlanStep } from "../api";
 import { RunState } from "../useRun";
 
 /**
@@ -116,77 +116,14 @@ export function RunTrail({ state, onDismiss }: { state: RunState; onDismiss: () 
     );
   }
 
-  const { run, events } = state;
-  const done = state.status === "done";
-
-  return (
-    <div className={`trail trail-${run.status.toLowerCase()}`} aria-live="polite">
-      <div className="trail-head">
-        <span className="trail-status">{headline(run.status, run.dryRun)}</span>
-        <span className="trail-meta mono">
-          {run.dryRun ? "dry run · " : ""}
-          {run.steps.length} step{run.steps.length === 1 ? "" : "s"}
-        </span>
-        {done && (
-          <button className="trail-close" onClick={onDismiss} aria-label="Dismiss">
-            ✕
-          </button>
-        )}
-      </div>
-
-      <ol className="trail-list" ref={listRef}>
-        {events.map((e) => (
-          <li key={e.sequence} className={`trail-row trail-row-${e.level.toLowerCase()}`}>
-            <span className="trail-action mono">{e.action}</span>
-            <span className="trail-subject mono">{e.pod ?? e.node ?? ""}</span>
-            <span className="trail-msg">{e.message}</span>
-            {/* Which rail refused. The question asked after any incident. */}
-            {e.rule && <span className="trail-rule mono">{e.rule}</span>}
-          </li>
-        ))}
-      </ol>
-
-      {run.summary && <p className="trail-summary">{run.summary}</p>}
-
-      {done && run.status === "Succeeded" && !run.dryRun && (
-        <p className="trail-note">
-          The drained nodes are empty and cordoned. k8s-dencer does not delete nodes — removing the
-          machines is your autoscaler&apos;s or node-pool tooling&apos;s job. Run{" "}
-          <code>kubectl uncordon</code> to put one back into service.
-        </p>
-      )}
-
-      {done && run.status === "Blocked" && (
-        <p className="trail-note">
-          The Safety Guard stopped this run. That is the rails working, not a failure — any node it
-          had already cordoned has been made schedulable again.
-        </p>
-      )}
-    </div>
-  );
+  // Unreachable by construction, and deliberately not implemented twice:
+  // App renders this only while a run is neither active nor done, because
+  // RunScreen owns both of those states. The event list that used to live
+  // here was a second rendering of a run in flight that nothing could ever
+  // display — the same drift, in the UI, that the store and the chart each
+  // had to have removed.
+  return null;
 }
-
-function headline(status: RunStatus, dryRun: boolean): string {
-  switch (status) {
-    case "Pending":
-      return "Waiting for the executor";
-    case "Running":
-      return dryRun ? "Rehearsing" : "Draining";
-    case "Succeeded":
-      return dryRun ? "Rehearsal complete" : "Drained";
-    case "Blocked":
-      return "Stopped by the Safety Guard";
-    case "Failed":
-      return "Run failed";
-  }
-}
-
-/** Events worth surfacing without expanding — used for the compact readout. */
-export function lastMeaningful(events: RunEvent[]): RunEvent | undefined {
-  return events[events.length - 1];
-}
-
-/* -------------------------------------------------------- converge consent */
 
 interface ConvergeProps {
   /** The current plan's reclaimable count — context only, and labelled so. */
@@ -195,14 +132,6 @@ interface ConvergeProps {
   onCancel: () => void;
 }
 
-/**
- * The consent sheet for a closed-loop run, and deliberately not ConfirmRun
- * with different text. A steps run approves a concrete list an operator can
- * picture; a converge run approves a POLICY — the executor re-plans after
- * every drain and picks its own targets — and this sheet exists to make that
- * difference impossible to miss. Both bounds are explicit inputs with no
- * pre-filled node budget, because a defaulted consent is not consent.
- */
 export function ConfirmConverge({ planReclaims, onConfirm, onCancel }: ConvergeProps) {
   const [maxNodes, setMaxNodes] = useState("");
   const [ceiling, setCeiling] = useState<"Green" | "Yellow">("Green");

--- a/ui/src/components/TopBar.tsx
+++ b/ui/src/components/TopBar.tsx
@@ -3,8 +3,13 @@
  *
  * 60px: what plan this is (name + short hash), whether it still describes
  * the cluster (the freshness dot), which algorithm produced it, and the one
- * action that follows from staleness — Recompute. The theme toggle and a
- * settings stub sit on the right.
+ * action that follows from staleness — Recompute. The theme toggle sits on
+ * the right.
+ *
+ * There was a disabled Settings square here, holding a place for a
+ * destination that was never specified. A control whose only state is refusal
+ * advertises somewhere that does not exist, so it is gone until there is
+ * something behind it.
  *
  * "Recompute" surfaces what the planner already does: it recomputes every
  * resync, and this button shows the latest plan when the view is pinned on
@@ -121,19 +126,6 @@ export default function TopBar({ planId, strategy, confirmedAt, stale, onRecompu
           </button>
         )}
         <ThemeToggle />
-        {/* Settings is designed as a destination but not yet specified;
-            the stub keeps its place in the frame without pretending. */}
-        <button type="button" className="topbar-square" disabled title="Settings — not yet available">
-          <svg viewBox="0 0 16 16" className="topbar-btn-icon" aria-hidden="true">
-            <circle cx="8" cy="8" r="2.6" stroke="currentColor" strokeWidth="1.4" fill="none" />
-            <path
-              d="M8 1.5v2M8 12.5v2M1.5 8h2M12.5 8h2"
-              stroke="currentColor"
-              strokeWidth="1.4"
-              strokeLinecap="round"
-            />
-          </svg>
-        </button>
       </div>
     </header>
   );

--- a/ui/src/styles/frame.css
+++ b/ui/src/styles/frame.css
@@ -287,24 +287,6 @@
   background: var(--raised);
 }
 
-.topbar-square {
-  width: 30px;
-  height: 30px;
-  border: 1px solid var(--border-strong);
-  border-radius: 7px;
-  background: none;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--text-3);
-  padding: 0;
-}
-
-.topbar-square:disabled {
-  color: var(--text-faint);
-  cursor: default;
-}
-
 .topbar-btn-icon {
   width: 13px;
   height: 13px;

--- a/ui/src/styles/run.css
+++ b/ui/src/styles/run.css
@@ -69,18 +69,8 @@
   background: var(--inset);
   border-bottom: 1px solid var(--border);
 }
-
-/* The only place a run's outcome is coloured, and it uses the same scale as
-   the ratings: blocked is the Yellow of "needs a human", failed is Red. */
-.trail-blocked {
-  box-shadow: inset 3px 0 0 var(--caution);
-}
-.trail-failed,
 .trail-error {
   box-shadow: inset 3px 0 0 var(--held);
-}
-.trail-succeeded {
-  box-shadow: inset 3px 0 0 var(--safe);
 }
 
 .trail-head {
@@ -94,11 +84,6 @@
   font-size: var(--text-md);
 }
 
-.trail-meta {
-  font-size: var(--text-2xs);
-  color: var(--text-5);
-}
-
 .trail-close {
   margin-left: auto;
   padding: 0 var(--space-1);
@@ -107,59 +92,10 @@
   border: 0;
 }
 
-.trail-list {
-  max-height: 9rem;
-  margin: 0.5rem 0 0;
-  padding: 0;
-  overflow-y: auto;
-  list-style: none;
-}
-
-.trail-row {
-  display: grid;
-  grid-template-columns: 5rem 12rem minmax(0, 1fr) auto;
-  gap: var(--space-3);
-  padding: var(--space-1) 0;
-  font-size: var(--text-xs);
-  color: var(--text-3);
-}
-
-.trail-row-blocked {
-  color: var(--caution);
-}
-
-.trail-row-error {
-  color: var(--held);
-}
-
-.trail-action {
-  color: var(--text-1);
-}
-
-.trail-subject {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.trail-rule {
-  font-size: var(--text-2xs);
-  padding: 0 var(--space-1);
-  border: 1px solid currentColor;
-  border-radius: var(--radius-sm);
-}
-
 .trail-summary {
   margin: 0.5rem 0 0;
   font-size: var(--text-sm);
   color: var(--text-1);
-}
-
-.trail-note {
-  margin: 0.35rem 0 0;
-  max-width: 70ch;
-  font-size: var(--text-xs);
-  color: var(--text-3);
 }
 
 .trail-grant {
@@ -180,7 +116,6 @@
     display: none;
   }
 }
-
 
 .verdict-flag {
   display: block;


### PR DESCRIPTION
Closes #195. Stage 1 of the UI review (#201) — deletions first, so what comes next lands in a codebase without dead things in it.

**159 lines out, 15 in.**

## 1. `RunTrail`'s event list was unreachable

`RunTrail` handled `idle`, `error`, `starting`, then fell through to a full event-list renderer for `active`/`done`. `App.tsx` mounts it **only** when a run is neither active nor done — `RunScreen` owns both. So that branch could never execute, and `lastMeaningful`, its only helper, was called from nowhere else.

It was a second rendering of a run in flight that nothing could display: the same drift the store and the chart each had to have removed, this time in the UI.

## 2. The Settings button could only say no

A permanently `disabled` square in the top bar. Its comment argued the stub "keeps its place in the frame without pretending" — which is also the argument against it: a placeholder that cannot be pressed is still a promise.

## 3. The styles that outlived them

Removing the markup orphaned twelve CSS rules — the entire trail event list, plus `.topbar-square`, whose only user was the disabled button. Dead CSS is how a stylesheet stops being readable, and this repo has had to clear it once already.

## One near-miss worth recording

`ConvergeProps` sat between the two dead functions and was nearly deleted with them. The typecheck caught it immediately — which is the argument for deleting in a typed codebase rather than a templated one.

## Verification

Not just the build: the frontend image was built, deployed to the OrbStack cluster, and the **served bundle** checked — zero occurrences of the settings stub, zero of the trail markup, frontend answering 200. Palette, ui and density gates green; typecheck clean.