### PR TITLE
Prepare the GKE run's Postgres phase, and fix what rehearsing it found

### DIFF
--- a/charts/k8s-dencer/templates/_helpers.tpl
+++ b/charts/k8s-dencer/templates/_helpers.tpl
@@ -170,9 +170,18 @@ is read from a Secret the operator already has.
       name: {{ . }}
       key: {{ $.Values.database.postgres.existingSecretPasswordKey }}
 {{- end }}
-{{- if .Values.database.postgres.sslRootCert.existingSecret }}
+{{- /*
+  Nil-safe, because helm upgrade --reuse-values carries the stored values
+  forward and does NOT merge in defaults for keys the chart has grown since.
+  sslRootCert arrived in 0.8.0, so an install predating it upgraded with
+  --reuse-values had no such map and this dereference failed the render with
+  "nil pointer evaluating interface {}.existingSecret" — an upgrade path
+  broken for exactly the operators who had been running longest.
+*/ -}}
+{{- $ca := .Values.database.postgres.sslRootCert | default dict }}
+{{- if $ca.existingSecret }}
 - name: POSTGRES_SSLROOTCERT
-  value: /etc/dencer/postgres-ca/{{ .Values.database.postgres.sslRootCert.key }}
+  value: /etc/dencer/postgres-ca/{{ $ca.key | default "ca.crt" }}
 {{- end }}
 {{- end }}
 {{- end -}}
@@ -199,14 +208,15 @@ network path can impersonate the database and collect the credentials, the
 audit trail and the run queue the executor drains from.
 */}}
 {{- define "k8s-dencer.mountsPostgresCA" -}}
-{{- if and (eq .Values.database.type "postgres") .Values.database.postgres.sslRootCert.existingSecret }}true{{ end -}}
+{{- $ca := .Values.database.postgres.sslRootCert | default dict -}}
+{{- if and (eq .Values.database.type "postgres") $ca.existingSecret }}true{{ end -}}
 {{- end -}}
 
 {{- define "k8s-dencer.postgresCAVolume" -}}
 {{- if include "k8s-dencer.mountsPostgresCA" . }}
 - name: postgres-ca
   secret:
-    secretName: {{ .Values.database.postgres.sslRootCert.existingSecret }}
+    secretName: {{ (.Values.database.postgres.sslRootCert | default dict).existingSecret }}
 {{- end }}
 {{- end -}}
 

--- a/hack/capture/CHECKLIST.md
+++ b/hack/capture/CHECKLIST.md
@@ -99,3 +99,42 @@ Capture as you go so the answers survive the window:
 RUN_DIR=/tmp/gcprun ./hack/capture/capture.sh baseline
 RUN_DIR=/tmp/gcprun ./hack/capture/capture.sh after-converge
 ```
+
+---
+
+## Phase 2 — the same questions on Postgres (optional, ~0 extra cost)
+
+Run **only after items 1-3 above have passed.** The P0 question deserves an
+uncontaminated answer first: a database pod consumes capacity on nodes whose
+940m allocatable is already 30-80% spoken for by GKE's own daemons, and this
+run exists to measure exactly that.
+
+```bash
+./hack/capture/postgres-phase.sh
+```
+
+It deploys Postgres on a 10Gi claim — not an emptyDir, because this exercise
+drains nodes and the database is an ordinary workload that a drain can evict;
+on a claim it comes back with its data — then converts the release with
+`uiBackend.replicaCount=2`, which is the constraint SQLite imposes and
+Postgres lifts.
+
+Cost: a pod on nodes already running, plus one PD for the rest of the window.
+Fractions of a cent against the ~15-20¢ the six e2-medium nodes cost anyway.
+
+| # | Question | Why it is on the list |
+|---|---|---|
+| P1 | Every pod Running, 0 restarts after conversion | Two ui-backends and a planner migrate at once. Before the advisory lock one died on a duplicate key and CrashLoopBackOffed until another committed |
+| P2 | No plan-store `/data` mount anywhere | If it survived, the single-node constraint came with it and Postgres bought nothing |
+| P3 | A plan appears, with steps | Item 1 asked again on the other backend |
+| P4 | A drain reaches the reclamation ledger | Exactly what v0.6.0 got wrong: the drain succeeded, the executor's events looked perfect, and nothing was written to the store |
+
+The old `k8s-dencer-data` claim survives the switch by design
+(`helm.sh/resource-policy: keep`) so a backend change never destroys plan
+history. It is removed with the cluster; `verify-teardown.sh` confirms it.
+
+**Rehearsed on a local cluster before this was written**, which found three
+things worth having found for free: a chart template that could not be
+upgraded into with `--reuse-values`, a script that broke its own database on
+a second run, and the fact that the component images are distroless and have
+no shell to exec into.

--- a/hack/capture/postgres-phase.sh
+++ b/hack/capture/postgres-phase.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+#
+# The Postgres phase of a GKE playground run.
+#
+# Deliberately a second step rather than a flag on the launch. The run exists
+# to answer one question — does this version plan on a real managed cluster —
+# and CHECKLIST item 1 says stop if it fails. Installing against Postgres from
+# the start would put a database pod on a node whose 940m allocatable is
+# already 30-80% spoken for by GKE's own daemons, changing what the planner
+# sees on the exact run meant to measure that. So: SQLite answers the P0
+# question, then this converts the same cluster and asks it again.
+#
+# Run it after checklist items 1-3 have passed, with time left in the window.
+#
+#   ./hack/capture/postgres-phase.sh
+#
+# What it costs: a Postgres pod on nodes already paid for, plus one 10Gi PD
+# for the rest of the window. Fractions of a cent. The expense of this run is
+# the six e2-medium nodes, and they are already running.
+#
+# The PD is not optional. This exercise drains nodes for a living, and the
+# database is an ordinary workload that can be evicted by the drain it is
+# recording. On a claim it comes back with its data; on an emptyDir it comes
+# back empty and the ui-backend then serves "relation does not exist" against
+# a schema it migrated minutes earlier. That is not a hypothetical — it
+# happened three times in the e2e this week before the cause was understood.
+
+set -euo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# The same chart the playground installed, so this cannot drift to a different
+# version mid-exercise.
+REPO_CHART="${REPO_CHART:-$REPO/charts/k8s-dencer}"
+
+CTX="${CTX:-$(kubectl config current-context)}"
+NS="${NS:-k8s-dencer}"
+RELEASE="${RELEASE:-k8s-dencer}"
+# Reuse the password already in the cluster if there is one.
+#
+# POSTGRES_PASSWORD only takes effect when the data directory is initialised.
+# The claim outlives the pod, so a second run that minted a fresh password
+# would leave the Secret and the database disagreeing, and every component
+# would crashloop on "password authentication failed" — which is what
+# happened the first time this was rehearsed. Idempotence here is not
+# tidiness; it is the difference between re-running this during a metered
+# window and losing the window.
+EXISTING="$(kubectl --context "$CTX" -n "$NS" \
+  get secret play-db -o jsonpath='{.data.password}' 2>/dev/null || true)"
+if [[ -n "$EXISTING" ]]; then
+  PG_PASSWORD="$(printf '%s' "$EXISTING" | base64 --decode)"
+else
+  PG_PASSWORD="${PG_PASSWORD:-$(head -c 18 /dev/urandom | base64 | tr -d '/+=' )}"
+fi
+# standard-rwo is GKE's. Overridable so this can be rehearsed on a local
+# cluster before it is run against something that costs money.
+PG_STORAGE_CLASS="${PG_STORAGE_CLASS:-standard-rwo}"
+PG_PF_PORT="${PG_PF_PORT:-18808}"
+
+bold()  { printf '\033[1m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+fail()  { red "ERROR: $*"; exit 1; }
+
+kubectl --context "$CTX" -n "$NS" get deploy "${RELEASE}-ui-backend" >/dev/null 2>&1 \
+  || fail "no k8s-dencer release in ${NS} on context ${CTX}; run the playground first"
+
+bold "==> the ledger before the switch"
+# Recorded, because it is about to be left behind. There is no migration path
+# from the SQLite store (#181, closed deliberately): the plan is recomputed
+# within a resync, but the reclamation ledger and audit trail stay in the file.
+# Through a port-forward rather than kubectl exec: the component images are
+# distroless and have no shell and no wget in them, which is the point of
+# distroless and was discovered the hard way.
+kubectl --context "$CTX" -n "$NS" port-forward "svc/${RELEASE}-ui-backend" "${PG_PF_PORT}:8080" >/dev/null 2>&1 &
+PF=$!
+trap 'kill $PF 2>/dev/null || true' EXIT
+sleep 4
+if TOKEN="$(kubectl --context "$CTX" -n "$NS" create token "${RELEASE}-ui-backend" --duration=10m 2>/dev/null)"; then
+  curl -s --max-time 8 -H "Authorization: Bearer ${TOKEN}" \
+    "http://localhost:${PG_PF_PORT}/api/v1/reclamations" | head -c 400 || true
+  echo
+fi
+kill $PF 2>/dev/null || true
+trap - EXIT
+
+bold "==> postgres, on a claim"
+kubectl --context "$CTX" -n "$NS" apply -f - >/dev/null <<YAML
+apiVersion: v1
+kind: Secret
+metadata:
+  name: play-db
+type: Opaque
+stringData:
+  password: ${PG_PASSWORD}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: play-postgres
+spec:
+  accessModes: [ReadWriteOnce]
+  storageClassName: ${PG_STORAGE_CLASS}
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: play-postgres
+spec:
+  selector: {app: play-postgres}
+  ports: [{port: 5432, targetPort: 5432}]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: play-postgres
+spec:
+  replicas: 1
+  strategy: {type: Recreate}
+  selector: {matchLabels: {app: play-postgres}}
+  template:
+    metadata:
+      labels: {app: play-postgres}
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:16-alpine
+          env:
+            - {name: POSTGRES_DB, value: dencer}
+            - {name: POSTGRES_USER, value: dencer}
+            - {name: POSTGRES_PASSWORD, valueFrom: {secretKeyRef: {name: play-db, key: password}}}
+            - {name: PGDATA, value: /var/lib/postgresql/data/pgdata}
+          ports: [{containerPort: 5432}]
+          readinessProbe:
+            exec: {command: ["pg_isready","-U","dencer"]}
+            periodSeconds: 3
+          resources:
+            requests: {cpu: 100m, memory: 256Mi}
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 70
+            capabilities: {drop: ["ALL"]}
+            seccompProfile: {type: RuntimeDefault}
+          volumeMounts: [{name: data, mountPath: /var/lib/postgresql/data}]
+      volumes:
+        - name: data
+          persistentVolumeClaim: {claimName: play-postgres}
+YAML
+
+kubectl --context "$CTX" -n "$NS" rollout status deploy/play-postgres --timeout=300s >/dev/null \
+  || fail "postgres did not become ready"
+green "  ready, on a 10Gi ${PG_STORAGE_CLASS} claim"
+
+bold "==> converting the release"
+# replicaCount 2 is the point of the exercise: it is the constraint SQLite
+# imposes and Postgres lifts, and it also puts two migrators in the race the
+# advisory lock exists for. persistence off is correct here, not a shortcut —
+# the chart gates the claim and the /data mount away on this backend.
+helm --kube-context "$CTX" upgrade "$RELEASE" "$REPO_CHART" \
+  --namespace "$NS" --reuse-values \
+  --set database.type=postgres \
+  --set database.postgres.host=play-postgres \
+  --set database.postgres.database=dencer \
+  --set database.postgres.user=dencer \
+  --set database.postgres.existingSecret=play-db \
+  --set database.postgres.sslMode=disable \
+  --set persistence.enabled=false \
+  --set uiBackend.replicaCount=2 \
+  --wait --timeout 420s >/dev/null || {
+    kubectl --context "$CTX" -n "$NS" get pods -o wide
+    kubectl --context "$CTX" -n "$NS" get events --sort-by=.lastTimestamp | tail -20
+    fail "the release did not come up on postgres"
+  }
+green "  converted"
+
+bold "==> what to check now"
+cat <<'NOTES'
+  1. Every pod Running with 0 restarts. Two ui-backends and a planner all
+     migrate at once; before the advisory lock one died on a duplicate key
+     and CrashLoopBackOffed until the other committed.
+  2. No PersistentVolumeClaim for the plan store, and no /data mount. If
+     either survived, the single-node constraint came with it.
+  3. A plan appears, with steps. This is CHECKLIST item 1 asked a second
+     time, on the other backend.
+  4. Drain one step and confirm it reaches the ledger. That is exactly what
+     v0.6.0 got wrong: the drain succeeded, the executor's events looked
+     perfect, and nothing was written to the store.
+
+  The ledger printed at the top of this run is gone — there is no migration
+  path from the file, by decision, and the reclamation history stays in it.
+
+  The old k8s-dencer-data claim is still there, and that is correct: the
+  chart marks it helm.sh/resource-policy: keep so changing backends never
+  destroys an operator's plan history. It costs a Persistent Disk until the
+  cluster goes away. Deleting the cluster removes it; hack/capture/
+  verify-teardown.sh is what confirms nothing was left behind.
+NOTES
+
+kubectl --context "$CTX" -n "$NS" get pods -o wide


### PR DESCRIPTION
Tomorrow's run, with an optional Postgres phase — and the three bugs that rehearsing it uncovered.

## Why a second phase, not a flag

The run answers one question: *does this version plan on a real managed cluster?* Checklist item 1 says stop if it fails.

Installing against Postgres from the start puts a database pod on nodes whose 940m allocatable is **already 30-80% spoken for by GKE's own daemons** — changing what the planner sees, on the exact run meant to measure that. So SQLite answers the P0 question, then `postgres-phase.sh` converts the same cluster and asks it again.

**Cost:** a pod on nodes already running, plus one PD for the rest of the window. Fractions of a cent against the ~15-20¢ the six `e2-medium` nodes cost anyway.

Postgres gets a **10Gi claim, not an emptyDir** — this exercise drains nodes, the database is an ordinary workload a drain can evict, and on a claim it comes back with its data. That is not hypothetical; it happened three times in the e2e this week.

## What rehearsing it found

Three things, all of which would otherwise have surfaced during a metered window.

**1. A chart template that could not be upgraded into.** `sslRootCert` arrived in 0.8.0. `helm upgrade --reuse-values` carries stored values forward and does **not** merge defaults for keys the chart has grown since, so any install predating it failed the render:

```
nil pointer evaluating interface {}.existingSecret
```

That is an upgrade path broken for exactly the operators who have been running longest, and **it has nothing to do with Postgres** — anyone upgrading into 0.8.0 with `--reuse-values` would hit it. Now nil-safe, with the CA path still asserted when set.

**2. A script that broke its own database on a second run.** `POSTGRES_PASSWORD` only applies when the data directory is initialised, and the claim outlives the pod — so minting a fresh password left the Secret and the database disagreeing, and every component crashlooped on `28P01`. It reuses the existing Secret now. Idempotence during a metered window is not tidiness.

**3. The component images are distroless.** The ledger snapshot cannot `kubectl exec` a shell into them. It reads the API through a port-forward, the way anything outside the cluster would.

## Verified end to end locally

Converted release, two ui-backend replicas, **no `/data` mount anywhere**, schema **v15** in Postgres, planner producing an eight-step plan against it.

The old `k8s-dencer-data` claim survives the switch by design (`helm.sh/resource-policy: keep`) so changing backends never destroys plan history — documented, and removed with the cluster.