### PR TITLE
Document v0.9.0, and bump the chart to match

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,21 +274,42 @@ until the next snapshot says where they truly landed.
 execution, and maintenance windows. Phase 4 — hardening toward 1000 nodes and
 50,000 pods — is in progress, with metrics, CI and the release pipeline landed.
 
-**v0.8.1 is published** — images, chart and CLI binaries on `ghcr.io` and the
+**v0.9.0 is published** — images, chart and CLI binaries on `ghcr.io` and the
 [releases page](https://github.com/atedgimo/k8s-dencer/releases), installable by
 the command above.
 
-**Upgrade from v0.8.0 if you use `--reuse-values`:** that release added
-`database.postgres.sslRootCert`, and `helm upgrade --reuse-values` carries
-stored values forward without merging defaults for new keys — so the template
-hit a nil pointer and the upgrade would not render at all. It is nil-safe now.
+v0.9.0 is the release the first GKE run produced. That run answered the
+question it existed to ask — the product plans on a real managed cluster, 4
+steps, 6 nodes to 2 — and then found what a laptop could not.
 
-v0.8.1 also fixes three bugs found by driving the UI against a real cluster
-rather than reading it: the fix queue reported **0 findings for a full minute
-after sign-in** on a cluster with 34, because three polling hooks never re-read
-when a token arrived; a step's rationale printed the same reason twice when
-several pods shared one rule; and the review footer called an empty selection
-"All Green" while the screen above it said nothing was safe.
+**Upgrade if you have ever read a rationale that repeated itself.** A plan is
+identified by its *actions*: the strategy, the sequence, the target nodes and
+the moves. That is the right identity, and it meant a planner that explained
+the same drain better produced the same id, took the deduplication path, and
+left the old wording in the store. The v0.8.1 fix for a stuttering rationale
+shipped, ran, and changed nothing on any plan that already existed. The store
+now refreshes what a step *says* as well as what it *is*.
+
+v0.9.0 also stops hiding nodes that are already free — a node carrying only
+DaemonSets read as empty, so "N nodes now" described the subset the packer had
+work for rather than the fleet — puts a monthly rate and a per-step forecast on
+Review rather than on the least-visited screen, and exports a plan as a
+**change record** in Markdown, for a PR body or a ticket.
+
+The UI now survives a narrow viewport, read path only: three tiers, and below
+the smallest one everything that evicts a pod disappears. Nobody drains a node
+from a phone. Someone does get paged, look at their phone, and need to know
+whether the cluster is fine.
+
+v0.8.1 before it fixed three bugs found by driving the UI rather than reading
+it: the fix queue reported **0 findings for a full minute after sign-in** on a
+cluster with 34, because three polling hooks never re-read when a token
+arrived; a step's rationale printed the same reason twice when several pods
+shared one rule; and the review footer called an empty selection "All Green"
+while the screen above it said nothing was safe. It also made the chart
+nil-safe for `helm upgrade --reuse-values` into v0.8.0, which added a key and
+could not render at all — Helm carries stored values forward without merging
+defaults for keys added since.
 
 v0.8.0 before it is the release that went looking. Every fix in it came from running the
 product rather than reading it: the CLI could not find its own backend unless

--- a/charts/k8s-dencer/Chart.yaml
+++ b/charts/k8s-dencer/Chart.yaml
@@ -10,8 +10,8 @@ type: application
 
 # Chart version tracks the chart; appVersion tracks the images. Component image
 # tags default to appVersion so a chart release pins a coherent image set.
-version: 0.8.1
-appVersion: "0.8.1"
+version: 0.9.0
+appVersion: "0.9.0"
 
 # controller-runtime and the policy/v1 PDB API used here are stable from 1.21,
 # but the chart relies on 1.27-era defaults for restricted Pod Security

--- a/docs/product-roadmap.md
+++ b/docs/product-roadmap.md
@@ -5,7 +5,7 @@ milestones. The engineering history behind each item, with measurements and
 design reasoning, is in **[roadmap.md](roadmap.md)**; this page is the view for
 deciding what to build next and telling users what they get.
 
-*Last updated: 2026-08-01.*
+*Last updated: 2026-08-15.*
 
 ## Shipped
 
@@ -260,6 +260,39 @@ talking through.
 None of these survived contact with a real cluster, and none of them were
 caught by unit tests, the gates, or a screenshot review. That is the pattern
 worth keeping: the reviews find the engine, the cluster finds the product.
+
+### Stale words, and a UI that fits on a phone (2026-08-15)
+- **A better explanation now reaches a plan that already exists.** `planID`
+  hashes the strategy, sequence numbers, target nodes and moves — the actions
+  — and deliberately not the rationale, impact or reasons, which describe
+  them. Correct identity, wrong consequence: an upgraded planner explaining
+  the same drain better produced the same id, took the dedup path, and left
+  the old wording in place. The v0.8.1 stutter fix shipped, ran against a live
+  cluster, and changed nothing on any existing plan
+- **Nodes carrying only DaemonSets were invisible**, so "N nodes now"
+  described the subset the packer had work for rather than the fleet, and a
+  node already free to take was never offered
+- **The money moved to the screen where the decision is made** — a monthly
+  rate on Review and a per-step forecast, with the doctrine intact: unknown is
+  never zero, spot is never on-demand, a rate is never a total
+- **A plan exports as a change record** — Markdown for a PR body or a ticket:
+  what changes, why each step is rated as it is, what the run does, how to
+  reverse it. Every team with a change process needs the approval to exist
+  somewhere other than this UI
+- **The read path survives a narrow viewport.** Three tiers; below the
+  smallest, everything that evicts a pod disappears. Nobody drains a node from
+  a phone — but someone gets paged, looks at their phone, and needs to know
+  whether the cluster is fine
+- **The landing screen leads with the answer**, the rail separates deciding
+  from understanding, and an empty plan reads as a cluster packed as tightly
+  as its rules allow rather than as an absence
+
+Three of these were found by building the thing and looking at it, after the
+automated checks reported clean: six CSS selectors that named elements called
+something else, a step list that collapsed to zero height at 1100px, and
+display headlines inheriting body leading. Two more — `--space-5` and
+`--text-primary`, neither of which exists — had been silently deleting whole
+declarations since the redesign. All five are now gates.
 
 ## Next
 


### PR DESCRIPTION
The release the first GKE run produced.

That run answered the question it existed to ask — the product plans on a real managed cluster, **4 steps, 6 nodes → 2** — and then found what a laptop could not.

## What is in it

| | |
|---|---|
| #217 | a better explanation never reached a plan that already existed |
| #211 | nodes holding only DaemonSets were invisible, and the counts described the wrong fleet |
| #196 | the money was on the least-visited screen |
| #200 | the landing screen did not lead with the answer |
| #198 | the UI broke below about 1200px |
| #212 | four harness bugs, none of which a laptop could have found |
| #199 | change-record export, from the capabilities backlog |

## The upgrade note

A plan is identified by its **actions** — strategy, sequence, target nodes, moves. That is the right identity, and its consequence was not: a planner explaining the same drain better produced the same id, took the deduplication path, and left the old wording in the store. **The v0.8.1 rationale-stutter fix shipped, ran against a live cluster, and changed nothing on any plan that already existed.** Anyone who read a stuttering rationale on v0.8.1 and concluded the fix had not worked was right.

`version` and `appVersion` both move to `0.9.0`; the release job refuses to publish if they do not match the tag.