### PR TITLE
Lead with the answer, and survive a narrow viewport

### DIFF
--- a/test/palette/narrow_test.go
+++ b/test/palette/narrow_test.go
@@ -1,0 +1,191 @@
+// The narrow-viewport layout, asserted rather than eyeballed once.
+//
+// Both tests here exist because of a defect they would have caught. The
+// first: a media query whose selectors matched nothing at all. Six of the
+// selectors in the first draft of narrow.css were plausible names for
+// elements that are called something else, and CSS reports that by doing
+// nothing — the rule sits in the file looking correct forever. There is no
+// build error, no console warning, and the only symptom is a layout that
+// stays broken at a width nobody re-checks.
+//
+// The second: `margin: var(--space-5) 0` in views.css, referring to a token
+// that was never defined. An undefined custom property makes the whole
+// declaration invalid at computed-value time, so the margin silently became
+// zero. It had been in the file, doing nothing, since the redesign.
+package palette_test
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func uiFiles(t *testing.T, dir string, exts ...string) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	root := filepath.Join("..", "..", "ui", "src")
+	err := filepath.Walk(filepath.Join(root, dir), func(p string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return err
+		}
+		for _, e := range exts {
+			if strings.HasSuffix(p, e) {
+				b, err := os.ReadFile(p)
+				if err != nil {
+					return err
+				}
+				rel, _ := filepath.Rel(root, p)
+				out[rel] = string(b)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", dir, err)
+	}
+	return out
+}
+
+// Every class narrow.css targets must be a class something actually renders.
+//
+// A rule that matches nothing is indistinguishable from a rule that works
+// until someone opens the page at that width, which for a breakpoint is
+// approximately never.
+func TestNarrowLayoutTargetsRealClasses(t *testing.T) {
+	narrowPath := filepath.Join("..", "..", "ui", "src", "styles", "narrow.css")
+	narrow, err := os.ReadFile(narrowPath)
+	if err != nil {
+		t.Fatalf("read narrow.css: %v", err)
+	}
+
+	// Everything else the UI ships: the other stylesheets define classes, the
+	// components render them. A class needs to appear in one or the other.
+	var known strings.Builder
+	for name, body := range uiFiles(t, ".", ".css", ".tsx", ".ts") {
+		if strings.HasSuffix(name, "narrow.css") {
+			continue
+		}
+		known.WriteString(body)
+	}
+	haystack := known.String()
+
+	classRE := regexp.MustCompile(`\.([a-zA-Z][\w-]*)`)
+	seen := map[string]bool{}
+	for _, m := range classRE.FindAllStringSubmatch(string(narrow), -1) {
+		cls := m[1]
+		if seen[cls] {
+			continue
+		}
+		seen[cls] = true
+
+		// Defined as a selector in another stylesheet...
+		defined := regexp.MustCompile(`\.` + regexp.QuoteMeta(cls) + `(?:[^\w-]|$)`).MatchString(haystack)
+		// ...or rendered as a class name by a component.
+		rendered := regexp.MustCompile(`["'\s]` + regexp.QuoteMeta(cls) + `["'\s]`).MatchString(haystack)
+		if !defined && !rendered {
+			t.Errorf("narrow.css targets .%s, which nothing defines or renders — "+
+				"the rule matches no element and the breakpoint silently does nothing", cls)
+		}
+	}
+}
+
+// Every custom property the stylesheets USE must be one theme.css DEFINES.
+//
+// CSS treats a reference to an undefined property as invalid at
+// computed-value time: the entire declaration is dropped, not just the one
+// value. So a typo does not degrade a colour or a gap, it deletes the rule,
+// and it does so without a single diagnostic anywhere in the build.
+func TestEveryTokenUsedIsDefined(t *testing.T) {
+	root := filepath.Join("..", "..", "ui", "src")
+	themeCSS, err := os.ReadFile(filepath.Join(root, "theme.css"))
+	if err != nil {
+		t.Fatalf("read theme.css: %v", err)
+	}
+
+	defRE := regexp.MustCompile(`(?m)^\s*(--[\w-]+)\s*:`)
+	defined := map[string]bool{}
+	for _, m := range defRE.FindAllStringSubmatch(string(themeCSS), -1) {
+		defined[m[1]] = true
+	}
+	// A handful of tokens are set on the element by the components rather
+	// than declared in theme.css; they are still definitions.
+	for name, body := range uiFiles(t, ".", ".tsx", ".ts", ".css") {
+		if strings.HasSuffix(name, "theme.css") {
+			continue
+		}
+		for _, m := range defRE.FindAllStringSubmatch(body, -1) {
+			defined[m[1]] = true
+		}
+		// Inline style objects: style={{ "--foo": ... }}
+		for _, m := range regexp.MustCompile(`["'](--[\w-]+)["']\s*:`).FindAllStringSubmatch(body, -1) {
+			defined[m[1]] = true
+		}
+	}
+
+	useRE := regexp.MustCompile(`var\(\s*(--[\w-]+)`)
+	for name, body := range uiFiles(t, ".", ".css") {
+		for _, m := range useRE.FindAllStringSubmatch(body, -1) {
+			tok := m[1]
+			if defined[tok] {
+				continue
+			}
+			// A fallback makes the reference survivable — var(--x, 8px) is a
+			// deliberate default, not a typo.
+			if regexp.MustCompile(`var\(\s*` + regexp.QuoteMeta(tok) + `\s*,`).MatchString(body) {
+				continue
+			}
+			t.Errorf("%s uses %s, which nothing defines — the whole declaration "+
+				"is dropped at computed-value time, silently", name, tok)
+		}
+	}
+}
+
+// The breakpoints are a design decision, so changing them should be one too.
+//
+// Fixed here because the issue that prompted the work named a width: the
+// maintainer read the UI on a phone and found a 224px rail crushed against a
+// horizontally scrolling table. If someone widens the first tier past 1200
+// the panes stop stacking on a laptop, which is the case that was reported.
+func TestNarrowBreakpointsAreTheOnesWeChose(t *testing.T) {
+	narrow, err := os.ReadFile(filepath.Join("..", "..", "ui", "src", "styles", "narrow.css"))
+	if err != nil {
+		t.Fatalf("read narrow.css: %v", err)
+	}
+	for _, want := range []string{
+		"@media (max-width: 1200px)", // panes stack
+		"@media (max-width: 1000px)", // rail becomes icons
+		"@media (max-width: 720px)",  // rail becomes a strip; execute hidden
+	} {
+		if !strings.Contains(string(narrow), want) {
+			t.Errorf("missing breakpoint %q", want)
+		}
+	}
+}
+
+// Below the smallest tier the UI must not offer to evict anything.
+//
+// The read path is the requirement — someone paged, checking whether the
+// cluster is fine. Draining a node is not something to confirm with a thumb,
+// and a control that is merely hard to hit is still a control that was hit.
+func TestTheSmallestTierHidesEveryExecuteControl(t *testing.T) {
+	narrow, err := os.ReadFile(filepath.Join("..", "..", "ui", "src", "styles", "narrow.css"))
+	if err != nil {
+		t.Fatalf("read narrow.css: %v", err)
+	}
+	_, tier, ok := strings.Cut(string(narrow), "@media (max-width: 720px)")
+	if !ok {
+		t.Fatal("no 720px tier")
+	}
+	for _, cls := range []string{
+		".reviewfooter-actions", // Rehearse and Drain
+		".steprow-box",          // the per-step checkbox
+		".stepdetail-actions",   // add / skip in the detail pane
+	} {
+		if !strings.Contains(tier, cls) {
+			t.Errorf("%s is still reachable below 720px — the read path is the "+
+				"requirement, and everything that evicts a pod should be gone", cls)
+		}
+	}
+}

--- a/ui/e2e-demo/narrow.mjs
+++ b/ui/e2e-demo/narrow.mjs
@@ -1,0 +1,137 @@
+/**
+ * Does the read path survive a narrow viewport?
+ *
+ * The complaint that produced this was concrete: the maintainer read the UI
+ * from a phone and got a 224px rail crushed against a horizontally scrolling
+ * table. So the assertions are the concrete failures, not "looks responsive".
+ *
+ * At each width, on every destination:
+ *   - the page body must not scroll sideways (a horizontal page scrollbar
+ *     hides the rail and the footer, which is what turned reading into
+ *     hunting)
+ *   - the destination must render something — a breakpoint that collapses a
+ *     pane to zero height passes a screenshot review and fails a reader
+ *   - nothing that evicts a pod may be visible at phone width
+ *
+ *   DENCER_URL=http://localhost:5173 DENCER_TOKEN=... SHOT_DIR=/tmp/narrow \
+ *     node ui/e2e-demo/narrow.mjs
+ */
+import { chromium } from "playwright";
+import { mkdirSync } from "node:fs";
+
+const URL = process.env.DENCER_URL || "http://localhost:5173";
+const TOKEN = process.env.DENCER_TOKEN || "";
+const OUT = process.env.SHOT_DIR || "narrow";
+const pause = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// The three tiers plus the width the design was drawn at, so a regression in
+// the wide case shows up in the same run.
+const WIDTHS = [
+  { w: 1440, h: 900, name: "wide" },
+  { w: 1100, h: 860, name: "stacked" }, // ≤1200: panes stack
+  { w: 900, h: 800, name: "icons" }, //    ≤1000: rail is icons
+  { w: 390, h: 844, name: "phone" }, //    ≤720:  rail is a strip, read-only
+];
+
+const DESTINATIONS = ["Review", "Cluster", "Recommendations", "Resilience", "Rightsizing", "History"];
+
+mkdirSync(OUT, { recursive: true });
+const problems = [];
+const note = (where, what) => problems.push(`${where}: ${what}`);
+
+const browser = await chromium.launch();
+
+for (const { w, h, name } of WIDTHS) {
+  const ctx = await browser.newContext({ viewport: { width: w, height: h }, deviceScaleFactor: 2 });
+  const page = await ctx.newPage();
+  await page.goto(URL, { waitUntil: "domcontentloaded" });
+  await pause(1200);
+
+  const box = page.locator("#token");
+  if (await box.isVisible().catch(() => false)) {
+    await box.fill(TOKEN);
+    await page.getByRole("button", { name: /sign in with token/i }).click();
+  }
+  await page.waitForSelector(".rail-item", { timeout: 30000 }).catch(() => note(name, "rail never rendered"));
+  await pause(3000);
+
+  for (const dest of DESTINATIONS) {
+    // At phone width the rail is a scrolling strip, so the destination may be
+    // out of view — click it by force rather than reporting a false miss.
+    const item = page.locator(`.rail-item:has-text("${dest}")`);
+    if (!(await item.count())) {
+      note(`${name}/${dest}`, "destination missing from the rail");
+      continue;
+    }
+    await item.first().scrollIntoViewIfNeeded().catch(() => {});
+    await item.first().click({ force: true }).catch(() => {});
+    await pause(2000);
+
+    // The page body must never scroll sideways.
+    const over = await page.evaluate(() => {
+      const d = document.documentElement;
+      return { scroll: d.scrollWidth, client: d.clientWidth };
+    });
+    if (over.scroll > over.client + 1) {
+      note(`${name}/${dest}`, `body scrolls sideways: ${over.scroll}px in ${over.client}px`);
+    }
+
+    // Something has to be on screen. A stacked pane that collapsed to nothing
+    // renders as a blank column and reads as a broken product.
+    const text = await page.locator(".frame-content").innerText().catch(() => "");
+    if (text.trim().length < 20) {
+      note(`${name}/${dest}`, "rendered essentially nothing");
+    }
+
+    // A pane can also survive with height zero while its SIBLING renders
+    // fine, which is what the first stacked layout did: the step list lost
+    // its space to the detail pane and the screen showed a toolbar sitting
+    // directly on a step detail for a step no list was offering. Every
+    // element on screen was present and the page was unusable, so presence
+    // is not the test — visible height is.
+    for (const [pane, label] of [
+      [".steplist", "step list"],
+      [".recsqueue", "findings queue"],
+    ]) {
+      const el = page.locator(pane).first();
+      if (!(await el.count())) continue;
+      const h = await el.evaluate((n) => n.getBoundingClientRect().height).catch(() => 0);
+      if (h < 80) note(`${name}/${dest}`, `${label} collapsed to ${Math.round(h)}px`);
+    }
+
+    if (dest === "Review") {
+      const railSteps = Number(
+        (await page.locator('.rail-item:has-text("Review") .rail-badge').innerText().catch(() => "0")) || 0,
+      );
+      const rows = await page.locator(".steprow").count().catch(() => 0);
+      if (railSteps > 0 && rows === 0) {
+        note(`${name}/Review`, `rail says ${railSteps} steps, the list renders none`);
+      }
+    }
+
+    await page.screenshot({ path: `${OUT}/${name}-${dest.toLowerCase()}.png` });
+  }
+
+  // Phone width is a reading surface. Nothing here may evict a pod.
+  if (w <= 720) {
+    await page.locator('.rail-item:has-text("Review")').first().click({ force: true }).catch(() => {});
+    await pause(1500);
+    for (const sel of [".reviewfooter-actions", ".steprow-box", ".stepdetail-actions"]) {
+      if (await page.locator(sel).first().isVisible().catch(() => false)) {
+        note(`${name}/Review`, `${sel} is visible — execute controls should be gone at this width`);
+      }
+    }
+  }
+
+  await ctx.close();
+}
+
+await browser.close();
+
+if (problems.length === 0) {
+  console.log(`NARROW CLEAN — shots in ${OUT}`);
+} else {
+  console.log(`NARROW FOUND ${problems.length} PROBLEM(S):`);
+  for (const p of problems) console.log("  - " + p);
+  process.exitCode = 1;
+}

--- a/ui/src/components/Rail.tsx
+++ b/ui/src/components/Rail.tsx
@@ -142,7 +142,9 @@ export default function Rail({
                   onClick={() => onSurface(s)}
                 >
                   {ICONS[s]}
-                  {LABELS[s]}
+                  {/* The label is a span so a narrow viewport can drop it and
+                      leave an icon rail — see styles/narrow.css. */}
+                  <span className="rail-label">{LABELS[s]}</span>
                   {s === "review" && stepCount != null && stepCount > 0 && (
                     <span className="rail-badge mono">{stepCount}</span>
                   )}

--- a/ui/src/components/Rail.tsx
+++ b/ui/src/components/Rail.tsx
@@ -1,9 +1,9 @@
 /**
  * The left rail — the redesign's spine (assets/design/README.md, screen 1a).
  *
- * 224px: lockup, the four destinations, and at the bottom the two facts the
- * old UI once forgot to show anywhere — which cluster this is, and who you
- * are. For a tool whose pitch is that a human approves before pods are
+ * 224px: lockup, the destinations in two groups — where you act and where
+ * you look — and at the bottom the two facts the old UI once forgot to show
+ * anywhere: which cluster this is, and who you are. For a tool whose pitch is that a human approves before pods are
  * evicted, both belong on every screen, which is why they live in the frame
  * and not on a settings page.
  *
@@ -11,6 +11,8 @@
  * Recommendations counts high-severity findings. A destination with nothing
  * to do shows no number.
  */
+
+import { Fragment } from "react";
 
 import { Surface } from "../view";
 
@@ -79,12 +81,16 @@ const ICONS: Record<Surface, React.ReactNode> = {
 
 const LABELS: Record<Surface, string> = {
   review: "Review",
-  cluster: "Cluster",
   recommendations: "Recommendations",
+  cluster: "Cluster",
   resilience: "Resilience",
   rightsizing: "Rightsizing",
   history: "History",
 };
+
+// Where an operator acts, as opposed to where they look. The rail renders
+// these as two groups; everything not listed here falls into "Understand".
+const DECIDE: Surface[] = ["review", "recommendations"];
 
 export default function Rail({
   surface,
@@ -116,24 +122,36 @@ export default function Rail({
       </div>
 
       <div className="rail-nav">
-        <div className="rail-group eyebrow mono">Plan</div>
-        {(Object.keys(LABELS) as Surface[]).map((s) => (
-          <button
-            key={s}
-            type="button"
-            className={"rail-item" + (s === surface ? " is-on" : "")}
-            aria-current={s === surface ? "page" : undefined}
-            onClick={() => onSurface(s)}
-          >
-            {ICONS[s]}
-            {LABELS[s]}
-            {s === "review" && stepCount != null && stepCount > 0 && (
-              <span className="rail-badge mono">{stepCount}</span>
-            )}
-            {s === "recommendations" && highFindings != null && highFindings > 0 && (
-              <span className="rail-badge rail-badge-pill mono">{highFindings}</span>
-            )}
-          </button>
+        {/*
+          Two groups, because the destinations are not peers. Review and
+          Recommendations are where an operator acts; the rest are where they
+          look. Six presented as a flat list made the rail a menu rather than
+          a hierarchy — and the group header already existed, used once.
+        */}
+        {(["Decide", "Understand"] as const).map((group) => (
+          <Fragment key={group}>
+            <div className="rail-group eyebrow mono">{group}</div>
+            {(Object.keys(LABELS) as Surface[])
+              .filter((s) => (group === "Decide") === DECIDE.includes(s))
+              .map((s) => (
+                <button
+                  key={s}
+                  type="button"
+                  className={"rail-item" + (s === surface ? " is-on" : "")}
+                  aria-current={s === surface ? "page" : undefined}
+                  onClick={() => onSurface(s)}
+                >
+                  {ICONS[s]}
+                  {LABELS[s]}
+                  {s === "review" && stepCount != null && stepCount > 0 && (
+                    <span className="rail-badge mono">{stepCount}</span>
+                  )}
+                  {s === "recommendations" && highFindings != null && highFindings > 0 && (
+                    <span className="rail-badge rail-badge-pill mono">{highFindings}</span>
+                  )}
+                </button>
+              ))}
+          </Fragment>
         ))}
       </div>
 

--- a/ui/src/components/cluster/ClusterPage.tsx
+++ b/ui/src/components/cluster/ClusterPage.tsx
@@ -11,7 +11,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { GraphPayload, Impact, NodeStability, PlanStep, WhatIf, api, formatCPU } from "../../api";
-import { FieldView, VIEW_LABELS } from "../../view";
+import { FieldView, VIEW_HINTS, VIEW_LABELS } from "../../view";
 import { VERDICT } from "../Impact";
 import type { ObservedNode } from "../../useObserved";
 
@@ -151,6 +151,7 @@ export default function ClusterPage({
               className={"viewswitch-btn" + (v === lens ? " is-on" : "")}
               aria-pressed={v === lens}
               onClick={() => onLens(v)}
+              title={VIEW_HINTS[v]}
             >
               {VIEW_LABELS[v]}
             </button>

--- a/ui/src/components/review/Hero.tsx
+++ b/ui/src/components/review/Hero.tsx
@@ -54,7 +54,9 @@ export default function Hero({ graph, steps, focusedRating, onFocusRating }: Pro
   return (
     <div className="hero">
       <div className="hero-lead">
-        <span className="eyebrow mono">If you approve everything safe</span>
+        <span className="eyebrow mono">
+          {safe.length > 0 ? "If you approve everything safe" : free > 0 ? "Free capacity" : "This cluster"}
+        </span>
         {safe.length > 0 ? (
           <div className="hero-line">
             <h2 className="hero-headline">
@@ -76,7 +78,13 @@ export default function Hero({ graph, steps, focusedRating, onFocusRating }: Pro
             <h2 className="hero-headline">
               {free > 0
                 ? `${free} node${free === 1 ? "" : "s"} ${free === 1 ? "is" : "are"} already free to take`
-                : "Nothing is safely reclaimable right now"}
+                : steps.length > 0
+                  ? "Nothing is safely reclaimable right now"
+                  : // The state a well-run cluster spends most of its life in.
+                    // It used to read as an absence — "nothing is safely
+                    // reclaimable" — which describes a failure and a success
+                    // with the same sentence. This is the success.
+                    "This cluster is packed as tightly as its rules allow"}
             </h2>
             {free > 0 && (
               // No step, because there is nothing to relocate — but saying
@@ -86,6 +94,12 @@ export default function Hero({ graph, steps, focusedRating, onFocusRating }: Pro
                 {free === 1 ? "It holds" : "They hold"} only DaemonSets and static pods.{" "}
                 <span className="hero-sub-strong">Draining {free === 1 ? "it" : "them"} moves nothing</span>
                 {" "}— most autoscalers remove {free === 1 ? "it" : "them"} unprompted.
+              </span>
+            )}
+            {steps.length === 0 && free === 0 && (
+              <span className="hero-sub">
+                Every node is either needed or held by a rule. Nothing to
+                approve — which is the point.
               </span>
             )}
             {steps.length > 0 && (

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -19,3 +19,6 @@
 @import "./styles/resilience.css";
 @import "./styles/rightsizing.css";
 @import "./styles/history.css";
+/* Last, deliberately: every width-based media query lives in one file and
+   overrides the ones above it on equal specificity. */
+@import "./styles/narrow.css";

--- a/ui/src/styles/cluster.css
+++ b/ui/src/styles/cluster.css
@@ -58,6 +58,7 @@
   font-size: var(--text-display);
   font-weight: 600;
   letter-spacing: var(--tracking-display);
+  line-height: 1.15;
 }
 
 .clusterpage-hint {

--- a/ui/src/styles/history.css
+++ b/ui/src/styles/history.css
@@ -73,6 +73,7 @@
   font-size: var(--text-display);
   font-weight: 600;
   letter-spacing: var(--tracking-display);
+  line-height: 1.15;
 }
 
 .estate-spare-word {

--- a/ui/src/styles/narrow.css
+++ b/ui/src/styles/narrow.css
@@ -1,0 +1,266 @@
+/*
+ * The read path at narrow widths.
+ *
+ * Every width-based media query in the product lives here rather than at the
+ * foot of the file it overrides. That is deliberate: the narrow layout is one
+ * design decision taken three times, and scattering it across ten stylesheets
+ * makes it impossible to answer "what does this look like on a phone?" by
+ * reading. Imported last, so it wins on equal specificity without !important.
+ *
+ * The requirement is READING, not operating. Nobody drains a node from a
+ * phone and nobody should: someone gets paged, looks at their phone, and
+ * needs to know whether the cluster is fine. So the plan, the verdicts, the
+ * findings and the ledger have to survive; the drain button does not, and
+ * below the smallest tier it goes away rather than inviting a fat-fingered
+ * eviction on a train.
+ *
+ * Three tiers, each doing exactly one thing:
+ *
+ *   ≤1200  the side-by-side panes stack. A 392px detail pane against a 1fr
+ *          list stops working here, not at some phone width — the list is
+ *          the first casualty and it is the part you came to read.
+ *   ≤1000  the rail loses its labels and becomes icons.
+ *   ≤720   the rail becomes a strip above the content, and everything that
+ *          evicts a pod disappears.
+ */
+
+/* ======================================================== ≤1200: unstack */
+
+@media (max-width: 1200px) {
+  /* List above, detail below — and ONE scroll for the pair.
+     
+     The first attempt kept both panes as bounded scrollers stacked on top of
+     each other, and it collapsed the step list to nothing at 1100px: the
+     detail pane asked for 46vh, the hero had already taken most of the
+     column, and the list is the flexible one so it lost. It rendered as a
+     toolbar sitting directly on top of a step detail for a step you could no
+     longer see in a list. Nested scrollers are also the wrong feel on touch,
+     where a drag lands in whichever pane it happens to start over.
+     
+     So the workspace scrolls, and every pane inside it renders at its
+     natural height. */
+  .review-main,
+  .recspage-body,
+  .clusterpage-body {
+    flex-direction: column;
+    overflow-y: auto;
+  }
+
+  .steplist,
+  .recsqueue,
+  .rackgrid,
+  .wellsgrid,
+  .loadtable,
+  .stepdetail,
+  .recsdetail,
+  .clusterdetail,
+  .clusterdetail-wells,
+  .steplist-scrollwrap,
+  .steplist-scroll,
+  .recsqueue-list {
+    flex: 0 0 auto;
+    width: auto;
+    min-height: 0;
+    max-height: none;
+    overflow: visible;
+    border-right: 0;
+  }
+
+  .stepdetail,
+  .recsdetail,
+  .clusterdetail,
+  .clusterdetail-wells {
+    border-top: 1px solid var(--border);
+  }
+
+  /* The fade advertises more content below the fold of a scroller that no
+     longer exists. */
+  .steplist-fade {
+    display: none;
+  }
+
+  /* The triage bar was a fixed 300px column beside the headline; below the
+     headline it can have the full width instead of squeezing it. */
+  .hero {
+    flex-wrap: wrap;
+    gap: var(--space-5);
+  }
+
+  .hero-triage {
+    width: 100%;
+    flex-shrink: 1;
+  }
+
+  /* Wide grids scroll inside themselves — last, so it wins over the
+     `overflow: visible` above. The page body must never scroll sideways: a
+     horizontal page scrollbar hides the rail and the footer, which is how
+     reading on a phone turned into hunting on a phone. */
+  .rightsizing-tablewrap,
+  .ledger,
+  .loadtable {
+    overflow-x: auto;
+  }
+}
+
+/* ==================================================== ≤1000: icons only */
+
+@media (max-width: 1000px) {
+  .rail {
+    width: 58px;
+  }
+
+  /* Labels and group headers go; the icon and the badge stay, because the
+     badge is the one thing on the rail carrying live information. */
+  .rail-label,
+  .rail-group,
+  .rail-wordmark,
+  .rail-cluster,
+  .rail-identity-name {
+    display: none;
+  }
+
+  /* Positioned, because the badge no longer has a label to sit after. */
+  .rail-item {
+    position: relative;
+    justify-content: center;
+    padding: 10px 0;
+  }
+
+  /* 11px is the type floor and it holds here too — the badge shrinks by
+     losing its padding, not by going below the floor. */
+  .rail-badge {
+    position: absolute;
+    top: 2px;
+    right: 4px;
+    margin-left: 0;
+    padding: 0 3px;
+  }
+
+  .rail-lockup,
+  .rail-nav,
+  .rail-foot {
+    padding-left: 0;
+    padding-right: 0;
+    justify-content: center;
+  }
+
+  .rail-identity {
+    justify-content: center;
+  }
+
+  /* The strategy and the plan hash are the first things the top bar can
+     afford to lose — the freshness dot is not. */
+  .topbar-strategy,
+  .topbar-sep {
+    display: none;
+  }
+}
+
+/* ============================================ ≤720: a strip, and read-only */
+
+@media (max-width: 720px) {
+  .frame {
+    flex-direction: column;
+  }
+
+  /* A horizontal strip that scrolls if six destinations do not fit, rather
+     than six icons squeezed to nothing. */
+  .rail {
+    width: auto;
+    flex-direction: row;
+    align-items: center;
+    border-right: 0;
+    border-bottom: 1px solid var(--border);
+    overflow-x: auto;
+  }
+
+  .rail-lockup {
+    border-bottom: 0;
+    border-right: 1px solid var(--border);
+    padding: 0 12px;
+    height: auto;
+    align-self: stretch;
+  }
+
+  .rail-nav {
+    flex-direction: row;
+    padding: 6px;
+    gap: 4px;
+  }
+
+  /* Identity and sign-out belong on every screen — the pitch is that a human
+     approves — but the cluster row and the run note do not fit a strip. */
+  .rail-foot {
+    margin-top: 0;
+    margin-left: auto;
+    flex-direction: row;
+    align-items: center;
+    border-top: 0;
+    border-left: 1px solid var(--border);
+    padding: 0 10px;
+  }
+
+  .rail-run {
+    display: none;
+  }
+
+  /* Back into the flow. The absolute badge that works on a vertical rail
+     lands on top of the NEXT destination once the items sit in a row. */
+  .rail-badge {
+    position: static;
+    margin-left: 5px;
+    padding: 0 5px;
+  }
+
+  .rail-item {
+    padding: 8px 9px;
+  }
+
+  /* Everything that evicts a pod. The read path is the requirement, and a
+     drain confirmed by a thumb on a train is not a decision anyone wanted to
+     make. Rehearse goes too: it starts a real run, writes real events, and
+     the result needs a screen to read on. */
+  .reviewfooter-actions,
+  .steplist-selected,
+  .steprow-box,
+  .stepdetail-actions {
+    display: none;
+  }
+
+  /* What is left of the footer is the summary, which is worth reading. */
+  .reviewfooter {
+    height: auto;
+    padding: 12px var(--space-5);
+  }
+
+  .topbar {
+    height: auto;
+    flex-wrap: wrap;
+    gap: var(--space-3);
+    padding: 10px var(--space-5);
+  }
+
+  .hero {
+    padding: 18px var(--space-5) 16px;
+  }
+
+  .hero-headline {
+    font-size: var(--text-lg);
+  }
+
+  /* The step row's fixed columns do not survive 360px. Name, verdict and the
+     node it drains are the row; the rest is detail, and the detail pane
+     underneath already has it. */
+  .steprow {
+    grid-template-columns: 30px 1fr auto;
+    gap: 8px;
+    padding: 11px var(--space-5);
+  }
+
+  .steprow-pool,
+  .steprow-pods,
+  .steprow-why,
+  .steprow-chevron {
+    display: none;
+  }
+}

--- a/ui/src/styles/recs.css
+++ b/ui/src/styles/recs.css
@@ -59,6 +59,7 @@
   font-size: var(--text-display);
   font-weight: 600;
   letter-spacing: var(--tracking-display);
+  line-height: 1.15;
 }
 
 .recspage-sub {

--- a/ui/src/styles/resilience.css
+++ b/ui/src/styles/resilience.css
@@ -26,6 +26,7 @@
   font-weight: 600;
   letter-spacing: var(--tracking-display);
   text-wrap: balance;
+  line-height: 1.15;
 }
 
 .resilience-sub {

--- a/ui/src/styles/rightsizing.css
+++ b/ui/src/styles/rightsizing.css
@@ -47,6 +47,7 @@
   font-weight: 600;
   letter-spacing: var(--tracking-display);
   text-wrap: balance;
+  line-height: 1.15;
 }
 
 .rightsizing-stats {

--- a/ui/src/styles/views.css
+++ b/ui/src/styles/views.css
@@ -90,7 +90,7 @@
 
 .sheet-seg .sheet-seg-on {
   background: var(--raised);
-  color: var(--text-primary);
+  color: var(--text-1);
 }
 
 .sheet-bound-unit {

--- a/ui/src/theme.css
+++ b/ui/src/theme.css
@@ -109,6 +109,7 @@
   --space-2: 0.5rem; /* 8 */
   --space-3: 0.75rem; /* 12 */
   --space-4: 1rem; /* 16 */
+  --space-5: 1.25rem; /* 20 */
   --space-6: 1.5rem; /* 24 */
   --space-8: 2rem; /* 32 */
 

--- a/ui/src/view.ts
+++ b/ui/src/view.ts
@@ -80,3 +80,17 @@ export const VIEW_LABELS: Record<FieldView, string> = {
   wells: "Wells",
   load: "Load",
 };
+
+/**
+ * What each lens is FOR, one clause each.
+ *
+ * The labels alone — Rack, Wells, Load — say what a thing is drawn as, not
+ * what question it answers, so someone who does not already know the three
+ * has no reason to try the other two. These ride as tooltips, which is the
+ * cheapest way to make a control explain itself.
+ */
+export const VIEW_HINTS: Record<FieldView, string> = {
+  rack: "Pods in place, one block per pod, width by CPU request — where the work actually is",
+  wells: "A vessel per node with its fill and the packing ceiling — how much room is left",
+  load: "Requested against measured usage per node — how much of what is reserved is used",
+};


### PR DESCRIPTION
Closes #200. Closes #198.

Two UI issues from the screen-by-screen review, together because the second kept finding defects in the first.

## Lead with the answer (#200)

Four findings, one theme: the UI presented its material accurately and made the reader assemble the conclusion.

The **empty state** is the one that mattered. A well-run cluster spends most of its life with nothing to consolidate, and the screen said *"Nothing is safely reclaimable right now"* — which describes a failure and a success with the same sentence. It now says the cluster is packed as tightly as its rules allow, and that having nothing to approve is the point.

The **rail** was six destinations presented as peers, which made it a menu rather than a hierarchy. Review and Recommendations are where you act; the rest are where you look. The group header already existed and was used once.

The **lenses** named what they draw — Rack, Wells, Load — not what they answer, so nobody who did not already know all three had a reason to try the other two. A clause each, as tooltips.

## Survive a narrow viewport (#198)

Three tiers, in one file rather than scattered across ten, because the narrow layout is one decision taken three times and nobody can answer "what does this look like on a phone" by reading ten stylesheets.

| | |
|---|---|
| ≤1200 | panes stack; the workspace takes over scrolling so every pane renders at its natural height |
| ≤1000 | the rail drops its labels and becomes icons |
| ≤720 | the rail becomes a strip above the content, and everything that evicts a pod disappears |

Not a phone-first redesign — nobody drains a node from a phone. The requirement is reading: someone gets paged, looks at their phone, needs to know whether the cluster is fine.

### Three defects found by building it and looking, none of which a gate would have caught

- **Six selectors in the first draft named elements that are called something else.** CSS reports that by doing nothing, forever — no build error, no warning, and the only symptom is a layout that stays broken at a width nobody re-checks.
- **The first stacked layout collapsed the step list to zero at 1100px.** The detail pane asked for 46vh, the hero had taken the column, and the list is the flexible one. It rendered as a toolbar sitting directly on a step detail for a step no list was offering — every element present, the page unusable.
- **Display headlines never set a line-height,** so 26px type inherited 1.55 body leading. Invisible on one line; a full line's gap once a narrow viewport wraps it. Fixed at the source, not per-breakpoint.

### And two dead declarations the new token test found

`views.css` used `--space-5` and `--text-primary`, neither of which exists. An undefined custom property invalidates the *whole declaration* at computed-value time — so a segmented control's selected colour and a panel's vertical margin had both silently been nothing since the redesign.

### Guards, so this is asserted rather than eyeballed once

- every class `narrow.css` targets must be one something defines or renders
- every token any stylesheet uses must be one `theme.css` defines
- the smallest tier must hide every execute control
- `ui/e2e-demo/narrow.mjs` drives four widths across six destinations against a live backend and fails on sideways body scroll, a collapsed pane, or a reachable drain button

Verified against the OrbStack cluster at all four widths in both directions; screenshots reviewed by eye, which is how two of the three defects above were found after the automated check reported clean.