### PR TITLE
Prepare the GKE run: what to look at, and what to keep

### DIFF
--- a/hack/capture/CHECKLIST.md
+++ b/hack/capture/CHECKLIST.md
@@ -138,3 +138,31 @@ things worth having found for free: a chart template that could not be
 upgraded into with `--reuse-values`, a script that broke its own database on
 a second run, and the fact that the component images are distroless and have
 no shell to exec into.
+
+---
+
+## Before you start
+
+- `hack/capture/UI-CHECKLIST.md` — what to look at on each screen and what
+  "right" looks like. Keep it open beside the browser; the last three UI bugs
+  all passed every automated gate and only appeared when someone read the
+  screen.
+
+## Before the cluster expires
+
+```bash
+./hack/capture/postrun.sh
+```
+
+Collects 30-odd files — nodes, pods, events, all three components' logs
+including the previous container, every API endpoint, metrics from all three,
+the per-node system overhead, and the graph every lens draws from — then
+writes a `FINDINGS.md` to fill in **while the cluster still exists**.
+
+Rehearsed against a local cluster, which is how three defects in it were found
+before they cost a window: it used the ui-backend's own ServiceAccount, whose
+token authenticates and is then refused, so every API file was an error body
+that looked like a successful capture; it read metrics from the wrong port on
+one component; and it passed `--context` to a script that reads stdin.
+
+Afterwards: `./hack/capture/verify-teardown.sh`.

--- a/hack/capture/UI-CHECKLIST.md
+++ b/hack/capture/UI-CHECKLIST.md
@@ -1,0 +1,111 @@
+# What to look at in the UI, and what "right" looks like
+
+The other checklist asks whether the product works. This one asks whether it
+**says true things**, which is a different question and the one the UI is for.
+
+Written because the last three UI bugs — a fix queue that reported 0 findings
+on a cluster with 34, a rationale that printed the same sentence twice, a
+footer that called an empty selection "All Green" — all passed every unit
+test, every gate, and a screenshot review. They only appeared when someone
+drove the real thing and read it.
+
+Open the UI with the URL the launcher prints. Auth is on: paste the token it
+gives you.
+
+---
+
+## The one that matters most
+
+**Everything below is downstream of this: the plan must have steps.**
+
+On 2026-08-07 this product could not plan on GKE at all — every node read as
+undrainable because a static pod owned by the node was treated as movable. If
+Review shows `0 steps` and Cluster shows nodes that are clearly half empty,
+**stop and capture**; that is the P0 returning and nothing else is worth
+measuring.
+
+---
+
+## Review
+
+| Look at | Right | Wrong, and what it means |
+|---|---|---|
+| Headline | Names a decision — "N nodes can be reclaimed safely" or, if nothing is safe, what is blocking | A number with no verdict |
+| Triage counts | Safe + Caution + Held back equals the step count in the rail badge | They disagree — two views of one plan drifting |
+| A step's rationale | One sentence per distinct reason | **The same sentence twice.** Fixed in v0.8.1; if it is back, the dedup regressed |
+| Footer with nothing selected | "Nothing selected. Choose the steps you want to run." | "All Green" — fixed in v0.8.1 |
+| Footer with a Red step selected | Demands a typed confirmation | Lets you run it silently |
+
+## Recommendations
+
+**Check this within ten seconds of signing in.** Three hooks used to fetch
+before a token existed, swallow the 401, and then wait a full minute — so the
+screen said "No findings against the current cluster" while there were 34.
+Fixed in v0.8.1, and this is the cheapest place to catch it coming back.
+
+- rail badge and the page header must agree on the high-severity count
+- a finding with a fix shows paste-ready YAML
+- "Blocking a step" is often empty on a healthy cluster; **that is correct** —
+  switch to "All findings" before concluding anything
+
+## Resilience *(new in v0.8.0)*
+
+- explanations are the analyzer's own words, identical to what `dencer audit`
+  prints
+- **DaemonSet pods must not appear.** They cannot move, but losing their node
+  costs nothing. If `ControllerPinned` findings are listed, the pinned-vs-
+  at-risk distinction regressed
+- kinds read as words — "PDB Zero Headroom", not "PDBZEROHEADROOM"
+
+## Cluster
+
+Three lenses, and the interesting one on GKE is **Load**.
+
+- **Load**: on OrbStack this shows one node, because 17 of 18 are simulated and
+  have no kubelet for metrics-server to scrape. **On GKE every node is real, so
+  every node should appear.** If nodes are missing there, that is a genuine
+  bug — and the headline must say "On the N measured nodes", never claim the
+  ratio for the whole fleet
+- **Wells**: the dashed line is the packing ceiling the planner actually used
+  (`planner.packCeiling`, default 0.85). Bars should not cross it
+- **Rack**: pods drawn in situ, width by CPU request
+
+## Rightsizing
+
+- refuses to guess: with no usage source it says so rather than estimating
+- on GKE with `usageSource=metrics-server` it should list real workloads
+- rows for workloads that also have a finding show "finding open"
+
+## History
+
+- the ledger fills only after a drain **and** a reclamation
+- money appears only if the launcher passed prices — it does, from the same
+  cents/hour the consent line quoted
+- **unpriced is not free.** If a machine type has no price it must be reported
+  as unpriced, never as zero
+
+## Both themes
+
+Toggle it. The verdict colours are redrawn per theme rather than inverted, so
+light is not a tint of dark and has to be looked at separately.
+
+---
+
+## While you are playing
+
+Worth trying, in rough order of how much they teach:
+
+1. **Select a Caution step and Rehearse.** A dry run executes every guard check
+   and emits the same events without cordoning or evicting anything.
+2. **Then drain it for real** and watch the run screen: cordon → evict → verify
+   → drained. Then check History and Resilience again — the estate changed.
+3. **Open a Red step.** It should refuse without a maintenance window, and say
+   so as the product working rather than as an error.
+4. **Try `dencer` from your terminal** against the same cluster; the CLI and the
+   UI must agree. Constraint explanations are printed verbatim in both
+   precisely so they cannot disagree.
+5. **Break something on purpose** — scale a Deployment to 1 replica, or add a
+   zero-headroom PDB — and watch it appear in Recommendations and Resilience.
+
+If anything reads oddly, `./hack/capture/capture.sh <phase>` takes the whole
+snapshot. Better a capture you throw away than a memory of something strange.

--- a/hack/capture/postrun.sh
+++ b/hack/capture/postrun.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+#
+# Everything worth keeping from a playground run, collected before the cluster
+# goes away — and a findings file to write into while it is still fresh.
+#
+#   ./hack/capture/postrun.sh            # into ./capture/<timestamp>/
+#   OUT=/tmp/run ./hack/capture/postrun.sh
+#
+# The 2026-08-07 run produced twenty issues, and the ones that turned out to
+# matter were not the ones anyone remembered afterwards. The cluster is
+# self-destructing and cannot be re-asked, so this errs heavily towards taking
+# too much: the expensive thing is the cluster, not the disk.
+#
+# Safe to run more than once, and safe to run late — every step tolerates the
+# thing it is asking about having already gone.
+
+set -uo pipefail
+
+CTX="${CTX:-$(kubectl config current-context)}"
+NS="${NS:-k8s-dencer}"
+DEMO_NS="${DEMO_NS:-play}"
+RELEASE="${RELEASE:-k8s-dencer}"
+OUT="${OUT:-capture/$(date -u +%Y%m%dT%H%M%SZ)}"
+PF_PORT="${PF_PORT:-18922}"
+
+mkdir -p "$OUT"
+bold()  { printf '\033[1m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+warn()  { printf '\033[33m%s\033[0m\n' "$*"; }
+
+say() { bold "==> $1"; }
+keep() { # keep <file> <command...>
+  local f="$OUT/$1"; shift
+  if "$@" > "$f" 2>&1; then green "  $f"; else warn "  $f (command failed; output kept)"; fi
+}
+
+say "cluster shape"
+keep nodes.txt          kubectl --context "$CTX" get nodes -o wide
+keep nodes.yaml         kubectl --context "$CTX" get nodes -o yaml
+keep pods-all.txt       kubectl --context "$CTX" get pods -A -o wide
+keep events.txt         kubectl --context "$CTX" get events -A --sort-by=.lastTimestamp
+
+say "the product"
+keep release.txt        helm --kube-context "$CTX" list -n "$NS"
+keep values.yaml        helm --kube-context "$CTX" get values "$RELEASE" -n "$NS"
+keep dencer-pods.txt    kubectl --context "$CTX" -n "$NS" get pods -o wide
+keep dencer-desc.txt    kubectl --context "$CTX" -n "$NS" describe pods
+for c in planner ui-backend executor; do
+  keep "log-$c.txt"     kubectl --context "$CTX" -n "$NS" logs "deploy/${RELEASE}-${c}" --tail=4000
+  # The previous container matters more than the current one when something
+  # crashlooped: the current log starts after the interesting part.
+  kubectl --context "$CTX" -n "$NS" logs "deploy/${RELEASE}-${c}" --previous --tail=2000 \
+    > "$OUT/log-$c-previous.txt" 2>/dev/null && green "  $OUT/log-$c-previous.txt"
+done
+
+say "the workloads under test"
+keep demo-pods.txt      kubectl --context "$CTX" -n "$DEMO_NS" get pods -o wide
+keep demo-all.yaml      kubectl --context "$CTX" -n "$DEMO_NS" get all,pdb -o yaml
+
+say "what the product says about itself"
+kubectl --context "$CTX" -n "$NS" port-forward "svc/${RELEASE}-ui-backend" "${PF_PORT}:8080" >/dev/null 2>&1 &
+PF=$!
+trap 'kill $PF 2>/dev/null || true' EXIT
+sleep 4
+# An identity that is allowed to read.
+#
+# The ui-backend's own ServiceAccount is not: it serves the API, it does not
+# consume it, so its token authenticates fine and is then refused by the
+# authorizer. Using it produced eleven files of
+# {"code":"forbidden","error":"… may not get plans.dencer.io"} that looked
+# like a successful capture — the failure mode this whole script exists to
+# avoid, since the cluster is gone by the time anyone reads them.
+kubectl --context "$CTX" -n "$NS" create sa capture >/dev/null 2>&1 || true
+kubectl --context "$CTX" create clusterrolebinding capture-dencer \
+  --clusterrole="${RELEASE}-consolidation-operator" \
+  --serviceaccount="${NS}:capture" >/dev/null 2>&1 || true
+TOKEN="$(kubectl --context "$CTX" -n "$NS" create token capture --duration=30m 2>/dev/null || true)"
+
+# Prove it before capturing eleven files with it.
+probe="$(curl -s --max-time 15 -H "Authorization: Bearer ${TOKEN}" \
+  "http://localhost:${PF_PORT}/api/v1/plans/latest" 2>/dev/null)"
+case "$probe" in
+  *forbidden*|*unauthenticated*|"")
+    warn "  the capture identity cannot read the API — JSON below will be error bodies"
+    warn "  ${probe:0:120}"
+    ;;
+  *) green "  capture identity authorised" ;;
+esac
+
+api() { curl -s --max-time 20 -H "Authorization: Bearer ${TOKEN}" "http://localhost:${PF_PORT}$1"; }
+for ep in version plans/latest reclamations recommendations rightsizing resilience preflight windows runs stability history; do
+  f="$OUT/api-$(echo "$ep" | tr '/' '-').json"
+  if api "/api/v1/$ep" > "$f" 2>&1 && [[ -s "$f" ]]; then green "  $f"; else warn "  $f (empty or failed)"; fi
+done
+# The graph is per-plan and is the payload every lens draws from.
+PID="$(python3 -c "
+import json,sys
+try:
+    d=json.load(open('$OUT/api-plans-latest.json')); print((d.get('plan') or d).get('id',''))
+except Exception: print('')
+" 2>/dev/null)"
+if [[ -n "$PID" ]]; then
+  if api "/api/v1/plans/$PID/graph" > "$OUT/api-graph.json" 2>&1 && [[ -s "$OUT/api-graph.json" ]]; then
+    green "  $OUT/api-graph.json"
+  else
+    warn "  $OUT/api-graph.json (empty)"
+  fi
+else
+  # Every lens draws from the graph, so its absence is worth a line rather
+  # than a gap someone notices a week later.
+  warn "  no plan id in api-plans-latest.json — graph not captured"
+fi
+kill $PF 2>/dev/null || true
+trap - EXIT
+
+say "metrics"
+# planner and executor expose metrics on their probe port; ui-backend serves
+# them on the same port as the API, because it already has one. Using 8081 for
+# all three quietly produced an empty file for ui-backend.
+for c in planner ui-backend executor; do
+  port=8081; [[ "$c" == "ui-backend" ]] && port=8080
+  kubectl --context "$CTX" -n "$NS" port-forward "deploy/${RELEASE}-${c}" "18923:${port}" >/dev/null 2>&1 &
+  MP=$!; sleep 3
+  if curl -s --max-time 10 http://localhost:18923/metrics > "$OUT/metrics-$c.txt" 2>&1 && [[ -s "$OUT/metrics-$c.txt" ]]; then
+    green "  $OUT/metrics-$c.txt"
+  else
+    warn "  $OUT/metrics-$c.txt (empty)"
+  fi
+  kill $MP 2>/dev/null || true
+done
+
+say "node overhead — what GKE's own daemons take"
+# The figure that explained the whole 2026-08-07 failure: e2-medium is 2 vCPU
+# but 940m allocatable, and system pods were taking 29-82% of that.
+# It reads `kubectl get pods -A -o json` on stdin — passing --context to it
+# gets a traceback, which is how this was found.
+kubectl --context "$CTX" get pods -A -o json \
+  | python3 "$(dirname "${BASH_SOURCE[0]}")/overhead.py" > "$OUT/overhead.txt" 2>&1 \
+  && green "  $OUT/overhead.txt" || warn "  overhead.py failed (kept)"
+
+say "findings, to fill in now rather than tomorrow"
+cat > "$OUT/FINDINGS.md" <<'NOTES'
+# Run findings
+
+Written while the cluster still exists. Anything left for later is a memory,
+and the 2026-08-07 run showed which of those survive: not the important ones.
+
+## The P0 question — did it plan?
+
+- steps in the first plan:
+- nodes before / after:
+- if zero steps: what did Cluster show, and what did preflight say?
+
+## Was anything wrong?
+
+One line each. Screen, what it said, what it should have said.
+
+-
+
+## Was anything surprising but correct?
+
+These matter as much — they are usually documentation bugs, not code bugs.
+
+-
+
+## Numbers worth keeping
+
+- allocatable per node:
+- system overhead observed:
+- plan: nodes before → after, reclaimable:
+- reclamation: drained at → observed gone at, elapsed:
+- money: what the ledger reported, and whether anything was unpriced:
+
+## What I would change
+
+Ordered by how much it would have helped during this run.
+
+1.
+
+## Follow-ups to file
+
+- [ ]
+NOTES
+green "  $OUT/FINDINGS.md"
+
+echo
+bold "captured into $OUT"
+echo "  Fill in FINDINGS.md before the cluster expires — it cannot be re-asked."
+echo "  Teardown check afterwards: ./hack/capture/verify-teardown.sh"


### PR DESCRIPTION
Two gaps before tomorrow's run, and the three defects that rehearsing them found.

## `UI-CHECKLIST.md` — what to look at

The existing checklist asks whether the product **works**. This asks whether it **says true things**, which is a different question and the one the UI is for.

Per screen: what to look at, what right looks like, what a wrong reading means. It leads with the P0 question, because everything else is downstream — zero steps on a cluster with half-empty nodes is 2026-08-07 returning, and nothing else is worth measuring.

It exists because the last three UI bugs — a fix queue reporting **0 findings on a cluster with 34**, a rationale printing the same sentence twice, a footer calling an empty selection "All Green" — passed every unit test, every gate, and a screenshot review. They appeared only when someone drove the real thing and read it.

It also flags the OrbStack/GKE difference on the Load lens: one node locally because 17 of 18 are simulated and have no kubelet to scrape, but **every node should appear on GKE** — missing nodes there are a real bug.

## `postrun.sh` — what to keep

Thirty-odd files taken before the cluster self-destructs: nodes, pods, events, all three components' logs *including the previous container*, every API endpoint, metrics from all three, per-node system overhead, and the graph every lens draws from. Plus a `FINDINGS.md` to fill in **while the cluster still exists**.

The 2026-08-07 run produced twenty issues, and the ones that mattered were not the ones anyone remembered afterwards.

## What rehearsing it found

All three would have cost a metered window:

1. **It authenticated as the ui-backend's own ServiceAccount.** That token is valid and then *refused* — the backend serves the API, it does not consume it — so all eleven endpoint files were `{"code":"forbidden"}` bodies that looked exactly like a successful capture. It now creates an operator identity and **proves it can read** before capturing anything with it.
2. **Metrics from the wrong port.** 8081 for all three; ui-backend serves on 8080 because it already has an HTTP port. That file was silently empty.
3. **`--context` passed to `overhead.py`**, which reads `kubectl get pods -A -o json` on stdin.

## Also verified rather than assumed

All six real-fabric scenarios render — each applied with **server-side dry-run against a live API server**, not just parsed.