### PR TITLE
Fix the four harness bugs a laptop could not have found

### DIFF
--- a/hack/capture/postgres-phase.sh
+++ b/hack/capture/postgres-phase.sh
@@ -124,6 +124,22 @@ spec:
     metadata:
       labels: {app: play-postgres}
     spec:
+      # fsGroup, or nothing starts on a real cloud disk.
+      #
+      # A GKE PersistentDisk mounts owned by root. Postgres runs as uid 70 and
+      # cannot create its own data directory:
+      #
+      #   mkdir: can't create directory '/var/lib/postgresql/data/pgdata':
+      #   Permission denied
+      #
+      # fsGroup makes the kubelet chown the volume on mount. This passed every
+      # rehearsal on OrbStack's local-path and on emptyDir, both permissive,
+      # and failed the moment it met real storage — which is the entire
+      # argument for having run this phase on GKE at all.
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 70
+        fsGroup: 70
       containers:
         - name: postgres
           image: postgres:16-alpine

--- a/hack/capture/postrun.sh
+++ b/hack/capture/postrun.sh
@@ -18,7 +18,9 @@ set -uo pipefail
 
 CTX="${CTX:-$(kubectl config current-context)}"
 NS="${NS:-k8s-dencer}"
-DEMO_NS="${DEMO_NS:-play}"
+# dencer-demo is what gcp-playground.sh actually uses; "play" was a guess and
+# produced empty workload files that looked like a successful capture.
+DEMO_NS="${DEMO_NS:-dencer-demo}"
 RELEASE="${RELEASE:-k8s-dencer}"
 OUT="${OUT:-capture/$(date -u +%Y%m%dT%H%M%SZ)}"
 PF_PORT="${PF_PORT:-18922}"
@@ -182,6 +184,35 @@ Ordered by how much it would have helped during this run.
 - [ ]
 NOTES
 green "  $OUT/FINDINGS.md"
+
+# A capture that looks successful and contains nothing has now happened twice:
+# once authenticating as a ServiceAccount that is refused (eleven files of
+# {"code":"forbidden"}), once pointed at a namespace with no workloads. Both
+# were discovered after the cluster was gone. Complain at the time instead.
+say "does this capture actually contain anything?"
+suspect=0
+for f in "$OUT"/api-*.json; do
+  [ -e "$f" ] || continue
+  if grep -qE '"code":"(forbidden|unauthenticated)"' "$f" 2>/dev/null; then
+    warn "  $(basename "$f") is an error body, not data"; suspect=$((suspect+1))
+  fi
+done
+# Not "does it contain letters" — kubectl writes its errors into the file, and
+# "Error from server (NotFound): namespaces not found" is full of letters. Ask
+# for the thing a real listing has: a header row.
+if ! grep -q '^NAME' "$OUT/demo-pods.txt" 2>/dev/null; then
+  warn "  demo-pods.txt has no workloads — is DEMO_NS=$DEMO_NS right for this cluster?"
+  warn "    $(head -1 "$OUT/demo-pods.txt" 2>/dev/null | cut -c1-90)"
+  suspect=$((suspect+1))
+fi
+for f in nodes.txt pods-all.txt log-planner.txt; do
+  [ -s "$OUT/$f" ] || { warn "  $f is empty"; suspect=$((suspect+1)); }
+done
+if [ "$suspect" -eq 0 ]; then
+  green "  looks real: $(ls "$OUT" | wc -l | tr -d ' ') files, no error bodies"
+else
+  warn "  $suspect problem(s) above — fix and re-run while the cluster exists"
+fi
 
 echo
 bold "captured into $OUT"

--- a/hack/capture/run.sh
+++ b/hack/capture/run.sh
@@ -57,8 +57,11 @@ sleep 1
 kubectl --context "$CTX" -n "$NS" port-forward --address 127.0.0.1 \
   "svc/${RELEASE}-ui-frontend" "${UI_PORT}:80" >/tmp/dencer-ui-pf.log 2>&1 &
 PF=$!
-cleanup() { kill $PF 2>/dev/null || true; }
-trap cleanup EXIT
+# Deliberately NOT trapped to EXIT. The capture happens at the end of this
+# script, and on 2026-08-15 the trap tore the port-forward down the instant it
+# ran — so the UI died exactly when the operator went to look at it. The
+# forward is meant to outlive the script; stop it with:
+#   pkill -f "port-forward.*ui-frontend"
 sleep 4
 
 # An identity that can read AND execute, because you are going to drain
@@ -117,10 +120,22 @@ fi
 echo
 
 bold "==> play"
-echo "  Take as long as you like. When you are done — and BEFORE the cluster"
-echo "  expires — press Enter here and everything gets captured."
+echo "  Take as long as you like. The UI stays up — this prompt does not hold"
+echo "  it open. When you are done, and BEFORE the cluster expires, type"
+echo "  'capture' here and everything is kept."
 echo
-read -r -p "  Press Enter to capture, or Ctrl-C to skip: " _ || true
+# A word rather than a bare Enter. On 2026-08-15 a newline left in the buffer
+# by the command that started this script counted as an answer and the capture
+# fired instantly, before anyone had opened a browser. Draining stdin first was
+# the obvious fix and the wrong one — it eats piped input, so the script became
+# unusable non-interactively. Requiring a specific word defeats the stray
+# newline without caring where stdin comes from.
+read -r -p "  Type 'capture' and Enter when you are done (Ctrl-C to skip): " answer || true
+if [[ "${answer:-}" != "capture" ]]; then
+  echo "  not capturing. Run it yourself when ready:"
+  echo "    CTX=$CTX NS=$NS DEMO_NS=$DEMO_NS $HERE/postrun.sh"
+  exit 0
+fi
 
 # --------------------------------------------------------------- the keeping
 echo

--- a/hack/capture/wait-up.sh
+++ b/hack/capture/wait-up.sh
@@ -22,6 +22,18 @@ echo "waiting for nodes ..."
 until [ "$(kubectl --context gke-play get nodes --no-headers 2>/dev/null | grep -c ' Ready')" -ge 1 ]; do sleep 15; done
 kubectl --context gke-play get nodes --no-headers 2>/dev/null | wc -l | xargs echo "nodes present:"
 
+echo "waiting for the product to be installed ..."
+# kubectl wait --all ERRORS when nothing matches, rather than waiting for
+# something to appear. On the 2026-08-15 run this raced the installer and
+# printed "=== READY ===" over an empty namespace, which is worse than being
+# slow: it is confidently wrong at the one moment someone is trusting it.
+for _ in $(seq 1 120); do
+  n=$(kubectl --context gke-play -n k8s-dencer get deploy --no-headers 2>/dev/null | wc -l | tr -d ' ')
+  [ "${n:-0}" -ge 3 ] && break
+  sleep 5
+done
+kubectl --context gke-play -n k8s-dencer get deploy --no-headers 2>/dev/null | wc -l | xargs echo "deployments present:"
+
 echo "waiting for the product to be Ready (up to ~10m) ..."
 kubectl --context gke-play -n k8s-dencer wait --for=condition=available deploy --all --timeout=600s 2>&1 | tail -4
 kubectl --context gke-play -n k8s-dencer get pods 2>&1


### PR DESCRIPTION
Closes #212. All four passed repeated rehearsal on OrbStack and failed on real infrastructure.

| Bug | Why a laptop missed it |
|---|---|
| **Postgres cannot start on a GKE PD** — `mkdir: Permission denied` | A PD mounts root-owned; `local-path` and `emptyDir` are permissive. `fsGroup: 70` makes the kubelet chown it. |
| **`wait-up.sh` prints READY over an empty namespace** | `kubectl wait --all` *errors* when nothing matches instead of waiting. It now waits for the deployments to exist first. |
| **`run.sh` killed the UI when it captured** | The forward was trapped to EXIT, so the browser died exactly when the operator went to look. No longer trapped. |
| **`postrun.sh` wrong demo namespace** | `play` vs `dencer-demo` — the workload files were empty and looked fine. |

## One fix I got wrong first

`run.sh`'s prompt fired on a newline left in the buffer by the launching command. The obvious fix was to drain stdin — and that **ate piped input**, making the script unusable non-interactively. Rehearsing caught it: 0 files captured.

Requiring the word `capture` defeats the stray newline without caring where stdin comes from. Both directions verified: declines on a bare newline, captures on the word, prints the fallback command either way. And the UI survives the exit — confirmed HTTP 200 after the script returns.

## The pattern worth fixing, not just the instance

The namespace bug produced **a capture that looked successful and contained nothing**. That has now happened twice — the first authenticated as a ServiceAccount that is *refused*, writing eleven `{"code":"forbidden"}` files. Both were discovered after the cluster was gone.

So `postrun.sh` now checks its own output before claiming success: error bodies, an empty workload listing, missing core files.

The first version of that check tested whether `demo-pods.txt` contained letters — which `Error from server (NotFound)` satisfies. It now looks for the header row a real listing has, and quotes what kubectl actually said. Verified in both directions.