### PR TITLE
Put the money on the screen where the decision is made

### DIFF
--- a/internal/api/graph/graph.go
+++ b/internal/api/graph/graph.go
@@ -129,6 +129,15 @@ type Stats struct {
 	// anywhere that they existed.
 	AlreadyReclaimable int `json:"alreadyReclaimable,omitempty"`
 
+	// Forecast is what executing this plan would stop costing, per month.
+	//
+	// Absent unless the operator supplied prices — there is no built-in price
+	// table and never will be. A prediction, and labelled as one wherever it
+	// is rendered: the reclamation ledger is the measured figure and the two
+	// must not be confused. Nil rather than zero when nothing is priced,
+	// because unpriced is not free.
+	Forecast *Forecast `json:"forecast,omitempty"`
+
 	// PackCeiling is the utilisation fraction THIS plan refused to pack
 	// above, copied from the plan record — the Wells lens draws its ceiling
 	// line here, and the line must describe the plan on screen, not the
@@ -143,6 +152,17 @@ type Stats struct {
 	// never read them from here — it gets the same numbers from the plan
 	// envelope. Same bar as ever: they can come back the day something reads
 	// them. nodesAfter also lived here once; still nothing reads it.
+}
+
+// Forecast is the money a plan would stop spending if it were executed.
+type Forecast struct {
+	Currency string  `json:"currency"`
+	PerMonth float64 `json:"perMonth"`
+	// PricedNodes and UnpricedNodes together are the plan's reclaimable nodes.
+	// An unpriced machine type is reported, never silently treated as free — a
+	// total that quietly omits half the fleet is worse than no total.
+	PricedNodes   int `json:"pricedNodes"`
+	UnpricedNodes int `json:"unpricedNodes"`
 }
 
 // Build renders the payload at default detail.

--- a/internal/api/rest/rest.go
+++ b/internal/api/rest/rest.go
@@ -390,7 +390,60 @@ func (s *Server) handleGraph(w http.ResponseWriter, r *http.Request) {
 		s.fail(w, err)
 		return
 	}
-	writeJSON(w, http.StatusOK, graph.BuildWith(rec.Plan, rec.Snapshot, rec.Analysis, s.graphOpts))
+	payload := graph.BuildWith(rec.Plan, rec.Snapshot, rec.Analysis, s.graphOpts)
+	payload.Stats.Forecast = s.forecast(rec)
+	writeJSON(w, http.StatusOK, payload)
+}
+
+// forecast prices the nodes this plan would free.
+//
+// The money lived only on History, which reports what was *measured* after the
+// fact. That is the honest number and it belongs there — but it meant the
+// screen where someone decides whether to run a plan said nothing about what
+// running it is worth, and the figure most likely to justify this tool to
+// whoever approves the spend was four clicks away.
+//
+// A prediction, unlike the ledger, and every renderer of it has to say so.
+// Nil when the operator supplied no prices: there is no built-in price table,
+// and an invented one would be a confident wrong number about someone's bill.
+func (s *Server) forecast(rec store.Record) *graph.Forecast {
+	if s.pricing.Empty() || rec.Plan == nil || rec.Snapshot == nil {
+		return nil
+	}
+
+	// Instance type comes from the node the step drains, so a plan that frees
+	// two spot machines and one on-demand is priced as exactly that rather
+	// than as three of something averaged.
+	byName := make(map[string]*model.Node, len(rec.Snapshot.Nodes))
+	for i := range rec.Snapshot.Nodes {
+		byName[rec.Snapshot.Nodes[i].Name] = &rec.Snapshot.Nodes[i]
+	}
+
+	nodes := make([]pricing.Node, 0, len(rec.Plan.Steps))
+	for _, step := range rec.Plan.Steps {
+		n, ok := byName[step.TargetNode]
+		if !ok {
+			continue
+		}
+		nodes = append(nodes, pricing.Node{
+			InstanceType: n.InstanceType(),
+			CapacityType: n.CapacityType(),
+		})
+	}
+	if len(nodes) == 0 {
+		return nil
+	}
+
+	v := s.pricing.Value(nodes)
+	if v.Priced == 0 && v.Unpriced == 0 {
+		return nil
+	}
+	return &graph.Forecast{
+		Currency:      s.pricing.Currency,
+		PerMonth:      v.PerMonth,
+		PricedNodes:   v.Priced,
+		UnpricedNodes: v.Unpriced,
+	}
 }
 
 func (s *Server) handleSnapshot(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/rest/rest_test.go
+++ b/internal/api/rest/rest_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/atedgimo/k8s-dencer/internal/auth"
 	"github.com/atedgimo/k8s-dencer/internal/constraints"
 	"github.com/atedgimo/k8s-dencer/internal/model"
+	"github.com/atedgimo/k8s-dencer/internal/pricing"
 	"github.com/atedgimo/k8s-dencer/internal/store"
 	sqlitestore "github.com/atedgimo/k8s-dencer/internal/store/sqlstore"
 )
@@ -42,6 +43,36 @@ func testServer(t *testing.T, records ...store.Record) *httptest.Server {
 	guard := auth.NewMiddleware(nil, nil, auth.Config{Enabled: false}, slog.New(slog.DiscardHandler))
 
 	api := rest.New(db, slog.New(slog.DiscardHandler), "test", guard, auth.Config{Enabled: false}.Describe())
+	mux := http.NewServeMux()
+	api.Routes(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// testServerPriced is the same server with an operator-supplied price table,
+// which is the only way prices ever reach this product.
+func testServerPriced(t *testing.T, records ...store.Record) *httptest.Server {
+	t.Helper()
+	db, err := sqlitestore.Open(filepath.Join(t.TempDir(), "priced.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := db.Migrate(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	for _, rec := range records {
+		if _, err := db.Save(context.Background(), rec); err != nil {
+			t.Fatal(err)
+		}
+	}
+	guard := auth.NewMiddleware(nil, nil, auth.Config{Enabled: false}, slog.New(slog.DiscardHandler))
+	api := rest.New(db, slog.New(slog.DiscardHandler), "test", guard, auth.Config{Enabled: false}.Describe()).
+		WithPricing(pricing.Table{
+			Currency: "USD",
+			PerHour:  map[string]float64{"e2-medium": 0.034},
+		})
 	mux := http.NewServeMux()
 	api.Routes(mux)
 	srv := httptest.NewServer(mux)
@@ -328,5 +359,83 @@ func TestStepFlagsOnlyReplicaMoves(t *testing.T) {
 	_, body = get(t, srv2, "/api/v1/plans/latest/steps/1")
 	if got, ok := body["singletons"].([]any); !ok || len(got) != 0 {
 		t.Errorf("singletons = %#v, want empty — the workload has a second replica", body["singletons"])
+	}
+}
+
+// The money belongs on the screen where the decision is made.
+//
+// It lived only on History, which reports what was measured after the fact —
+// the honest number, in the right place, and four clicks from where someone
+// decides whether to run a plan. So Review said nothing about what running it
+// is worth, and the figure most likely to justify this tool to whoever
+// approves the spend was the hardest one to find.
+//
+// A forecast, not the ledger. The doctrine holds: no built-in price table,
+// unpriced is never treated as free, and spot is not on-demand.
+func TestGraphCarriesAForecastWhenPricesAreConfigured(t *testing.T) {
+	snap := &model.ClusterSnapshot{
+		TakenAt: time.Now().UTC(),
+		Nodes: []model.Node{
+			{Name: "n1", Ready: true,
+				Labels:      map[string]string{"node.kubernetes.io/instance-type": "e2-medium"},
+				Allocatable: model.Resources{MilliCPU: 940, MemoryBytes: 1 << 31, Pods: 110}},
+			{Name: "n2", Ready: true,
+				// No instance-type label: unpriced, and it must be reported as
+				// unpriced rather than quietly counted as free.
+				Allocatable: model.Resources{MilliCPU: 940, MemoryBytes: 1 << 31, Pods: 110}},
+		},
+		Pods: []model.Pod{
+			{Namespace: "app", Name: "a", NodeName: "n1", Phase: model.PodRunning,
+				Owner: &model.OwnerRef{Kind: "ReplicaSet", Name: "a"}},
+			{Namespace: "app", Name: "b", NodeName: "n2", Phase: model.PodRunning,
+				Owner: &model.OwnerRef{Kind: "ReplicaSet", Name: "b"}},
+		},
+	}
+	rec := store.Record{
+		Plan: &model.Plan{
+			ID: "priced01", GeneratedAt: time.Now().UTC(), SnapshotTakenAt: snap.TakenAt,
+			Status: model.PlanValid, NodesBefore: 2, NodesAfter: 0,
+			Steps: []model.PlanStep{
+				{ID: "s1", SequenceNumber: 1, TargetNode: "n1", Impact: model.ImpactGreen,
+					Moves: []model.Move{{Namespace: "app", Pod: "a", FromNode: "n1", ToNode: "n2"}}},
+				{ID: "s2", SequenceNumber: 2, TargetNode: "n2", Impact: model.ImpactGreen,
+					Moves: []model.Move{{Namespace: "app", Pod: "b", FromNode: "n2", ToNode: "n1"}}},
+			},
+		},
+		Snapshot: snap,
+		Analysis: &constraints.Analysis{},
+		Strategy: "greedy-first-fit-decreasing",
+	}
+
+	srv := testServerPriced(t, rec)
+	code, body := get(t, srv, "/api/v1/plans/priced01/graph")
+	if code != 200 {
+		t.Fatalf("graph = %d, want 200", code)
+	}
+	stats, _ := body["stats"].(map[string]any)
+	f, ok := stats["forecast"].(map[string]any)
+	if !ok {
+		t.Fatalf("no forecast in stats: %v", stats)
+	}
+	if f["pricedNodes"].(float64) != 1 {
+		t.Errorf("pricedNodes = %v, want 1", f["pricedNodes"])
+	}
+	if f["unpricedNodes"].(float64) != 1 {
+		t.Errorf("unpricedNodes = %v, want 1 — unpriced must be reported, never treated as free",
+			f["unpricedNodes"])
+	}
+	if f["perMonth"].(float64) <= 0 {
+		t.Errorf("perMonth = %v, want a positive rate", f["perMonth"])
+	}
+}
+
+// With no prices configured the field is absent, not zero. A zero would read
+// as "this plan saves nothing", which is a claim the product has not earned.
+func TestGraphOmitsTheForecastWithoutPrices(t *testing.T) {
+	srv := testServer(t, sampleRecord("noprice01"))
+	_, body := get(t, srv, "/api/v1/plans/noprice01/graph")
+	stats, _ := body["stats"].(map[string]any)
+	if _, present := stats["forecast"]; present {
+		t.Errorf("forecast present with no price table: %v", stats["forecast"])
 	}
 }

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -104,6 +104,14 @@ export interface GraphStats {
   /** Nodes holding only DaemonSets and static pods: free to take, and needing
    *  no step because there is nothing to relocate. */
   alreadyReclaimable?: number;
+  /** What executing this plan would stop costing. Absent unless the operator
+   *  supplied prices — a prediction, not the measured ledger. */
+  forecast?: {
+    currency: string;
+    perMonth: number;
+    pricedNodes: number;
+    unpricedNodes: number;
+  };
   /** The utilisation fraction THIS plan refused to pack above; the Wells
    *  lens draws its ceiling line here. Absent on plans that predate it. */
   packCeiling?: number;

--- a/ui/src/components/review/Hero.tsx
+++ b/ui/src/components/review/Hero.tsx
@@ -27,6 +27,10 @@ export default function Hero({ graph, steps, focusedRating, onFocusRating }: Pro
   const byRating = (r: Impact) => steps.filter((s) => s.impact === r);
   // Nodes needing no step because nothing on them can or must move.
   const free = graph.stats.alreadyReclaimable ?? 0;
+  // What running this plan would stop costing. Deliberately on the screen
+  // where someone decides whether to run it: the measured figure lives on
+  // History, which is the honest place for it and four clicks from here.
+  const forecast = graph.stats.forecast;
   const safe = byRating("Green");
   const caution = byRating("Yellow");
   const held = byRating("Red");
@@ -92,6 +96,22 @@ export default function Hero({ graph, steps, focusedRating, onFocusRating }: Pro
             )}
           </div>
         )}
+        {forecast && forecast.pricedNodes > 0 && (
+          // A rate, not a running total, and named as a forecast: the ledger
+          // on History reports what was measured after the fact, and the two
+          // numbers must never be mistaken for each other.
+          <p className="hero-worth">
+            Worth <strong>{fmtMoney(forecast.currency, forecast.perMonth)}/month</strong> if run in
+            full
+            {forecast.unpricedNodes > 0 && (
+              <span className="hero-worth-gap">
+                {" "}
+                · {forecast.unpricedNodes} node{forecast.unpricedNodes === 1 ? "" : "s"} unpriced,
+                so the real figure is higher
+              </span>
+            )}
+          </p>
+        )}
         {safe.length > 0 && (
           <div className="hero-stats">
             <div className="hero-stat">
@@ -154,4 +174,18 @@ export default function Hero({ graph, steps, focusedRating, onFocusRating }: Pro
       </div>
     </div>
   );
+}
+
+/** Money, at the precision a monthly rate deserves and no more. */
+function fmtMoney(currency: string, amount: number): string {
+  try {
+    return new Intl.NumberFormat(undefined, {
+      style: "currency",
+      currency,
+      maximumFractionDigits: amount < 100 ? 2 : 0,
+    }).format(amount);
+  } catch {
+    // An unknown currency code must not blank the figure it is attached to.
+    return `${amount.toFixed(2)} ${currency}`;
+  }
 }

--- a/ui/src/styles/review.css
+++ b/ui/src/styles/review.css
@@ -894,3 +894,22 @@
 .whynothing-unlock {
   color: var(--accent-text);
 }
+
+/*
+ * What the plan is worth, on the screen where someone decides to run it.
+ * Quiet: the hero's job is the decision, and money is the argument for it
+ * rather than the headline.
+ */
+.hero-worth {
+  margin: 6px 0 0;
+  font-size: var(--text-sm);
+  color: var(--text-3);
+}
+
+.hero-worth strong {
+  color: var(--text-1);
+}
+
+.hero-worth-gap {
+  color: var(--text-5);
+}


### PR DESCRIPTION
Closes #196. **Stacked on #214** — both touch the hero.

## The problem

`pricing` appeared in exactly one component: `History.tsx`. That reports what was *measured* — the honest figure, in the right place, and four clicks from where anyone lands.

So Review, where someone decides whether to run a plan, said nothing about what running it is worth.

## What it does

The graph now carries a forecast, priced from **the instance type of each step's target node** — so a plan freeing two spot machines and one on-demand is priced as exactly that, not as three of something averaged.

> Worth **$74/month** if run in full · 2 nodes unpriced, so the real figure is higher

## The doctrine is why this took care rather than a `SUM()`

- **No built-in price table**, ever. Operator-supplied via `uiBackend.pricing`.
- **Unpriced is not free.** An unpriced machine type is counted and reported, because a total that quietly omits half the fleet is worse than no total.
- **A rate, not a running total.** A reclaimed node saves money every hour from now on; a cumulative figure is small and unimpressive on day one.
- **Absent, not zero**, with no prices configured — a zero reads as "this plan saves nothing", which the product has not earned.
- **A forecast, not the ledger.** History reports what happened; this predicts. Both are labelled.

## The guard did its job

The first attempt added `Stats.forecast` without a UI reader, and `TestEveryStatsFieldIsReadByTheUI` failed immediately:

```
Stats.forecast is sent to every client but the UI never reads it; remove it, or wire it up
```

Exactly the rule this repo wrote for itself. Reader landed in the same change.

## Tests

Both directions: priced nodes counted and unpriced *reported* with a real price table; the field absent entirely without one.