### PR TITLE
Document v0.8.1, and bump the chart to match

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,11 +274,23 @@ until the next snapshot says where they truly landed.
 execution, and maintenance windows. Phase 4 — hardening toward 1000 nodes and
 50,000 pods — is in progress, with metrics, CI and the release pipeline landed.
 
-**v0.8.0 is published** — images, chart and CLI binaries on `ghcr.io` and the
+**v0.8.1 is published** — images, chart and CLI binaries on `ghcr.io` and the
 [releases page](https://github.com/atedgimo/k8s-dencer/releases), installable by
 the command above.
 
-It is the release that went looking. Every fix in it came from running the
+**Upgrade from v0.8.0 if you use `--reuse-values`:** that release added
+`database.postgres.sslRootCert`, and `helm upgrade --reuse-values` carries
+stored values forward without merging defaults for new keys — so the template
+hit a nil pointer and the upgrade would not render at all. It is nil-safe now.
+
+v0.8.1 also fixes three bugs found by driving the UI against a real cluster
+rather than reading it: the fix queue reported **0 findings for a full minute
+after sign-in** on a cluster with 34, because three polling hooks never re-read
+when a token arrived; a step's rationale printed the same reason twice when
+several pods shared one rule; and the review footer called an empty selection
+"All Green" while the screen above it said nothing was safe.
+
+v0.8.0 before it is the release that went looking. Every fix in it came from running the
 product rather than reading it: the CLI could not find its own backend unless
 the Helm release happened to be named `k8s-dencer`; it reported a plan the
 planner had just re-confirmed as twenty hours old, contradicting the UI about

--- a/charts/k8s-dencer/Chart.yaml
+++ b/charts/k8s-dencer/Chart.yaml
@@ -10,8 +10,8 @@ type: application
 
 # Chart version tracks the chart; appVersion tracks the images. Component image
 # tags default to appVersion so a chart release pins a coherent image set.
-version: 0.8.0
-appVersion: "0.8.0"
+version: 0.8.1
+appVersion: "0.8.1"
 
 # controller-runtime and the policy/v1 PDB API used here are stable from 1.21,
 # but the chart relies on 1.27-era defaults for restricted Pod Security

--- a/docs/product-roadmap.md
+++ b/docs/product-roadmap.md
@@ -239,6 +239,28 @@ everything else, including two flaws in the new test itself — it drained the
 node its own database was on, then drained the pod its own port-forward was
 talking through.
 
+### What driving it found (2026-08-15)
+- **The fix queue was blind for a minute after sign-in.** Three polling hooks
+  fetched on mount, before anyone had a token, got a 401, and swallowed it —
+  then waited out a 60-second interval. Measured on a live cluster: 0 findings
+  at t+6s, 34 at t+68s, with the screen saying "No findings against the current
+  cluster" the whole time. Not a spinner; a sentence, and a false one
+- **A rationale that stuttered** — several pods bound by one rule each
+  contribute an identically-worded reason, and every one was printed. The UI,
+  the CLI and the Kagent agent all quote that string
+- **"All Green" over a plan with nothing green**, whenever the selection was
+  empty
+- **`helm upgrade --reuse-values` into v0.8.0 could not render**, because the
+  chart grew a key and Helm does not merge defaults for keys added since the
+  stored values were written
+- **An audit script** that walks every destination in both themes and reports
+  console errors, failed requests, empty screens and cross-surface
+  contradictions
+
+None of these survived contact with a real cluster, and none of them were
+caught by unit tests, the gates, or a screenshot review. That is the pattern
+worth keeping: the reviews find the engine, the cluster finds the product.
+
 ## Next
 
 Ordered by intent; items move up when a user need pulls them.


### PR DESCRIPTION
Patch release: one upgrade-blocking fix, three bugs a real cluster found.

## The one that decides whether anyone can take this release

v0.8.0 added `database.postgres.sslRootCert`. `helm upgrade --reuse-values` carries stored values forward and does **not** merge defaults for keys the chart has grown since — so any install predating that key failed the render outright:

```
nil pointer evaluating interface {}.existingSecret
```

An upgrade path broken for exactly the operators who had been running longest. Nil-safe now.

## Three from driving the UI, not reading it

| Bug | Effect |
|---|---|
| Three polling hooks never re-read on sign-in | **0 findings for a full minute** on a cluster with 34 — with the screen saying "No findings against the current cluster" |
| Rationale printed duplicate reasons | *"Rated Yellow because: Topology spread… Also: Topology spread…"* — quoted verbatim by UI, CLI and Kagent agent |
| Footer called an empty selection "All Green" | …while the screen above said 0 safe, 4 caution, 4 held back |

## What the roadmap records

Not just the fixes — the pattern. None of these survived contact with a real cluster, and none were caught by unit tests, the gates, or a screenshot review.

**The reviews find the engine; the cluster finds the product.** That is why an audit script now walks every destination in both themes and reports console errors, failed requests, empty screens and cross-surface contradictions.