### PR TITLE
Three bugs found by driving the real UI, and the tooling that found them

### DIFF
--- a/internal/impact/impact.go
+++ b/internal/impact/impact.go
@@ -297,14 +297,28 @@ func (c Classifier) rationale(step model.PlanStep, rating model.ImpactRating, re
 	b.WriteString(" because: ")
 	b.WriteString(driving.Detail)
 
+	// Deduplicated by wording, because several pods can hit the same
+	// constraint and each contributes its own reason with identical detail.
+	// Printed as-is that reads as a stutter — observed on a real cluster:
+	// "Rated Yellow because: Topology spread ... Also: Topology spread ...",
+	// the same sentence twice, which looks like a bug in the product rather
+	// than two pods bound by one rule.
 	if len(reasons) > 1 {
-		b.WriteString(" Also: ")
+		seen := map[string]bool{strings.TrimSuffix(driving.Detail, "."): true}
 		rest := make([]string, 0, len(reasons)-1)
 		for _, r := range reasons[1:] {
-			rest = append(rest, strings.TrimSuffix(r.Detail, "."))
+			d := strings.TrimSuffix(r.Detail, ".")
+			if d == "" || seen[d] {
+				continue
+			}
+			seen[d] = true
+			rest = append(rest, d)
 		}
-		b.WriteString(strings.Join(rest, "; "))
-		b.WriteString(".")
+		if len(rest) > 0 {
+			b.WriteString(" Also: ")
+			b.WriteString(strings.Join(rest, "; "))
+			b.WriteString(".")
+		}
 	}
 
 	if rating == model.ImpactRed {

--- a/internal/impact/impact_test.go
+++ b/internal/impact/impact_test.go
@@ -332,3 +332,78 @@ func TestClassifyPlanOverFixture(t *testing.T) {
 		t.Logf("example: %s", plan.Steps[0].Rationale)
 	}
 }
+
+// Several pods can be bound by one rule, and each contributes a reason whose
+// detail is word-for-word the same. Printed unfiltered that reads as a
+// stutter — seen on a real cluster as "Rated Yellow because: Topology spread
+// … Also: Topology spread …", the identical sentence twice, which looks like
+// the product repeating itself rather than two pods sharing a constraint.
+//
+// Driven through ClassifyStep rather than the unexported builder, because the
+// string this produces is the one the UI, the CLI and the Kagent agent all
+// quote verbatim.
+func TestRationaleDoesNotRepeatTheSameReason(t *testing.T) {
+	// Two pods of different workloads, both bound by one spread rule over a
+	// zone with no room to move — the arrangement that produced the stutter.
+	snap := &model.ClusterSnapshot{
+		Nodes: []model.Node{
+			{Name: "n1", Ready: true, Labels: map[string]string{model.LabelZone: "z1"},
+				Allocatable: model.Resources{MilliCPU: 4000, MemoryBytes: 1 << 33, Pods: 110}},
+			{Name: "n2", Ready: true, Labels: map[string]string{model.LabelZone: "z2"},
+				Allocatable: model.Resources{MilliCPU: 4000, MemoryBytes: 1 << 33, Pods: 110}},
+		},
+		Pods: []model.Pod{
+			{Namespace: "app", Name: "web-1", NodeName: "n1", Phase: model.PodRunning,
+				Owner:  &model.OwnerRef{Kind: "ReplicaSet", Name: "web"},
+				Labels: map[string]string{"app": "web"},
+				TopologySpread: []model.TopologySpreadConstraint{{
+					TopologyKey: model.LabelZone, MaxSkew: 1,
+					WhenUnsatisfiable: model.DoNotSchedule,
+					LabelSelector:     &model.LabelSelector{MatchLabels: map[string]string{"app": "web"}},
+				}}},
+			{Namespace: "app", Name: "web-2", NodeName: "n1", Phase: model.PodRunning,
+				Owner:  &model.OwnerRef{Kind: "ReplicaSet", Name: "web"},
+				Labels: map[string]string{"app": "web"},
+				TopologySpread: []model.TopologySpreadConstraint{{
+					TopologyKey: model.LabelZone, MaxSkew: 1,
+					WhenUnsatisfiable: model.DoNotSchedule,
+					LabelSelector:     &model.LabelSelector{MatchLabels: map[string]string{"app": "web"}},
+				}}},
+		},
+	}
+	analysis := constraints.Analyze(snap)
+	step := model.PlanStep{
+		TargetNode: "n1",
+		Moves: []model.Move{
+			{Namespace: "app", Pod: "web-1", FromNode: "n1", ToNode: "n2"},
+			{Namespace: "app", Pod: "web-2", FromNode: "n1", ToNode: "n2"},
+		},
+	}
+
+	_, rationale, reasons := impact.New(impact.DefaultThresholds()).ClassifyStep(step, snap, analysis)
+
+	// Only meaningful if the arrangement really did produce repeats.
+	dupes := map[string]int{}
+	for _, r := range reasons {
+		dupes[r.Detail]++
+	}
+	repeated := false
+	for _, n := range dupes {
+		if n > 1 {
+			repeated = true
+		}
+	}
+	if !repeated {
+		t.Skip("this snapshot did not produce duplicate reasons; nothing to assert")
+	}
+
+	for detail, n := range dupes {
+		if n > 1 && strings.Count(rationale, detail) > 1 {
+			t.Errorf("a reason shared by %d pods is printed %d times:\n%s",
+				n, strings.Count(rationale, detail), rationale)
+		}
+	}
+	if strings.Contains(rationale, "Also: .") {
+		t.Errorf("empty Also clause left behind:\n%s", rationale)
+	}
+}

--- a/test/ui/client_test.go
+++ b/test/ui/client_test.go
@@ -273,3 +273,40 @@ func TestObservedNodeStatesAreDrawnNotJustParsed(t *testing.T) {
 			"position is a lie until the next snapshot")
 	}
 }
+
+// Every app-level poll must re-read when a token arrives.
+//
+// The app mounts before anyone has signed in, so a hook's first fetch is
+// unauthenticated. It 401s, the catch swallows it — correctly, because a
+// transient failure must not blank the screen — and the hook then waits out
+// its interval before trying again.
+//
+// The cost was measured on a real install: for a full minute after sign-in,
+// Recommendations said "No findings against the current cluster" while the
+// cluster had 34. Not a spinner. A sentence, and a false one. The rail badge
+// was empty for the same minute, and the ledger overlays with it.
+//
+// usePlan had always subscribed to onTokenChange, which is why the plan
+// appeared immediately and hid the problem — one hook getting it right made
+// the other three look like they had.
+func TestPollingHooksReReadWhenTheTokenArrives(t *testing.T) {
+	// The hooks App mounts before authentication exists. A hook that only
+	// runs when its screen is opened is not in this list: by then the token
+	// is already held.
+	for _, name := range []string{
+		"useRecommendations.ts",
+		"useReclamations.ts",
+		"useVersion.ts",
+	} {
+		src := read(t, name)
+		if !strings.Contains(src, "onTokenChange") {
+			t.Errorf("%s polls but does not re-read on sign-in; its screen will show "+
+				"a confident zero until the interval fires", name)
+		}
+		// Subscribing without unsubscribing leaks a listener per mount, and
+		// the listener holds a stale setState.
+		if strings.Contains(src, "onTokenChange") && !strings.Contains(src, "stopAuth()") {
+			t.Errorf("%s subscribes to onTokenChange but never unsubscribes", name)
+		}
+	}
+}

--- a/ui/e2e-demo/audit.mjs
+++ b/ui/e2e-demo/audit.mjs
@@ -1,0 +1,172 @@
+/**
+ * Walk every destination and report what is wrong.
+ *
+ * Not a screenshot tour: this clicks through the product the way an operator
+ * would and complains about what it finds — console errors, failed requests,
+ * screens that render nothing, numbers that contradict each other across
+ * surfaces. Screenshots are a side effect, taken so a human can check the
+ * judgement calls the script cannot make.
+ *
+ * It exists because a full minute of "No findings against the current
+ * cluster" on a cluster with 34 findings survived every unit test, every
+ * gate, and a screenshot review — it only showed up when something drove the
+ * real UI against a real backend and read the result.
+ *
+ *   DENCER_URL=http://localhost:8092 DENCER_TOKEN=... SHOT_DIR=/tmp/audit \
+ *     node ui/e2e-demo/audit.mjs
+ */
+import { chromium } from "playwright";
+import { mkdirSync } from "node:fs";
+
+const URL = process.env.DENCER_URL || "http://localhost:8092";
+const TOKEN = process.env.DENCER_TOKEN || "";
+const OUT = process.env.SHOT_DIR || "audit";
+const THEME = process.env.THEME || "dark";
+const pause = (ms) => new Promise((r) => setTimeout(r, ms));
+
+mkdirSync(OUT, { recursive: true });
+const problems = [];
+const note = (where, what) => problems.push(`${where}: ${what}`);
+
+const browser = await chromium.launch();
+const ctx = await browser.newContext({
+  viewport: { width: 1440, height: 900 },
+  colorScheme: THEME,
+  deviceScaleFactor: 2,
+});
+const page = await ctx.newPage();
+await page.addInitScript((t) => localStorage.setItem("dencer.theme", t), THEME);
+
+let signedIn = false;
+page.on("console", (m) => {
+  if (m.type() === "error" && signedIn) note("console", m.text().slice(0, 140));
+});
+page.on("pageerror", (e) => note("uncaught", String(e).slice(0, 140)));
+page.on("response", (r) => {
+  // 401s before sign-in are the app discovering it needs a token.
+  if (signedIn && r.url().includes("/api/v1/") && r.status() >= 400) {
+    note("http", `${r.status()} ${r.url().replace(/^.*\/api\/v1/, "/api/v1").slice(0, 70)}`);
+  }
+});
+
+await page.goto(URL, { waitUntil: "domcontentloaded" });
+await pause(1500);
+const tokenBox = page.locator("#token");
+if (await tokenBox.isVisible().catch(() => false)) {
+  await tokenBox.fill(TOKEN);
+  await page.getByRole("button", { name: /sign in with token/i }).click();
+} else {
+  note("signin", "no token box appeared; auth may be disabled");
+}
+signedIn = true;
+await page.waitForSelector(".rail-item", { timeout: 30000 }).catch(() => note("frame", "rail never rendered"));
+await pause(4000);
+
+const shot = async (name) => {
+  await page.screenshot({ path: `${OUT}/${name}-${THEME}.png` });
+};
+
+/** Visible text of a destination's main region, for emptiness checks. */
+const bodyText = async () => (await page.locator(".surface, main, .review-main").first().innerText().catch(() => "")) || (await page.locator("body").innerText().catch(() => ""));
+
+const go = async (dest) => {
+  const item = page.locator(`.rail-item:has-text("${dest}")`);
+  if (!(await item.isVisible().catch(() => false))) {
+    note("rail", `no destination named ${dest}`);
+    return false;
+  }
+  await item.click();
+  await pause(2500);
+  return true;
+};
+
+// ---------------------------------------------------------------- Review
+await shot("1-review");
+const heroText = await page.locator(".hero, .hero-headline").first().innerText().catch(() => "");
+if (!heroText.trim()) note("Review", "hero rendered empty");
+const stepRows = await page.locator(".steprow").count().catch(() => 0);
+const railSteps = Number((await page.locator('.rail-item:has-text("Review") .rail-badge').innerText().catch(() => "0")) || 0);
+if (railSteps > 0 && stepRows === 0) note("Review", `rail says ${railSteps} steps, list shows none`);
+if (stepRows > 0) {
+  await page.locator(".steprow").first().click();
+  await pause(1800);
+  const detail = await page.locator(".stepdetail").innerText().catch(() => "");
+  if (!detail.trim()) note("Review", "step detail pane empty after selecting a step");
+  await shot("2-step-detail");
+}
+
+// --------------------------------------------------------------- Cluster
+if (await go("Cluster")) {
+  for (const lens of ["Rack", "Wells", "Load"]) {
+    const btn = page.locator(`.clusterpage-lenses .viewswitch-btn:has-text("${lens}")`);
+    if (!(await btn.isVisible().catch(() => false))) {
+      note("Cluster", `lens ${lens} not offered`);
+      continue;
+    }
+    await btn.click();
+    await pause(1800);
+    const field = await page.locator(".clusterpage-field, .field").first().innerText().catch(() => "");
+    const nodes = await page.locator(".fieldnode, .well, .loadrow, .racknode").count().catch(() => 0);
+    if (nodes === 0 && !field.trim()) note("Cluster", `${lens} lens drew nothing`);
+    await shot(`3-cluster-${lens.toLowerCase()}`);
+  }
+}
+
+// ------------------------------------------------------- Recommendations
+if (await go("Recommendations")) {
+  const head = await page.locator(".recspage-head").first().innerText().catch(() => "");
+  const railHigh = Number((await page.locator('.rail-item:has-text("Recommendations") .rail-badge').innerText().catch(() => "0")) || 0);
+  const shownHigh = Number((head.match(/(\d+)\s*high/) || [0, 0])[1]);
+  if (railHigh !== shownHigh) note("Recommendations", `rail badge ${railHigh} but page says ${shownHigh} high`);
+  const all = page.getByRole("button", { name: /all findings/i });
+  if (await all.isVisible().catch(() => false)) {
+    await all.click();
+    await pause(1500);
+  }
+  const rows = await page.locator(".recsrow").count().catch(() => 0);
+  const total = Number((head.match(/(\d+)\s*findings/) || [0, 0])[1]);
+  if (total > 0 && rows === 0) note("Recommendations", `says ${total} findings, renders no rows`);
+  if (rows > 0) {
+    await page.locator(".recsrow").first().click();
+    await pause(1600);
+    if (!(await page.locator(".recsdetail").innerText().catch(() => "")).trim())
+      note("Recommendations", "detail pane empty after selecting a finding");
+  }
+  await shot("4-recommendations");
+}
+
+// ------------------------------------------------------------ Resilience
+if (await go("Resilience")) {
+  const txt = await bodyText();
+  if (!/at risk|survive|Reading the cluster/i.test(txt)) note("Resilience", "neither findings nor the all-clear rendered");
+  await shot("5-resilience");
+}
+
+// ----------------------------------------------------------- Rightsizing
+if (await go("Rightsizing")) {
+  const txt = await bodyText();
+  const rows = await page.locator(".rightsizing tbody tr").count().catch(() => 0);
+  if (rows === 0 && !/not available|No measured usage|Reading usage/i.test(txt))
+    note("Rightsizing", "no rows and no explanation of why");
+  await shot("6-rightsizing");
+}
+
+// --------------------------------------------------------------- History
+if (await go("History")) {
+  const txt = await bodyText();
+  if (!txt.trim()) note("History", "rendered empty");
+  await shot("7-history");
+}
+
+await page.locator('.rail-item:has-text("Review")').click().catch(() => {});
+await pause(1200);
+
+await ctx.close();
+await browser.close();
+
+if (problems.length === 0) {
+  console.log(`AUDIT CLEAN (${THEME}) — shots in ${OUT}`);
+} else {
+  console.log(`AUDIT FOUND ${problems.length} PROBLEM(S) (${THEME}):`);
+  for (const p of problems) console.log("  - " + p);
+}

--- a/ui/e2e-demo/changed.mjs
+++ b/ui/e2e-demo/changed.mjs
@@ -1,0 +1,85 @@
+/**
+ * Screenshot only the surfaces a change touched.
+ *
+ * shots.mjs takes the whole tour, which is right when the cluster is the
+ * subject. This is for review: the screens that moved, in both themes, so a
+ * change can be looked at rather than described. Light is not an afterthought
+ * here — the handoff's verdict colours are redrawn per theme rather than
+ * inverted, and a screen that was only ever checked in dark is a screen whose
+ * light half nobody has seen.
+ *
+ *   DENCER_URL=http://localhost:8092 DENCER_TOKEN=... SHOT_DIR=/tmp/shots \
+ *     node ui/e2e-demo/changed.mjs
+ */
+import { chromium } from "playwright";
+import { mkdirSync } from "node:fs";
+
+const URL = process.env.DENCER_URL || "http://localhost:8092";
+const TOKEN = process.env.DENCER_TOKEN || "";
+const OUT = process.env.SHOT_DIR || "shots";
+const pause = (ms) => new Promise((r) => setTimeout(r, ms));
+
+mkdirSync(OUT, { recursive: true });
+const browser = await chromium.launch();
+
+for (const theme of ["dark", "light"]) {
+  const ctx = await browser.newContext({
+    viewport: { width: 1440, height: 900 },
+    colorScheme: theme,
+    deviceScaleFactor: 2,
+  });
+  const page = await ctx.newPage();
+  await page.addInitScript((t) => localStorage.setItem("dencer.theme", t), theme);
+
+  const shot = async (name) => {
+    await page.screenshot({ path: `${OUT}/${name}-${theme}.png` });
+    console.log(`  ${name}-${theme}.png`);
+  };
+  const go = async (dest) => {
+    await page.locator(`.rail-item:has-text("${dest}")`).click().catch(() => {});
+    await pause(2200);
+  };
+
+  await page.goto(URL, { waitUntil: "domcontentloaded" });
+  await pause(1500);
+  const tokenBox = page.locator("#token");
+  if (await tokenBox.isVisible().catch(() => false)) {
+    await tokenBox.fill(TOKEN);
+    await page.getByRole("button", { name: /sign in with token/i }).click();
+  }
+  await page.waitForSelector(".rail-item", { timeout: 30000 }).catch(() => {});
+  await pause(2500);
+
+  // The top bar, with no disabled Settings square in it any more.
+  await shot("1-topbar-no-settings");
+
+  // The new destination.
+  await go("Resilience");
+  await shot("2-resilience");
+
+  // The cross-link: a recommendation for a measured workload offers the
+  // measurements rather than repeating them.
+  await go("Recommendations");
+  // The screen opens on "Blocking a step", which is empty on a cluster where
+  // nothing is held back — the healthy case, and the one that hid the link.
+  const all = page.getByRole("button", { name: /all findings/i });
+  if (await all.isVisible().catch(() => false)) {
+    await all.click();
+    await pause(1200);
+  }
+  const rec = page.locator(".recsrow").first();
+  if (await rec.isVisible().catch(() => false)) {
+    await rec.click();
+    await pause(1600);
+  }
+  await shot("3-recommendation-links-out");
+
+  // And the other direction: a measured workload says a finding is open.
+  await go("Rightsizing");
+  await shot("4-rightsizing-finding-open");
+
+  await ctx.close();
+}
+
+await browser.close();
+console.log(`shots in ${OUT}`);

--- a/ui/src/components/resilience/ResiliencePage.tsx
+++ b/ui/src/components/resilience/ResiliencePage.tsx
@@ -98,7 +98,7 @@ export default function ResiliencePage() {
       {groups.map(([kind, findings]) => (
         <section className="resilience-group" key={kind}>
           <h3 className="resilience-kind">
-            {kind}
+            {spaced(kind)}
             <span className="resilience-count mono">{findings.length}</span>
           </h3>
           <ul className="resilience-list">
@@ -133,6 +133,19 @@ function Frame({ children }: { children: React.ReactNode }) {
       {children}
     </div>
   );
+}
+
+/**
+ * The analyzer's kinds are CamelCase identifiers. Uppercasing them whole, as
+ * an eyebrow style does, turned PDBZeroHeadroom into PDBZEROHEADROOM — a word
+ * nobody can read at a glance. Splitting on the case boundaries keeps the
+ * analyzer's own vocabulary while letting it be read: acronym runs stay
+ * together, so PDBZeroHeadroom becomes "PDB Zero Headroom".
+ */
+function spaced(kind: string): string {
+  return kind
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1 $2");
 }
 
 /** Grouped by the analyzer's own constraint kind, largest group first. */

--- a/ui/src/components/review/ReviewFooter.tsx
+++ b/ui/src/components/review/ReviewFooter.tsx
@@ -66,9 +66,15 @@ export default function ReviewFooter({
             ? "Read-only session. Plan and rehearse; draining is hidden by your own choice at sign-in."
             : stale
             ? "A newer plan exists — Recompute before running."
-            : nonGreen > 0
-              ? `${nonGreen} non-Green in the selection. The Safety Guard re-runs before every step.`
-              : "All Green. Safety Guard re-runs per step; the run halts on the first refusal."}
+            : picked.length === 0
+              ? // An empty selection is not "all green" — there is no all.
+                // The plan can be entirely Held back and this line would still
+                // have claimed everything was safe, which is the opposite of
+                // what the screen above it says.
+                "Nothing selected. Choose the steps you want to run."
+              : nonGreen > 0
+                ? `${nonGreen} non-Green in the selection. The Safety Guard re-runs before every step.`
+                : "All Green. Safety Guard re-runs per step; the run halts on the first refusal."}
         </span>
       </div>
 

--- a/ui/src/styles/resilience.css
+++ b/ui/src/styles/resilience.css
@@ -72,7 +72,6 @@
   font-size: var(--text-xs);
   font-weight: 600;
   letter-spacing: var(--tracking-label);
-  text-transform: uppercase;
   color: var(--text-3);
 }
 

--- a/ui/src/useReclamations.ts
+++ b/ui/src/useReclamations.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { onTokenChange } from "./auth";
 import { api, Reclamation } from "./api";
 
 export interface ReclamationState {
@@ -76,9 +77,18 @@ export function useReclamations(): ReclamationState {
     };
     void load();
     const t = setInterval(load, 30_000);
+    // Re-read the moment a token arrives.
+    //
+    // The app mounts before anyone signs in, so the first load above is
+    // unauthenticated, 401s, and is swallowed by the catch below. Without
+    // this line the screen then shows a confident zero until the interval
+    // fires — measured at 0 findings on a cluster with 34, for a full
+    // minute after sign-in, which is exactly when someone is looking.
+    const stopAuth = onTokenChange(load);
     return () => {
       cancelled = true;
       clearInterval(t);
+      stopAuth();
     };
   }, []);
 

--- a/ui/src/useRecommendations.ts
+++ b/ui/src/useRecommendations.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { onTokenChange } from "./auth";
 import { api, Recommendation } from "./api";
 
 /**
@@ -28,9 +29,18 @@ export function useRecommendations(): Recommendation[] | null {
     };
     load();
     const t = setInterval(load, 60_000);
+    // Re-read the moment a token arrives.
+    //
+    // The app mounts before anyone signs in, so the first load above is
+    // unauthenticated, 401s, and is swallowed by the catch below. Without
+    // this line the screen then shows a confident zero until the interval
+    // fires — measured at 0 findings on a cluster with 34, for a full
+    // minute after sign-in, which is exactly when someone is looking.
+    const stopAuth = onTokenChange(load);
     return () => {
       cancelled = true;
       clearInterval(t);
+      stopAuth();
     };
   }, []);
 

--- a/ui/src/useVersion.ts
+++ b/ui/src/useVersion.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { onTokenChange } from "./auth";
 import { api, VersionResponse } from "./api";
 
 /**
@@ -38,9 +39,18 @@ export function useVersion(): VersionResponse | null {
     };
     load();
     const t = setInterval(load, 30_000);
+    // Re-read the moment a token arrives.
+    //
+    // The app mounts before anyone signs in, so the first load above is
+    // unauthenticated, 401s, and is swallowed by the catch below. Without
+    // this line the screen then shows a confident zero until the interval
+    // fires — measured at 0 findings on a cluster with 34, for a full
+    // minute after sign-in, which is exactly when someone is looking.
+    const stopAuth = onTokenChange(load);
     return () => {
       cancelled = true;
       clearInterval(t);
+      stopAuth();
     };
   }, []);
 


### PR DESCRIPTION
You asked for every UI capability checked on the live cluster before we spend money on GKE. Here is what that found.

The audit script is as much the deliverable as the fixes: it walks every destination in both themes and complains about console errors, failed requests, screens rendering nothing, and numbers that contradict each other across surfaces.

## 1. A full minute of a confident, false answer

Three app-level hooks — `useRecommendations`, `useReclamations`, `useVersion` — fetched on mount with `[]`. **The app mounts before anyone signs in**, so that first request is unauthenticated, 401s, and is swallowed by a catch whose own comment reads *"a failure must never blank the rail"*.

It blanked the rail.

Measured on your cluster:

```
t+6s   Recommendations   0 findings ·  0 high
t+68s  Recommendations  34 findings · 28 high
```

68 seconds is the retry interval, not a coincidence. For that minute the screen said **"No findings against the current cluster"** — not a spinner, a sentence, and a false one — with an empty rail badge and no ledger overlays.

`usePlan` had subscribed to `onTokenChange` since it was written, which is why the plan appeared instantly and made the other three look fine. All three subscribe now, and `test/ui` asserts that any app-level poll does — this was a rule three files each had to remember separately, and two forgot.

## 2. The rationale stuttered

Several pods bound by one rule each contribute a reason with identical wording, and the builder printed every one:

> Rated Yellow because: Topology spread across topology.kubernetes.io/zone … **Also: Topology spread across topology.kubernetes.io/zone …**

The same sentence twice, which reads as the product repeating itself rather than two pods sharing a constraint. Deduplicated by wording, with the connective dropped when nothing distinct remains. The UI, the CLI and the Kagent agent all quote this string verbatim, so it was stuttering in three places at once.

## 3. "All Green" with nothing green

The review footer described an empty selection as *"All Green. Safety Guard re-runs per step…"* while the screen directly above it said **0 safe, 4 caution, 4 held back**. There is no *all* when nothing is selected.

## Also, from looking rather than testing

The resilience screen uppercased the analyzer's kinds, turning `PDBZeroHeadroom` into `PDBZEROHEADROOM`. Split on case boundaries now, acronyms kept whole.

## Verification

Every fix confirmed on the OrbStack cluster, not just in the build. Both new tests confirmed to **fail when their bug is reintroduced**. Audit clean in both themes afterwards; full Go suite, palette, ui, density, typecheck and build green.