### PR TITLE
Let the two request screens mention each other

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -71,6 +71,9 @@ export default function App() {
   // places you visit, and reopening the app anywhere but the plan would bury
   // the thing the product is for.
   const [surface, setSurface] = useState<Surface>("review");
+  // Set when arriving at Rightsizing from a recommendation, so the row an
+  // operator asked about is the one they land on.
+  const [rightsizingFocus, setRightsizingFocus] = useState<string | null>(null);
   const lastToggled = useRef<number | null>(null);
 
   const recommendations = useRecommendations();
@@ -400,6 +403,10 @@ export default function App() {
               muted={muted}
               onMute={mute}
               onUnmute={unmute}
+              onOpenRightsizing={(workload) => {
+                setRightsizingFocus(workload);
+                setSurface("rightsizing");
+              }}
               onOpenSteps={(seqs) => {
                 setSurface("review");
                 setFocusedRating(null);
@@ -410,7 +417,9 @@ export default function App() {
 
           {state.status === "ready" && surface === "resilience" && <ResiliencePage />}
 
-          {state.status === "ready" && surface === "rightsizing" && <RightsizingPage />}
+          {state.status === "ready" && surface === "rightsizing" && (
+            <RightsizingPage focus={rightsizingFocus} recs={recommendations} />
+          )}
 
           {state.status === "ready" && surface === "history" && <History pricing={reclamations.stats.pricing} />}
         </div>

--- a/ui/src/components/recs/RecsPage.tsx
+++ b/ui/src/components/recs/RecsPage.tsx
@@ -9,8 +9,8 @@
  * work. Muting removes a finding from the queue, never from the plan.
  */
 
-import { useMemo, useState } from "react";
-import { GraphPayload, PlanStep, Recommendation, formatCPU } from "../../api";
+import { useEffect, useMemo, useState } from "react";
+import { GraphPayload, PlanStep, Recommendation, api, formatCPU } from "../../api";
 import { findingKey } from "../../useMuted";
 
 interface Props {
@@ -22,6 +22,8 @@ interface Props {
   onUnmute: (key: string) => void;
   /** Cross-navigation: focus these steps on the Review screen. */
   onOpenSteps: (steps: number[]) => void;
+  /** Cross-navigation: open Rightsizing, scrolled to this workload. */
+  onOpenRightsizing: (workload: string) => void;
 }
 
 const SEV_LABEL: Record<Recommendation["severity"], string> = {
@@ -30,9 +32,43 @@ const SEV_LABEL: Record<Recommendation["severity"], string> = {
   info: "INFO",
 };
 
-export default function RecsPage({ recs, steps, graph, muted, onMute, onUnmute, onOpenSteps }: Props) {
+export default function RecsPage({
+  recs,
+  steps,
+  graph,
+  muted,
+  onMute,
+  onUnmute,
+  onOpenSteps,
+  onOpenRightsizing,
+}: Props) {
   const [showAll, setShowAll] = useState(false);
   const [selected, setSelected] = useState<string | null>(null);
+
+  // Which workloads have measurements waiting on the other screen.
+  //
+  // These two screens are not halves of one thing and must not be merged: a
+  // recommendation carries a paste-ready fix, and Rightsizing deliberately
+  // carries none, because a single usage sample is not a number to set
+  // requests from. But an operator could read either without learning the
+  // other existed, and "you have no requests" is far more useful next to
+  // "here is what this workload actually uses".
+  const [measured, setMeasured] = useState<Set<string>>(new Set());
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .rightsizing()
+      .then((d) => {
+        if (cancelled || !d.available) return;
+        setMeasured(new Set((d.workloads ?? []).map((w) => w.workload)));
+      })
+      // No usage source is a normal configuration, not an error: the link
+      // simply does not appear.
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const all = recs ?? [];
   const visible = useMemo(() => {
@@ -199,6 +235,8 @@ export default function RecsPage({ recs, steps, graph, muted, onMute, onUnmute, 
             onMute={() => onMute(findingKey(current.kind, current.workload))}
             onUnmute={() => onUnmute(findingKey(current.kind, current.workload))}
             onOpenSteps={onOpenSteps}
+            measured={measured.has(current.workload)}
+            onOpenRightsizing={onOpenRightsizing}
           />
         )}
       </div>
@@ -214,6 +252,8 @@ function Detail({
   onMute,
   onUnmute,
   onOpenSteps,
+  measured,
+  onOpenRightsizing,
 }: {
   rec: Recommendation;
   steps: PlanStep[];
@@ -222,6 +262,9 @@ function Detail({
   onMute: () => void;
   onUnmute: () => void;
   onOpenSteps: (steps: number[]) => void;
+  /** True when Rightsizing has measurements for this workload. */
+  measured: boolean;
+  onOpenRightsizing: (workload: string) => void;
 }) {
   const [copied, setCopied] = useState(false);
   const blocked = rec.unblocksSteps ?? [];
@@ -318,6 +361,19 @@ function Detail({
               onClick={() => onOpenSteps(blocked)}
             >
               Open the {blocked.length} blocked step{blocked.length === 1 ? "" : "s"}
+            </button>
+          )}
+          {measured && (
+            // Deliberately a link to a measurement rather than a number
+            // repeated here. Rightsizing refuses to turn one usage sample into
+            // a suggested request, and copying its figures onto a card that
+            // already carries a paste-ready fix would imply exactly that.
+            <button
+              type="button"
+              className="btn"
+              onClick={() => onOpenRightsizing(rec.workload)}
+            >
+              See what it actually uses
             </button>
           )}
           <button type="button" className="btn" onClick={muted ? onUnmute : onMute}>

--- a/ui/src/components/rightsizing/RightsizingPage.tsx
+++ b/ui/src/components/rightsizing/RightsizingPage.tsx
@@ -12,8 +12,8 @@
  * different claims and only one of them is ever true here.
  */
 
-import { useEffect, useState } from "react";
-import { Rightsizing, api, formatBytes, formatCPU } from "../../api";
+import { useEffect, useRef, useState } from "react";
+import { Recommendation, Rightsizing, api, formatBytes, formatCPU } from "../../api";
 
 /** Below this the gap is noise, not a finding worth a row's attention. */
 const WORTH_SHOWING_MILLI = 50;
@@ -21,9 +21,23 @@ const WORTH_SHOWING_MILLI = 50;
 /** formatCPU drops the unit above a core, so "cores" is only right above it. */
 const cores = (milli: number) => (milli >= 1000 ? `${formatCPU(milli)} cores` : formatCPU(milli));
 
-export default function RightsizingPage() {
+interface Props {
+  /** Workload to scroll to and mark, when arriving from a recommendation. */
+  focus?: string | null;
+  /** Open findings, so a measured workload can say one is waiting for it. */
+  recs?: Recommendation[] | null;
+}
+
+export default function RightsizingPage({ focus, recs }: Props = {}) {
   const [data, setData] = useState<Rightsizing | null>(null);
   const [failed, setFailed] = useState(false);
+  const focusRow = useRef<HTMLTableRowElement>(null);
+
+  // Arriving from a recommendation should land on the row that was asked
+  // about, not at the top of a table the operator then has to search.
+  useEffect(() => {
+    focusRow.current?.scrollIntoView({ block: "center", behavior: "smooth" });
+  }, [focus, data]);
 
   useEffect(() => {
     let cancelled = false;
@@ -73,6 +87,13 @@ export default function RightsizingPage() {
       </div>
     );
   }
+
+  // Workloads with an open finding on the other screen. These two screens are
+  // deliberately not merged — a recommendation carries a paste-ready fix and
+  // this one carries none, because a single usage sample is not a number to
+  // set requests from — but reading either without knowing the other exists
+  // is how an operator ends up doing half the job.
+  const advised = new Set((recs ?? []).map((r) => r.workload));
 
   const rows = [...(data.workloads ?? [])].sort(
     (a, b) => b.requestedMilli - b.usedMilli - (a.requestedMilli - a.usedMilli),
@@ -130,8 +151,19 @@ export default function RightsizingPage() {
               const gap = Math.max(r.requestedMilli - r.usedMilli, 0);
               const usedPct = r.requestedMilli > 0 ? (r.usedMilli / r.requestedMilli) * 100 : 0;
               return (
-                <tr key={r.workload}>
-                  <td className="mono rightsizing-name">{r.workload}</td>
+                <tr
+                  key={r.workload}
+                  ref={r.workload === focus ? focusRow : undefined}
+                  className={r.workload === focus ? "is-focused" : undefined}
+                >
+                  <td className="mono rightsizing-name">
+                    {r.workload}
+                    {advised.has(r.workload) && (
+                      <span className="rightsizing-advised" title="This workload also has an open recommendation">
+                        finding open
+                      </span>
+                    )}
+                  </td>
                   <td className="num mono">{r.pods}</td>
                   <td className="num mono">{formatCPU(r.requestedMilli)}</td>
                   <td className="num mono">{formatCPU(r.usedMilli)}</td>

--- a/ui/src/styles/rightsizing.css
+++ b/ui/src/styles/rightsizing.css
@@ -171,3 +171,23 @@
   color: var(--text-5);
   text-wrap: pretty;
 }
+
+/*
+ * The row an operator was sent to, and the note that another screen has
+ * something to say about the same workload. Both are quiet: this table's job
+ * is the measurement, and a badge that shouted would compete with it.
+ */
+.rightsizing-advised {
+  margin-left: 8px;
+  padding: 1px 6px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  font-size: var(--text-2xs);
+  color: var(--text-5);
+  white-space: nowrap;
+}
+
+.rightsizing tbody tr.is-focused {
+  background: var(--raised);
+  box-shadow: inset 2px 0 0 var(--accent);
+}


### PR DESCRIPTION
Closes #197 — **which asked for a merge, and was wrong.** The issue has been rewritten with the reasoning; this is the smaller, better change that came out of it.

## Why not to merge

| | Recommendations | Rightsizing |
|---|---|---|
| Ships a fix? | **Yes** — paste-ready YAML | **No, deliberately** |
| Shape | a queue of discrete changes | a measurement to interpret |

Rightsizing's own source: *"It refuses to guess. Without usage data the answer is 'not available' and the reason, never an estimate — an invented utilisation figure would make confident, wrong recommendations, which is worse than none."*

Merging forces one of two bad outcomes:

1. Rightsizing becomes prescriptive — on the one report where a confident wrong number does real damage; or
2. Recommendations gains findings with no fix — weakening the promise that every queue item is actionable.

Neither is worth one fewer rail destination.

## The actual defect

An operator could read either screen without learning the other existed. *"You have no requests, here is a patch"* and *"here is what this workload actually uses"* are complementary, and they were strangers.

- A recommendation for a **measured** workload offers **"See what it actually uses"**, which navigates to Rightsizing and scrolls to that row.
- Rightsizing rows carry a quiet **"finding open"** note when a recommendation is waiting on the same workload.

The link is deliberately a link rather than the figures repeated on the card: copying usage numbers next to a paste-ready fix would imply they are what to set the request to, which is exactly what Rightsizing refuses to say.

## Verification

The join is on the workload key, which both sides already build identically (`namespace/Kind/name`) — **verified against the live cluster rather than assumed**: 33 recommendations, 32 measured workloads, real intersection.

No usage source configured is a normal state, not an error — the link simply does not appear. Every CSS token checked to exist. Full suite, palette, ui, density, typecheck and build green; deployed to OrbStack.