### PR TITLE
Give the resilience audit a screen, and stop it crying wolf

### DIFF
--- a/internal/api/rest/resilience.go
+++ b/internal/api/rest/resilience.go
@@ -44,6 +44,18 @@ func (s *Server) handleResilience(w http.ResponseWriter, r *http.Request) {
 		if pc.Movable {
 			continue
 		}
+		// Pinned is not at risk, and this is the same distinction that made
+		// NodeDrainable correct. A DaemonSet pod cannot move, but losing its
+		// node costs nothing — the DaemonSet is meant to have one pod per
+		// node and now there is one fewer node. A static pod owned by the
+		// node goes away with the thing that defined it.
+		//
+		// Reporting them here read as "3 pods will not survive a node loss"
+		// on a healthy cluster, which is the kind of false alarm that teaches
+		// people to stop reading a screen.
+		if pc.PinnedToNode {
+			continue
+		}
 		for _, c := range pc.Blockers() {
 			findings = append(findings, resilienceFinding{
 				Kind: string(c.Kind), Pod: pc.Key(), Node: pc.NodeName,

--- a/internal/api/rest/resilience_test.go
+++ b/internal/api/rest/resilience_test.go
@@ -1,0 +1,66 @@
+package rest_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/atedgimo/k8s-dencer/internal/constraints"
+	"github.com/atedgimo/k8s-dencer/internal/model"
+	"github.com/atedgimo/k8s-dencer/internal/store"
+)
+
+// A DaemonSet pod cannot move, and that is not a resilience finding.
+//
+// This audit reports what will not survive losing a node. A DaemonSet pod
+// survives it in the only sense that matters: the DaemonSet is meant to have
+// one pod per node, the node is gone, so one fewer pod is the correct outcome.
+// A static pod owned by the node goes away with the thing that defined it.
+//
+// Before this, a healthy k3s cluster reported three pods "at risk" and all
+// three were svclb DaemonSet pods. A screen that cries wolf on a correct
+// cluster is one people stop reading — and this is the same pinned-versus-
+// blocking distinction whose absence made every GKE node read as undrainable.
+func TestResilienceIgnoresPodsPinnedToTheirNode(t *testing.T) {
+	snap := &model.ClusterSnapshot{
+		TakenAt: time.Now().UTC(),
+		Nodes: []model.Node{{
+			Name: "n1", Ready: true,
+			Allocatable: model.Resources{MilliCPU: 4000, MemoryBytes: 1 << 33, Pods: 110},
+		}},
+		Pods: []model.Pod{
+			{
+				Namespace: "kube-system", Name: "kube-proxy-xyz", NodeName: "n1",
+				Phase: model.PodRunning,
+				Owner: &model.OwnerRef{Kind: "DaemonSet", Name: "kube-proxy"},
+			},
+			{
+				// GKE runs kube-proxy this way: owned by the node itself.
+				Namespace: "kube-system", Name: "static-thing", NodeName: "n1",
+				Phase: model.PodRunning,
+				Owner: &model.OwnerRef{Kind: "Node", Name: "n1"},
+			},
+		},
+	}
+
+	rec := store.Record{
+		Plan: &model.Plan{
+			ID: "pinned01", GeneratedAt: time.Now().UTC(), SnapshotTakenAt: snap.TakenAt,
+			Status: model.PlanValid, NodesBefore: 1, NodesAfter: 1,
+		},
+		Snapshot: snap,
+		Analysis: &constraints.Analysis{},
+		Strategy: "greedy-first-fit-decreasing",
+	}
+
+	srv := testServer(t, rec)
+	code, body := get(t, srv, "/api/v1/resilience")
+	if code != 200 {
+		t.Fatalf("resilience = %d, want 200", code)
+	}
+
+	findings, _ := body["findings"].([]any)
+	for _, f := range findings {
+		m, _ := f.(map[string]any)
+		t.Errorf("pinned pod reported as a resilience risk: %v (%v)", m["pod"], m["kind"])
+	}
+}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -20,6 +20,7 @@ import { runtimeConfig } from "./runtime-config";
 import { useObserved } from "./useObserved";
 import { usePlan } from "./usePlan";
 import { useReclamations } from "./useReclamations";
+import ResiliencePage from "./components/resilience/ResiliencePage";
 import RightsizingPage from "./components/rightsizing/RightsizingPage";
 import WhyNothing from "./components/review/WhyNothing";
 import { useRecommendations } from "./useRecommendations";
@@ -406,6 +407,8 @@ export default function App() {
               }}
             />
           )}
+
+          {state.status === "ready" && surface === "resilience" && <ResiliencePage />}
 
           {state.status === "ready" && surface === "rightsizing" && <RightsizingPage />}
 

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -490,6 +490,10 @@ export const api = {
 
   /** Requests against observed usage, per workload. Needs metrics-server. */
   rightsizing: (signal?: AbortSignal) => get<Rightsizing>(`/api/v1/rightsizing`, signal),
+
+  /** The resilience audit: what this cluster does not survive losing a node
+   *  to. The same analysis the planner runs, read in the opposite mood. */
+  resilience: (signal?: AbortSignal) => get<Resilience>(`/api/v1/resilience`, signal),
   /** Per node: will it drain, and if not, what is in the way. */
   preflight: (signal?: AbortSignal) => get<Preflight>(`/api/v1/preflight`, signal),
 
@@ -591,6 +595,24 @@ function dispatchFrame(frame: string, onEvent: (event: string, data: string) => 
 }
 
 /** One workload's requests against what it actually uses. */
+/**
+ * A pod that cannot be evicted voluntarily is also a pod that handles an
+ * involuntary node loss badly. Explanation is the analyzer's own text, quoted
+ * rather than paraphrased, so a constraint cannot be described one way here
+ * and another way on the plan.
+ */
+export interface ResilienceFinding {
+  kind: string;
+  pod: string;
+  node?: string;
+  explanation: string;
+}
+
+export interface Resilience {
+  takenAt?: string;
+  findings?: ResilienceFinding[];
+}
+
 export interface RightsizingRow {
   workload: string;
   pods: number;

--- a/ui/src/components/Rail.tsx
+++ b/ui/src/components/Rail.tsx
@@ -50,6 +50,19 @@ const ICONS: Record<Surface, React.ReactNode> = {
       <circle cx="8" cy="8" r="3" stroke="currentColor" strokeWidth="1.4" fill="none" />
     </svg>
   ),
+  resilience: (
+    // A shield outline: what holds when something is lost, rather than a
+    // warning triangle — this screen is an audit, not an alarm.
+    <svg viewBox="0 0 16 16" className="rail-icon" aria-hidden="true">
+      <path
+        d="M8 1.8 13 3.6v4.1c0 3-2.1 5.4-5 6.5-2.9-1.1-5-3.5-5-6.5V3.6L8 1.8Z"
+        stroke="currentColor"
+        strokeWidth="1.4"
+        strokeLinejoin="round"
+        fill="none"
+      />
+    </svg>
+  ),
   rightsizing: (
     <svg viewBox="0 0 16 16" className="rail-icon" aria-hidden="true">
       <rect x="2.5" y="4" width="11" height="3.4" rx="1" stroke="currentColor" strokeWidth="1.4" fill="none" />
@@ -68,6 +81,7 @@ const LABELS: Record<Surface, string> = {
   review: "Review",
   cluster: "Cluster",
   recommendations: "Recommendations",
+  resilience: "Resilience",
   rightsizing: "Rightsizing",
   history: "History",
 };

--- a/ui/src/components/RunPanel.tsx
+++ b/ui/src/components/RunPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { PlanStep, RunEvent, RunStatus } from "../api";
+import { PlanStep } from "../api";
 import { RunState } from "../useRun";
 
 /**
@@ -116,77 +116,14 @@ export function RunTrail({ state, onDismiss }: { state: RunState; onDismiss: () 
     );
   }
 
-  const { run, events } = state;
-  const done = state.status === "done";
-
-  return (
-    <div className={`trail trail-${run.status.toLowerCase()}`} aria-live="polite">
-      <div className="trail-head">
-        <span className="trail-status">{headline(run.status, run.dryRun)}</span>
-        <span className="trail-meta mono">
-          {run.dryRun ? "dry run · " : ""}
-          {run.steps.length} step{run.steps.length === 1 ? "" : "s"}
-        </span>
-        {done && (
-          <button className="trail-close" onClick={onDismiss} aria-label="Dismiss">
-            ✕
-          </button>
-        )}
-      </div>
-
-      <ol className="trail-list" ref={listRef}>
-        {events.map((e) => (
-          <li key={e.sequence} className={`trail-row trail-row-${e.level.toLowerCase()}`}>
-            <span className="trail-action mono">{e.action}</span>
-            <span className="trail-subject mono">{e.pod ?? e.node ?? ""}</span>
-            <span className="trail-msg">{e.message}</span>
-            {/* Which rail refused. The question asked after any incident. */}
-            {e.rule && <span className="trail-rule mono">{e.rule}</span>}
-          </li>
-        ))}
-      </ol>
-
-      {run.summary && <p className="trail-summary">{run.summary}</p>}
-
-      {done && run.status === "Succeeded" && !run.dryRun && (
-        <p className="trail-note">
-          The drained nodes are empty and cordoned. k8s-dencer does not delete nodes — removing the
-          machines is your autoscaler&apos;s or node-pool tooling&apos;s job. Run{" "}
-          <code>kubectl uncordon</code> to put one back into service.
-        </p>
-      )}
-
-      {done && run.status === "Blocked" && (
-        <p className="trail-note">
-          The Safety Guard stopped this run. That is the rails working, not a failure — any node it
-          had already cordoned has been made schedulable again.
-        </p>
-      )}
-    </div>
-  );
+  // Unreachable by construction, and deliberately not implemented twice:
+  // App renders this only while a run is neither active nor done, because
+  // RunScreen owns both of those states. The event list that used to live
+  // here was a second rendering of a run in flight that nothing could ever
+  // display — the same drift, in the UI, that the store and the chart each
+  // had to have removed.
+  return null;
 }
-
-function headline(status: RunStatus, dryRun: boolean): string {
-  switch (status) {
-    case "Pending":
-      return "Waiting for the executor";
-    case "Running":
-      return dryRun ? "Rehearsing" : "Draining";
-    case "Succeeded":
-      return dryRun ? "Rehearsal complete" : "Drained";
-    case "Blocked":
-      return "Stopped by the Safety Guard";
-    case "Failed":
-      return "Run failed";
-  }
-}
-
-/** Events worth surfacing without expanding — used for the compact readout. */
-export function lastMeaningful(events: RunEvent[]): RunEvent | undefined {
-  return events[events.length - 1];
-}
-
-/* -------------------------------------------------------- converge consent */
 
 interface ConvergeProps {
   /** The current plan's reclaimable count — context only, and labelled so. */
@@ -195,14 +132,6 @@ interface ConvergeProps {
   onCancel: () => void;
 }
 
-/**
- * The consent sheet for a closed-loop run, and deliberately not ConfirmRun
- * with different text. A steps run approves a concrete list an operator can
- * picture; a converge run approves a POLICY — the executor re-plans after
- * every drain and picks its own targets — and this sheet exists to make that
- * difference impossible to miss. Both bounds are explicit inputs with no
- * pre-filled node budget, because a defaulted consent is not consent.
- */
 export function ConfirmConverge({ planReclaims, onConfirm, onCancel }: ConvergeProps) {
   const [maxNodes, setMaxNodes] = useState("");
   const [ceiling, setCeiling] = useState<"Green" | "Yellow">("Green");

--- a/ui/src/components/TopBar.tsx
+++ b/ui/src/components/TopBar.tsx
@@ -3,8 +3,13 @@
  *
  * 60px: what plan this is (name + short hash), whether it still describes
  * the cluster (the freshness dot), which algorithm produced it, and the one
- * action that follows from staleness — Recompute. The theme toggle and a
- * settings stub sit on the right.
+ * action that follows from staleness — Recompute. The theme toggle sits on
+ * the right.
+ *
+ * There was a disabled Settings square here, holding a place for a
+ * destination that was never specified. A control whose only state is refusal
+ * advertises somewhere that does not exist, so it is gone until there is
+ * something behind it.
  *
  * "Recompute" surfaces what the planner already does: it recomputes every
  * resync, and this button shows the latest plan when the view is pinned on
@@ -121,19 +126,6 @@ export default function TopBar({ planId, strategy, confirmedAt, stale, onRecompu
           </button>
         )}
         <ThemeToggle />
-        {/* Settings is designed as a destination but not yet specified;
-            the stub keeps its place in the frame without pretending. */}
-        <button type="button" className="topbar-square" disabled title="Settings — not yet available">
-          <svg viewBox="0 0 16 16" className="topbar-btn-icon" aria-hidden="true">
-            <circle cx="8" cy="8" r="2.6" stroke="currentColor" strokeWidth="1.4" fill="none" />
-            <path
-              d="M8 1.5v2M8 12.5v2M1.5 8h2M12.5 8h2"
-              stroke="currentColor"
-              strokeWidth="1.4"
-              strokeLinecap="round"
-            />
-          </svg>
-        </button>
       </div>
     </header>
   );

--- a/ui/src/components/resilience/ResiliencePage.tsx
+++ b/ui/src/components/resilience/ResiliencePage.tsx
@@ -1,0 +1,148 @@
+/**
+ * Resilience — what this cluster does not survive losing a node to.
+ *
+ * The endpoint has been served since the CLI shipped and the UI never called
+ * it, so the question an SRE asks most often was answerable only from a
+ * terminal. It is the same analysis the planner runs, read in the opposite
+ * mood: the zero-headroom PDB that blocks a drain is the same PDB a dying node
+ * violates, and the pod with no controller that eviction would delete
+ * permanently is deleted just as permanently by hardware.
+ *
+ * Explanations are the analyzer's own text, rendered verbatim. The CLI already
+ * prints them unparaphrased for exactly this reason — one constraint described
+ * two ways leaves an operator with no way to tell which to believe — and a
+ * third surface is a third chance to get that wrong.
+ *
+ * Deliberately no severity ranking. The payload carries none, and inventing
+ * one here would mean this screen disagreeing with Recommendations about how
+ * bad something is. Findings are grouped by kind and counted; which kind
+ * matters most is the operator's judgement and depends on their cluster.
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import { Resilience, ResilienceFinding, api } from "../../api";
+
+export default function ResiliencePage() {
+  const [data, setData] = useState<Resilience | null>(null);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = () =>
+      api
+        .resilience()
+        .then((d) => {
+          if (!cancelled) {
+            setData(d);
+            setFailed(false);
+          }
+        })
+        .catch(() => !cancelled && setFailed(true));
+    load();
+    // The analysis is computed fresh per request rather than read from the
+    // stored plan, so this is a real question each time and not worth asking
+    // faster than the planner changes its mind.
+    const t = setInterval(load, 60_000);
+    return () => {
+      cancelled = true;
+      clearInterval(t);
+    };
+  }, []);
+
+  const groups = useMemo(() => byKind(data?.findings ?? []), [data]);
+
+  if (failed) {
+    return (
+      <Frame>
+        <p className="resilience-empty">Could not read the audit just now. It will retry on its own.</p>
+      </Frame>
+    );
+  }
+
+  if (!data) {
+    return (
+      <Frame>
+        <p className="resilience-empty">Reading the cluster…</p>
+      </Frame>
+    );
+  }
+
+  const total = data.findings?.length ?? 0;
+
+  if (total === 0) {
+    return (
+      <Frame>
+        <p className="resilience-clear">
+          <strong>Every pod here can survive losing its node.</strong> Nothing is held by a
+          zero-headroom budget, nothing depends on a node that cannot be replaced, and nothing
+          would be deleted rather than rescheduled.
+        </p>
+        <p className="resilience-empty">
+          This is the answer you want, and it is worth re-reading after a deploy — it describes
+          the cluster as it is now, not as it was configured.
+        </p>
+      </Frame>
+    );
+  }
+
+  return (
+    <Frame>
+      <p className="resilience-lede">
+        <strong>
+          {total} {total === 1 ? "pod is" : "pods are"} at risk if a node goes away.
+        </strong>{" "}
+        Each of these is also a reason a drain would be refused — the same constraint, met from
+        the other side.
+      </p>
+
+      {groups.map(([kind, findings]) => (
+        <section className="resilience-group" key={kind}>
+          <h3 className="resilience-kind">
+            {kind}
+            <span className="resilience-count mono">{findings.length}</span>
+          </h3>
+          <ul className="resilience-list">
+            {findings.map((f, i) => (
+              <li className="resilience-row" key={`${f.pod}-${f.kind}-${i}`}>
+                <div className="resilience-subject">
+                  <span className="resilience-pod mono">{f.pod}</span>
+                  {f.node && <span className="resilience-node mono">on {f.node}</span>}
+                </div>
+                {/* The analyzer's wording, not ours. */}
+                <p className="resilience-why">{f.explanation}</p>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ))}
+    </Frame>
+  );
+}
+
+function Frame({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="resilience">
+      <header className="resilience-head">
+        <div className="eyebrow mono">Resilience</div>
+        <h2 className="resilience-headline">What a lost node would cost</h2>
+        <p className="resilience-sub">
+          Consolidation asks whether a node can be emptied on purpose. This asks what happens
+          when one empties itself.
+        </p>
+      </header>
+      {children}
+    </div>
+  );
+}
+
+/** Grouped by the analyzer's own constraint kind, largest group first. */
+function byKind(findings: ResilienceFinding[]): Array<[string, ResilienceFinding[]]> {
+  const m = new Map<string, ResilienceFinding[]>();
+  for (const f of findings) {
+    const k = f.kind || "Other";
+    const list = m.get(k);
+    if (list) list.push(f);
+    else m.set(k, [f]);
+  }
+  return [...m.entries()].sort((a, b) => b[1].length - a[1].length || a[0].localeCompare(b[0]));
+}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -16,5 +16,6 @@
 @import "./styles/sidebar.css";
 @import "./styles/run.css";
 @import "./styles/views.css";
+@import "./styles/resilience.css";
 @import "./styles/rightsizing.css";
 @import "./styles/history.css";

--- a/ui/src/styles/frame.css
+++ b/ui/src/styles/frame.css
@@ -287,24 +287,6 @@
   background: var(--raised);
 }
 
-.topbar-square {
-  width: 30px;
-  height: 30px;
-  border: 1px solid var(--border-strong);
-  border-radius: 7px;
-  background: none;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--text-3);
-  padding: 0;
-}
-
-.topbar-square:disabled {
-  color: var(--text-faint);
-  cursor: default;
-}
-
 .topbar-btn-icon {
   width: 13px;
   height: 13px;

--- a/ui/src/styles/resilience.css
+++ b/ui/src/styles/resilience.css
@@ -1,0 +1,122 @@
+/*
+ * Resilience — grouped prose, not a table.
+ *
+ * Rightsizing is a table because its finding is a number in two columns.
+ * This screen's finding is a sentence the analyzer already wrote, so the
+ * layout gets out of its way: a kind, a count, and the explanation at
+ * readable measure. Borrowing Recommendations' rhythm rather than inventing
+ * a third, because both screens answer "what should I change".
+ */
+
+.resilience {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.resilience-head {
+  padding: 20px var(--space-6) 18px;
+  border-bottom: 1px solid var(--border);
+  background: var(--surface);
+}
+
+.resilience-headline {
+  margin: 6px 0 0;
+  font-size: var(--text-display);
+  font-weight: 600;
+  letter-spacing: var(--tracking-display);
+  text-wrap: balance;
+}
+
+.resilience-sub {
+  margin: 8px 0 0;
+  max-width: 62ch;
+  font-size: var(--text-sm);
+  color: var(--text-3);
+}
+
+.resilience-lede,
+.resilience-clear,
+.resilience-empty {
+  margin: 0;
+  padding: 18px var(--space-6);
+  max-width: 74ch;
+  font-size: var(--text-md);
+  color: var(--text-2);
+}
+
+.resilience-empty {
+  font-size: var(--text-sm);
+  color: var(--text-4);
+}
+
+/* The good answer reads as an answer, not as an absence. */
+.resilience-clear {
+  padding-bottom: 4px;
+}
+
+.resilience-clear strong {
+  color: var(--safe);
+}
+
+.resilience-group {
+  border-top: 1px solid var(--border);
+}
+
+.resilience-kind {
+  margin: 0;
+  padding: 14px var(--space-6) 8px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: var(--text-xs);
+  font-weight: 600;
+  letter-spacing: var(--tracking-label);
+  text-transform: uppercase;
+  color: var(--text-3);
+}
+
+.resilience-count {
+  font-size: var(--text-2xs);
+  color: var(--text-5);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 1px 7px;
+}
+
+.resilience-list {
+  margin: 0;
+  padding: 0 0 10px;
+  list-style: none;
+}
+
+.resilience-row {
+  padding: 8px var(--space-6) 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.resilience-subject {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.resilience-pod {
+  font-size: var(--text-sm);
+  color: var(--text-1);
+}
+
+.resilience-node {
+  font-size: var(--text-2xs);
+  color: var(--text-5);
+}
+
+.resilience-why {
+  margin: 0;
+  max-width: 78ch;
+  font-size: var(--text-sm);
+  color: var(--text-4);
+}

--- a/ui/src/styles/run.css
+++ b/ui/src/styles/run.css
@@ -69,18 +69,8 @@
   background: var(--inset);
   border-bottom: 1px solid var(--border);
 }
-
-/* The only place a run's outcome is coloured, and it uses the same scale as
-   the ratings: blocked is the Yellow of "needs a human", failed is Red. */
-.trail-blocked {
-  box-shadow: inset 3px 0 0 var(--caution);
-}
-.trail-failed,
 .trail-error {
   box-shadow: inset 3px 0 0 var(--held);
-}
-.trail-succeeded {
-  box-shadow: inset 3px 0 0 var(--safe);
 }
 
 .trail-head {
@@ -94,11 +84,6 @@
   font-size: var(--text-md);
 }
 
-.trail-meta {
-  font-size: var(--text-2xs);
-  color: var(--text-5);
-}
-
 .trail-close {
   margin-left: auto;
   padding: 0 var(--space-1);
@@ -107,59 +92,10 @@
   border: 0;
 }
 
-.trail-list {
-  max-height: 9rem;
-  margin: 0.5rem 0 0;
-  padding: 0;
-  overflow-y: auto;
-  list-style: none;
-}
-
-.trail-row {
-  display: grid;
-  grid-template-columns: 5rem 12rem minmax(0, 1fr) auto;
-  gap: var(--space-3);
-  padding: var(--space-1) 0;
-  font-size: var(--text-xs);
-  color: var(--text-3);
-}
-
-.trail-row-blocked {
-  color: var(--caution);
-}
-
-.trail-row-error {
-  color: var(--held);
-}
-
-.trail-action {
-  color: var(--text-1);
-}
-
-.trail-subject {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.trail-rule {
-  font-size: var(--text-2xs);
-  padding: 0 var(--space-1);
-  border: 1px solid currentColor;
-  border-radius: var(--radius-sm);
-}
-
 .trail-summary {
   margin: 0.5rem 0 0;
   font-size: var(--text-sm);
   color: var(--text-1);
-}
-
-.trail-note {
-  margin: 0.35rem 0 0;
-  max-width: 70ch;
-  font-size: var(--text-xs);
-  color: var(--text-3);
 }
 
 .trail-grant {
@@ -180,7 +116,6 @@
     display: none;
   }
 }
-
 
 .verdict-flag {
   display: block;

--- a/ui/src/view.ts
+++ b/ui/src/view.ts
@@ -34,7 +34,13 @@ export type FieldView = "rack" | "wells" | "load";
  * the axes is what made the old view switcher read as four equal views of
  * the same thing.
  */
-export type Surface = "review" | "cluster" | "recommendations" | "rightsizing" | "history";
+export type Surface =
+  | "review"
+  | "cluster"
+  | "recommendations"
+  | "resilience"
+  | "rightsizing"
+  | "history";
 
 const KEY = "dencer.view";
 


### PR DESCRIPTION
Closes #194. Stage 2 of the UI review (#201).

## The screen

`/api/v1/resilience` has been served since the CLI shipped and the UI never called it. The question an SRE asks most often — *what does this cluster not survive?* — was answerable only from a terminal.

It is the same analysis the planner runs, read in the opposite mood: the zero-headroom PDB that blocks a voluntary drain is the same PDB a dying node violates.

Two deliberate restraints:

- **Explanations render verbatim.** The CLI already prints them unparaphrased so one constraint cannot be described two ways; a third surface is a third chance to get that wrong.
- **No severity ranking.** The payload carries none, and inventing one would mean this screen disagreeing with Recommendations about how bad something is. Grouped by kind and counted instead — which kind matters is the operator's judgement and depends on their cluster.

## Building it found a bug in the endpoint

On a healthy k3s cluster the audit reported **seven** findings. Three were svclb DaemonSet pods.

A DaemonSet pod cannot move — but losing its node costs nothing. The DaemonSet is meant to have one pod per node, the node is gone, so one fewer pod is the correct outcome. A static pod owned by the node goes away with the thing that defined it. **Pinned is not at risk.**

That is the same distinction whose absence made every GKE node read as undrainable in v0.4.0, and it was still missing here.

On the live cluster: **7 findings → 4**, and the four that remain are real — three pods held by a PDB, one budget with no headroom.

A screen that cries wolf on a correct cluster is one people stop reading, so this had to be fixed before the screen shipped rather than after.

## Verification

- Test confirmed to **fail when the fix is reverted**, naming both pinned pods
- Built, deployed to the OrbStack cluster, and the live payload checked before and after
- Full Go suite, palette, ui, density, typecheck and build all green
- Every CSS token used verified to exist — `--tracking-eyebrow` did not, and was caught before it silently did nothing