### PR TITLE
Export a plan as a change record

### DIFF
--- a/test/ui/client_test.go
+++ b/test/ui/client_test.go
@@ -310,3 +310,61 @@ func TestPollingHooksReReadWhenTheTokenArrives(t *testing.T) {
 		}
 	}
 }
+
+// A read-only reviewer must still be able to export the change record.
+//
+// The overflow menu used to be hidden wholesale alongside the drain
+// controls, on the reasonable-looking grounds that everything in it acted on
+// the cluster. Adding the change record to it made that wrong: the person
+// who signs in read-only to review a plan is exactly the person who needs
+// the approval to exist in a ticket, and hiding it would have shipped a
+// feature that is invisible to its main audience.
+func TestTheChangeRecordSurvivesAReadOnlySession(t *testing.T) {
+	src := read(t, "components/review/ReviewFooter.tsx")
+
+	// The menu item exists.
+	if !strings.Contains(src, "Copy as change record") {
+		t.Fatal("no change-record action in the footer")
+	}
+
+	// The overflow container is not itself gated on !readOnly. Anything of
+	// the form `{!readOnly && (` immediately before the overflow div would
+	// take the record down with the drain controls.
+	overflow := strings.Index(src, `className="reviewfooter-overflow"`)
+	if overflow < 0 {
+		t.Fatal("no overflow container")
+	}
+	// Look back over the JSX immediately preceding the container.
+	window := src[max(0, overflow-400):overflow]
+	if strings.Contains(window, "{!readOnly && (") {
+		t.Error("the overflow menu is gated on !readOnly, which hides the change " +
+			"record from the read-only reviewer it exists for")
+	}
+
+	// Run to optimum, which evicts pods, must still be gated. Anchored on the
+	// button's own label -- with its ellipsis -- because the file's doc
+	// comment names the action too, and matching that instead made this test
+	// report a gate that was three hundred characters further down.
+	converge := strings.Index(src, "Run to optimum\u2026")
+	if converge < 0 {
+		t.Fatal("no converge action")
+	}
+	if !strings.Contains(src[max(0, converge-600):converge], "!readOnly") {
+		t.Error("Run to optimum is reachable in a read-only session")
+	}
+}
+
+// The record must speak the product's vocabulary, not its own.
+//
+// The UI renders verdicts as Safe now / Needs a call / Held back, and the
+// underlying values are Green / Yellow / Red. A record that pasted the raw
+// values into a ticket would describe the same step differently from the
+// screen it was exported from, which is how a reviewer and an operator end
+// up arguing about two things they both call "the yellow one".
+func TestTheChangeRecordUsesTheProductsWordsForAVerdict(t *testing.T) {
+	src := read(t, "components/review/ReviewFooter.tsx")
+	if !strings.Contains(src, "VERDICT_LABEL[s.impact]") {
+		t.Error("the change record does not render verdicts through VERDICT_LABEL; " +
+			"a raw Green/Yellow/Red in a ticket contradicts the screen it came from")
+	}
+}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -357,6 +357,7 @@ export default function App() {
               <ReviewFooter
                 planId={state.plan.plan.id}
                 picked={pickedSteps}
+                clusterLabel={server?.clusterLabel}
                 readOnly={readOnly}
                 stale={state.superseded}
                 busy={busy}

--- a/ui/src/components/review/ReviewFooter.tsx
+++ b/ui/src/components/review/ReviewFooter.tsx
@@ -14,10 +14,13 @@
 
 import { useMemo, useRef, useState } from "react";
 import { PlanStep } from "../../api";
+import { VERDICT_LABEL } from "../Impact";
 
 interface Props {
   planId: string;
   picked: PlanStep[];
+  /** Operator-set; names the cluster in an exported change record. */
+  clusterLabel?: string;
   /** A read-only session hides the drain affordances; RBAC enforces anyway. */
   readOnly?: boolean;
   stale: boolean;
@@ -33,6 +36,7 @@ interface Props {
 export default function ReviewFooter({
   planId,
   picked,
+  clusterLabel,
   readOnly,
   stale,
   busy,
@@ -44,10 +48,15 @@ export default function ReviewFooter({
   const [confirming, setConfirming] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [recorded, setRecorded] = useState(false);
 
   const pods = picked.reduce((n, s) => n + s.moves.length, 0);
   const nonGreen = picked.filter((s) => s.impact !== "Green").length;
   const yaml = useMemo(() => selectionYAML(planId, picked), [planId, picked]);
+  const record = useMemo(
+    () => changeRecord(planId, picked, clusterLabel),
+    [planId, picked, clusterLabel],
+  );
 
   const drain = () => {
     if (nonGreen > 0) setConfirming(true);
@@ -111,7 +120,11 @@ export default function ReviewFooter({
             Drain {picked.length} node{picked.length === 1 ? "" : "s"}
           </button>
         )}
-        {!readOnly && (
+        {/* The overflow renders in a read-only session too. It used to be
+            hidden wholesale with the drain controls, which also hid the
+            change record — and a reviewer who cannot execute is exactly the
+            person who needs the approval to exist somewhere else. Only the
+            item that evicts something is gated. */}
         <div className="reviewfooter-overflow">
           <button
             type="button"
@@ -128,18 +141,33 @@ export default function ReviewFooter({
                 type="button"
                 role="menuitem"
                 className="reviewfooter-menuitem"
-                disabled={busy}
+                disabled={picked.length === 0}
                 onClick={() => {
+                  void navigator.clipboard.writeText(record);
+                  setRecorded(true);
                   setMenuOpen(false);
-                  onConverge();
+                  setTimeout(() => setRecorded(false), 1500);
                 }}
               >
-                Run to optimum…
+                {recorded ? "Copied" : "Copy as change record"}
               </button>
+              {!readOnly && (
+                <button
+                  type="button"
+                  role="menuitem"
+                  className="reviewfooter-menuitem"
+                  disabled={busy}
+                  onClick={() => {
+                    setMenuOpen(false);
+                    onConverge();
+                  }}
+                >
+                  Run to optimum…
+                </button>
+              )}
             </div>
           )}
         </div>
-        )}
       </div>
 
       {confirming && (
@@ -226,6 +254,80 @@ function TypedConfirm({
  * ticket. Deliberately not a kubectl manifest: nothing applies it; it is
  * the plan excerpt a colleague reads.
  */
+
+/**
+ * The selection as a change record — Markdown, for a PR body or a ticket.
+ *
+ * Every team with a change process needs the approval to exist somewhere
+ * other than this UI, and until now the audit trail was only inside the
+ * store. The plan already carries stable ids, per-step rationale and the
+ * guard's verdicts, so this is a transform rather than a feature.
+ *
+ * It says what changes, why each step is rated as it is, what the run
+ * actually does, and how to reverse it — the four things a reviewer who was
+ * not looking at this screen has to be told. Verdicts are the product's own
+ * words, so the record and the UI cannot describe the same step differently.
+ */
+function changeRecord(planId: string, picked: PlanStep[], clusterLabel?: string): string {
+  const pods = picked.reduce((n, s) => n + s.moves.length, 0);
+  const out: string[] = [
+    `# Node consolidation — plan \`${planId}\``,
+    "",
+    ...(clusterLabel ? [`**Cluster:** ${clusterLabel}  `] : []),
+    `**Prepared:** ${new Date().toISOString()}  `,
+    `**Approving:** ${picked.length} step${picked.length === 1 ? "" : "s"}, ${pods} pod${pods === 1 ? "" : "s"} relocated`,
+    "",
+    "## What changes",
+    "",
+    "| Step | Node | Verdict | Pods moved |",
+    "| --- | --- | --- | --- |",
+  ];
+  for (const s of picked) {
+    out.push(
+      `| ${String(s.sequenceNumber).padStart(2, "0")} | \`${s.targetNode}\` | ` +
+        `${VERDICT_LABEL[s.impact]} | ${s.moves.length} |`,
+    );
+  }
+
+  out.push("", "## Why each step is rated as it is", "");
+  for (const s of picked) {
+    out.push(
+      `### ${String(s.sequenceNumber).padStart(2, "0")} — \`${s.targetNode}\` · ${VERDICT_LABEL[s.impact]}`,
+      "",
+      s.rationale || "_No rationale recorded._",
+      "",
+    );
+    if (s.moves.length > 0) {
+      out.push("Pods relocated:", "");
+      for (const m of s.moves) {
+        out.push(`- \`${m.namespace}/${m.pod}\` → \`${m.toNode}\``);
+      }
+      out.push("");
+    }
+  }
+
+  out.push(
+    "## What the run does",
+    "",
+    "Each step cordons the node, evicts its pods through the Eviction API, and waits",
+    "for every one of them to be Ready elsewhere before the next step begins. The",
+    "Safety Guard re-runs before every step and halts the run on the first refusal.",
+    "There is no override.",
+    "",
+    "## Reversal",
+    "",
+    "Uncordon the node. Nothing is deleted — the pods were rescheduled by Kubernetes",
+    "and stay where they landed; consolidation is undone by the scheduler filling the",
+    "node again, not by moving them back.",
+    "",
+    "---",
+    "",
+    `Generated by k8s-dencer from plan \`${planId}\`. A plan is identified by its`,
+    "actions, so the same steps against the same nodes produce the same id.",
+  );
+  return out.join("\n") + "\n";
+}
+
 function selectionYAML(planId: string, picked: PlanStep[]): string {
   const lines = [`# k8s-dencer plan ${planId} — selected steps`, `plan: ${planId}`, "steps:"];
   for (const s of picked) {


### PR DESCRIPTION
From the #199 backlog — the item with the clearest value for the least new machinery.

Every team with a change process needs the approval to exist somewhere other than this UI, and until now the audit trail was only inside the store. The plan already carries stable ids, per-step rationale and the guard's verdicts, so this is a transform, not a feature.

The record says **what changes**, **why each step is rated as it is**, **what the run actually does**, and **how to reverse it** — the four things a reviewer who was not looking at this screen has to be told. Markdown, because the destination is a PR body or a ticket.

Two decisions worth naming:

**Verdicts render through `VERDICT_LABEL`**, not the raw `Green`/`Yellow`/`Red`. A record that pasted the raw values into a ticket would describe the same step differently from the screen it was exported from — which is how a reviewer and an operator end up arguing about two things they both call "the yellow one".

**The overflow menu now renders in a read-only session.** It was hidden wholesale with the drain controls, which was correct when everything in it acted on the cluster and became wrong the moment this landed: someone who signs in read-only to review a plan is exactly the person who needs the approval in a ticket. Only Run to optimum stays gated, and a test asserts both halves of that.

Verified against the OrbStack cluster — two steps selected in the real footer, record copied, output read back from the clipboard.

<details><summary>Sample output</summary>

```markdown
# Node consolidation — plan `51e99333b1a5`

**Prepared:** 2026-08-15T17:53:10.507Z  
**Approving:** 2 steps, 5 pods relocated

## What changes

| Step | Node | Verdict | Pods moved |
| --- | --- | --- | --- |
| 01 | `kwok-std-5` | Needs a call | 3 |
| 04 | `kwok-std-11` | Needs a call | 2 |
```

</details>