### PR TITLE
One command for everything except the spending

### DIFF
--- a/hack/capture/CHECKLIST.md
+++ b/hack/capture/CHECKLIST.md
@@ -141,6 +141,27 @@ no shell to exec into.
 
 ---
 
+## The short version
+
+Two terminals.
+
+```bash
+# Terminal 1 — launches, prints the cost, waits for a typed yes
+PLAY_MINUTES=45 SCENARIO=a-fragmented GCP_MACHINE=e2-medium REAL_NODES=6 make gcp-play
+
+# Terminal 2 — everything else
+./hack/capture/run.sh
+```
+
+`run.sh` waits for the cluster, names the context, opens the UI, prints a
+token that can also execute, tells you the first plan's step count — the P0
+question, answered before you have opened a browser — and then waits. Press
+Enter when you are done and it captures everything.
+
+The launch stays in terminal 1 deliberately: it prints what it will create and
+what that costs and waits for you to type `yes`. A wrapper that answered that
+for you would be a wrapper that spends your money without asking.
+
 ## Before you start
 
 - `hack/capture/UI-CHECKLIST.md` — what to look at on each screen and what

--- a/hack/capture/README.md
+++ b/hack/capture/README.md
@@ -1,5 +1,51 @@
 # Capturing a cloud run
 
+## The run, in two terminals
+
+Everything you need. Copy these.
+
+```bash
+# TERMINAL 1 — launches. Prints what it creates and what it costs, then waits
+# for you to type: yes
+PLAY_MINUTES=45 SCENARIO=a-fragmented GCP_MACHINE=e2-medium REAL_NODES=6 make gcp-play
+```
+
+```bash
+# TERMINAL 2 — everything else. Waits for the cluster, opens the UI, prints a
+# token, tells you the first plan's step count, then waits while you play.
+# Press Enter when done and it captures 33 files.
+./hack/capture/run.sh
+```
+
+If terminal 2 cannot find the cluster, the context it wants is `gke-play`:
+
+```bash
+CTX=gke-play ./hack/capture/run.sh
+```
+
+Optional, only after checklist items 1-3 pass and only if time remains:
+
+```bash
+./hack/capture/postgres-phase.sh      # convert the same cluster to Postgres
+```
+
+After the cluster self-destructs:
+
+```bash
+./hack/capture/verify-teardown.sh     # confirm nothing is still billing
+```
+
+Every script also runs standalone, so nothing depends on `run.sh` working:
+`wait-up.sh`, `capture.sh <phase>`, `watch-reclaim.sh`, `postrun.sh`.
+
+**Read beside the browser:** `UI-CHECKLIST.md` (what each screen should say)
+and `CHECKLIST.md` (the eight questions). Item 1 is the stop condition — no
+steps on a cluster with spare nodes means the 2026-08-07 P0 is back, and
+nothing downstream is worth measuring.
+
+**Cost:** roughly 15-20¢ for six `e2-medium` nodes over 45 minutes, less on
+spot. The Postgres phase adds fractions of a cent.
+
 Built during the 2026-08-07 GKE run, when the interesting findings turned out
 to be things nobody had thought to look at. A metered cluster is a bad place
 to be writing tooling, so it lives here now.

--- a/hack/capture/run.sh
+++ b/hack/capture/run.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+#
+# The second terminal. Everything around a playground run except the launch.
+#
+#   Terminal 1:  PLAY_MINUTES=45 SCENARIO=a-fragmented GCP_MACHINE=e2-medium \
+#                REAL_NODES=6 make gcp-play
+#   Terminal 2:  ./hack/capture/run.sh
+#
+# The launch stays in terminal 1 on purpose. It prints what it will create and
+# what that costs and waits for a typed yes, and a wrapper that answered that
+# for you would be a wrapper that spends your money without asking. This does
+# the parts that are safe to automate: waiting, connecting, reminding, and —
+# the one that actually matters — capturing before the cluster self-destructs.
+#
+# Safe to run late, safe to re-run, and safe to Ctrl-C: the only thing it
+# creates is a port-forward and a read-only ServiceAccount.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HERE="$REPO/hack/capture"
+CTX="${CTX:-}"
+NS="${NS:-k8s-dencer}"
+DEMO_NS="${DEMO_NS:-play}"
+RELEASE="${RELEASE:-k8s-dencer}"
+UI_PORT="${UI_PORT:-8090}"
+
+bold()  { printf '\033[1m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+warn()  { printf '\033[33m%s\033[0m\n' "$*"; }
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+rule()  { printf '\033[2m%s\033[0m\n' "────────────────────────────────────────────────────────────"; }
+
+# ------------------------------------------------------- wait, then context
+# wait-up.sh is self-contained: it waits for the cluster, fetches credentials,
+# names the context gke-play, and puts your previous context back. So it has
+# to run before there is a context to talk to — guessing one first would find
+# whatever you were last pointed at, which on a good day is OrbStack and on a
+# bad day is production.
+bold "==> waiting for the cluster and the release"
+if [[ -x "$HERE/wait-up.sh" && -z "$CTX" ]]; then
+  "$HERE/wait-up.sh" || warn "  wait-up reported a problem; continuing so you can look"
+  CTX="${CTX:-gke-play}"
+fi
+if [[ -z "$CTX" ]]; then
+  CTX="$(kubectl config current-context 2>/dev/null || true)"
+fi
+[[ -n "$CTX" ]] || { red "no kubectl context found"; exit 1; }
+kubectl --context "$CTX" get ns "$NS" >/dev/null 2>&1 \
+  || { red "context $CTX has no $NS namespace — is this the playground?"; exit 1; }
+bold "==> context: $CTX"
+
+# ------------------------------------------------------------------- access
+bold "==> opening the UI"
+pkill -f "port-forward.*${RELEASE}-ui-frontend" 2>/dev/null || true
+sleep 1
+kubectl --context "$CTX" -n "$NS" port-forward --address 127.0.0.1 \
+  "svc/${RELEASE}-ui-frontend" "${UI_PORT}:80" >/tmp/dencer-ui-pf.log 2>&1 &
+PF=$!
+cleanup() { kill $PF 2>/dev/null || true; }
+trap cleanup EXIT
+sleep 4
+
+# An identity that can read AND execute, because you are going to drain
+# something. The components' own ServiceAccounts cannot: they serve the API,
+# they do not consume it.
+kubectl --context "$CTX" -n "$NS" create sa player >/dev/null 2>&1 || true
+kubectl --context "$CTX" create clusterrolebinding player-dencer \
+  --clusterrole="${RELEASE}-consolidation-operator" \
+  --serviceaccount="${NS}:player" >/dev/null 2>&1 || true
+TOKEN="$(kubectl --context "$CTX" -n "$NS" create token player --duration=8h 2>/dev/null || true)"
+
+code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 8 "http://localhost:${UI_PORT}/" || echo 000)"
+if [[ "$code" == "200" ]]; then green "  UI is up"; else warn "  UI returned $code — it may still be starting"; fi
+
+rule
+bold "  http://localhost:${UI_PORT}"
+echo
+echo "  Paste this into the sign-in box:"
+echo
+echo "$TOKEN"
+rule
+echo
+bold "  CLI against the same cluster:"
+echo "    export DENCER_TOKEN='<the token above>'"
+echo "    dencer plan --context $CTX -n $NS --release $RELEASE"
+echo
+bold "  Open beside the browser:"
+echo "    $HERE/UI-CHECKLIST.md      what to look at, and what right looks like"
+echo "    $HERE/CHECKLIST.md         the eight questions this run exists to answer"
+echo
+warn "  Item 1 is the stop condition: if Review shows no steps on a cluster"
+warn "  with half-empty nodes, capture and stop — everything else is downstream."
+echo
+
+# ------------------------------------------------------------------ the run
+bold "==> first look"
+if [[ -n "$TOKEN" ]]; then
+  steps="$(curl -s --max-time 15 -H "Authorization: Bearer $TOKEN" \
+    "http://localhost:${UI_PORT}/api/v1/plans/latest" 2>/dev/null \
+    | python3 -c "
+import json,sys
+try:
+    d=json.load(sys.stdin); p=d.get('plan') or d
+    print(len(p.get('steps') or []), p.get('nodesBefore'), p.get('nodesAfter'))
+except Exception: print('? ? ?')" 2>/dev/null)"
+  read -r n before after <<<"$steps"
+  if [[ "$n" == "0" ]]; then
+    red "  THE PLAN HAS NO STEPS (${before} nodes). This is the P0 question failing."
+    red "  Capture now:  $HERE/postrun.sh"
+  elif [[ "$n" == "?" ]]; then
+    warn "  could not read a plan yet — give the planner a resync and refresh the UI"
+  else
+    green "  plan has $n step(s): $before nodes now, $after after"
+  fi
+fi
+echo
+
+bold "==> play"
+echo "  Take as long as you like. When you are done — and BEFORE the cluster"
+echo "  expires — press Enter here and everything gets captured."
+echo
+read -r -p "  Press Enter to capture, or Ctrl-C to skip: " _ || true
+
+# --------------------------------------------------------------- the keeping
+echo
+OUT="${OUT:-$REPO/capture/$(date -u +%Y%m%dT%H%M%SZ)}"
+CTX="$CTX" NS="$NS" DEMO_NS="$DEMO_NS" RELEASE="$RELEASE" OUT="$OUT" "$HERE/postrun.sh"
+
+echo
+rule
+bold "  Fill in $OUT/FINDINGS.md now, while the cluster still exists."
+echo "  After it self-destructs:  $HERE/verify-teardown.sh"
+rule


### PR DESCRIPTION
You asked for one command. Everything after the launch now is one.

```bash
# Terminal 1 — prints the cost, waits for a typed yes
PLAY_MINUTES=45 SCENARIO=a-fragmented GCP_MACHINE=e2-medium REAL_NODES=6 make gcp-play

# Terminal 2 — everything else
./hack/capture/run.sh
```

## What it does

1. **Waits** for the cluster, letting `wait-up.sh` name the context first — that ordering matters, because guessing a context before the playground exists finds whatever you were last pointed at, which on a good day is OrbStack
2. **Opens the UI** and prints the URL plus a token that can execute as well as read (the components' own ServiceAccounts cannot — they serve the API, they do not consume it)
3. **Answers the P0 question before you open a browser** — reads the first plan and reports its step count. Zero steps on a cluster with nodes to spare is 2026-08-07 returning, and it says so in red rather than leaving it to be noticed
4. **Waits while you play**, then captures everything on Enter

## Why the launch stays manual

`make gcp-play` prints what it will create and what it costs and waits for a typed `yes`. A wrapper that answered that for you would be a wrapper that spends your money without asking. That is the one rule in the playground worth keeping manual, and this respects it.

## Rehearsed

End to end against OrbStack: **exit 0, 33 files, none an error body**.

The first attempt captured exactly one file — piping the script through `head` killed it with SIGPIPE mid-capture. Worth knowing if anyone ever runs it inside a pipeline.