### PR TITLE
Let a better explanation reach a plan that already exists

### DIFF
--- a/internal/store/sqlstore/sqlstore.go
+++ b/internal/store/sqlstore/sqlstore.go
@@ -607,6 +607,21 @@ func (s *Store) Save(ctx context.Context, rec store.Record) (bool, error) {
 	} else if n > 0 {
 		// Same content hash as the last write: the cluster has not changed in
 		// any way that alters the plan.
+		// The steps keep their identity and can still change their wording.
+		//
+		// planID hashes the strategy, sequence numbers, target nodes and
+		// moves — the actions — and deliberately not the rationale, impact or
+		// reasons, which describe those actions. So an upgraded planner that
+		// explains the same drain better produces the same id, takes this
+		// branch, and leaves the old explanation in place forever.
+		//
+		// That is not hypothetical: a fix that stopped a rationale repeating
+		// itself shipped, ran, and changed nothing on any existing plan,
+		// because every plan it applied to hashed the same as before. The
+		// same argument the pack_ceiling touch already makes, one level down.
+		if err := s.refreshStepText(ctx, rec); err != nil {
+			return false, err
+		}
 		return false, nil
 	}
 
@@ -685,6 +700,31 @@ func (s *Store) Save(ctx context.Context, rec store.Record) (bool, error) {
 		return false, err
 	}
 	return true, nil
+}
+
+// refreshStepText rewrites what a step says without touching what it is.
+//
+// Matched on (plan_id, sequence_number) rather than deleting and reinserting,
+// because the rows are identical in every column this does not name and the
+// dedup path exists precisely to avoid that write volume. Bounded by the step
+// count, which is tens.
+func (s *Store) refreshStepText(ctx context.Context, rec store.Record) error {
+	for _, step := range rec.Plan.Steps {
+		reasonsJSON, err := json.Marshal(step.Reasons)
+		if err != nil {
+			return fmt.Errorf("encode reasons: %w", err)
+		}
+		if _, err := s.exec(ctx, `
+			UPDATE plan_steps
+			   SET impact = ?, rationale = ?, reasons = ?, requires_maintenance_window = ?
+			 WHERE plan_id = ? AND sequence_number = ?`,
+			string(step.Impact), step.Rationale, reasonsJSON,
+			boolToInt(step.RequiresMaintenanceWindow()),
+			rec.Plan.ID, step.SequenceNumber); err != nil {
+			return fmt.Errorf("refresh step %d: %w", step.SequenceNumber, err)
+		}
+	}
+	return nil
 }
 
 // Latest returns the most recently stored record.

--- a/internal/store/sqlstore/sqlstore_test.go
+++ b/internal/store/sqlstore/sqlstore_test.go
@@ -559,3 +559,53 @@ func TestDedupCarriesTheCeilingForward(t *testing.T) {
 		t.Errorf("stored ceiling = %v, want 0.85 — the dedup touch dropped the policy", got.Plan.PackCeiling)
 	}
 }
+
+// A better explanation of the same drain must reach an existing plan.
+//
+// planID hashes the strategy, sequence numbers, target nodes and moves — the
+// actions — and deliberately not the rationale, impact or reasons, which
+// describe those actions. That is the right identity: the same drains are the
+// same plan however they are worded.
+//
+// But it means an upgraded planner that explains a step better produces the
+// same id, takes the dedup path, and used to leave the old wording in place
+// forever. Observed: a fix that stopped a rationale repeating itself shipped,
+// ran against a live cluster, and changed nothing — every plan it applied to
+// hashed the same as before, so the store kept the stutter.
+func TestDedupRefreshesWhatAStepSays(t *testing.T) {
+	ctx := context.Background()
+	s := openTemp(t)
+
+	before := record("samesteps", step(1, "n1", model.ImpactYellow))
+	before.Plan.Steps[0].Rationale = "Rated Yellow because: X. Also: X."
+	mustSave(t, s, before, true)
+
+	// Same actions, better words — and a changed rating, which is the same
+	// class of thing: a judgement about the step rather than the step itself.
+	after := record("samesteps", step(1, "n1", model.ImpactGreen))
+	after.Plan.Steps[0].Rationale = "Rated Green because: X."
+	after.Plan.Steps[0].Reasons = []model.ImpactReason{
+		{Kind: "BlastRadius", Subject: "n1", Detail: "moves 1 pod"},
+	}
+	if stored, err := s.Save(ctx, after); err != nil || stored {
+		t.Fatalf("identical actions should dedup: stored=%v err=%v", stored, err)
+	}
+
+	got, err := s.Latest(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Plan.Steps) != 1 {
+		t.Fatalf("steps = %d, want 1", len(got.Plan.Steps))
+	}
+	if got.Plan.Steps[0].Rationale != "Rated Green because: X." {
+		t.Errorf("rationale stale after dedup: %q — a wording fix would never reach an "+
+			"existing plan", got.Plan.Steps[0].Rationale)
+	}
+	if got.Plan.Steps[0].Impact != model.ImpactGreen {
+		t.Errorf("impact stale after dedup: %q, want Green", got.Plan.Steps[0].Impact)
+	}
+	if len(got.Plan.Steps[0].Reasons) != 1 {
+		t.Errorf("reasons stale after dedup: %d, want 1", len(got.Plan.Steps[0].Reasons))
+	}
+}


### PR DESCRIPTION
Closes #217.

The rationale-stutter fix shipped in v0.8.1, ran against a live cluster, and changed nothing. Verified on OrbStack with the fixed planner running and the doubled sentence still on screen.

`planID` hashes the strategy, sequence numbers, target nodes and moves — the actions — and deliberately not the rationale, impact or reasons, which describe those actions. That identity is right. The consequence was not: a planner that explains the same drain better produces the same id, takes the dedup path, and the stored steps keep the old wording forever.

Same family as #211. The `plans` row touch already refreshes `pack_ceiling` and the node counts for exactly this reason; this does the same one level down, on `plan_steps`.

Matched on `(plan_id, sequence_number)` rather than deleted and reinserted — every column this does not name is identical, and avoiding that write volume is what the dedup path is for. Bounded by the step count, which is tens.

The test asserts a changed rationale, a changed impact and changed reasons all reach an existing plan, and that the plan still dedups.