### PR TITLE
Ask whether the cluster can drain anything, at minute three

### DIFF
--- a/hack/capture/CHECKLIST.md
+++ b/hack/capture/CHECKLIST.md
@@ -1,14 +1,56 @@
-# v0.5.0 on a real managed cluster — what to check
+# A real managed cluster — what to check
 
-The 2026-08-07 run found that the product could not plan on GKE at all. Every
-fix since was verified against `test/fixtures/gke-managed.yaml` and locally.
-**Nobody has watched v0.5.0 plan on a real managed cluster.** That is what this
-run is for.
+**The planning question is answered.** On 2026-08-15 the product planned on a
+real GKE cluster: 4 steps, 6 nodes to 2, with GKE's own DaemonSets and static
+pods correctly read as pinned rather than movable. The 2026-08-07 failure —
+every node undrainable, zero steps — is closed.
 
-If line 1 fails, stop and treat the fixture as wrong about something —
-everything below it is downstream of that one answer.
+**The execution question is not.** That run never drained anything, because
+the cluster was 88.5% requested and there was nowhere to move pods to. So
+cordon → evict → verify → reclaim is still verified only by the e2e and by
+OrbStack, and the savings ledger has never been filled in money by a drain of
+ours — only by GKE's autoscaler reclaiming nodes on its own. That is what the
+next run is for (issue #225).
 
-## 1. The P0 — does it plan at all?
+Sections 1–7 below are now regression checks: they were failures once, they
+are fixed, and they are cheap to re-confirm. **Section 0 is the run's actual
+purpose.**
+
+## 0. Can it drain, and will it?
+
+`run.sh` asks the first half automatically, before anything else, and says so
+loudly if the answer is no:
+
+```
+==> is there room to drain anything?
+  OK — capacity for 3 drains. Enough to execute one and still have a spare.
+```
+
+If that prints `TOO PACKED`, **relaunch with a bigger fleet immediately** —
+`REAL_NODES=8 make gcp-play`. Everything downstream will look fine and prove
+nothing, which is exactly how the last run spent its window. Add nodes rather
+than shrinking the demo workload: the movable load is what makes the plan
+interesting in the first place.
+
+It is a capacity ceiling, not a plan. Constraints can only take nodes off that
+number, so a zero is decisive and a healthy number is necessary rather than
+sufficient.
+
+Then, in the UI:
+
+- [ ] **Rehearse a Caution step.** Every guard check runs, the same events are
+      emitted, nothing is cordoned or evicted.
+- [ ] **Drain one for real.** Watch cordon → evict → verify → drained on the
+      run screen. This is the line no managed-cluster run has ever crossed.
+- [ ] **Let the reclamation close** — the node goes away and History records
+      it as ours, with money attached, rather than `external: true`.
+- [ ] **Open a Red step** and confirm it refuses without a maintenance window,
+      and reads as the product working rather than as an error.
+
+Give the Postgres phase more than ten minutes if it runs. Last time it proved
+Postgres starts and migrates, and said nothing about it under load.
+
+## 1. Regression: does it still plan at all?
 
 ```bash
 go run ./cmd/dencer plan --context gke-play

--- a/hack/capture/headroom.py
+++ b/hack/capture/headroom.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Can this cluster actually demonstrate a drain?
+
+The 2026-08-15 GKE run answered its P0 — the product plans on a real managed
+cluster — and then never executed a single drain, because the cluster was
+88.5% requested for most of the window and there was nowhere to move pods to.
+Nobody knew that until minute forty, by which point the cluster was most of
+the way through its life.
+
+This answers it at minute three, from the live cluster rather than from a
+formula. A formula was tried on paper first and was wrong: the obvious guess
+is that a managed node's ~470m of system requests is fixed per-node overhead,
+and it is not — most of it is Deployments (kube-dns alone is 270m) that move
+like any other pod. Only the DaemonSets and the node-owned static pods are
+genuinely per-node, and on the measured cluster that was ~276m, not ~470m.
+Guessing wrong in that direction says a cluster is hopeless when it is fine.
+
+So: read what is actually there, split it the way the planner splits it, and
+say how many nodes could come out.
+
+This is a CAPACITY CEILING, not a plan. It answers "is there physically room
+to put these pods somewhere else", and ignores every constraint that might
+refuse the move — PDBs, topology spread, anti-affinity, taints. Constraints
+can only take nodes off this number, never add them. So a zero here is
+decisive (the run cannot demonstrate a drain and the fleet needs to be
+bigger) and a healthy number is necessary rather than sufficient.
+
+Reads `kubectl get nodes -o json` and `kubectl get pods -A -o json`, in that
+order, from two files named on the command line.
+
+    kubectl get nodes -o json > /tmp/n.json
+    kubectl get pods -A -o json > /tmp/p.json
+    headroom.py /tmp/n.json /tmp/p.json [PACK_CEILING]
+"""
+import json
+import sys
+from collections import defaultdict
+
+
+def cpu_m(v):
+    """Kubernetes CPU quantity -> millicores."""
+    if not v:
+        return 0
+    v = str(v)
+    if v.endswith("m"):
+        return int(float(v[:-1]))
+    if v.endswith("n"):
+        return int(float(v[:-1]) / 1_000_000)
+    return int(float(v) * 1000)
+
+
+def pinned(pod):
+    """Can this pod never move off its node?
+
+    The same two cases the planner treats as pinned rather than blocking:
+    a DaemonSet puts one on every node by definition, and a static pod is
+    owned by the kubelet that runs it. Both survive their node going away
+    at no cost, so neither counts as work that has to be re-homed — and
+    both consume room on every node that stays.
+    """
+    for ref in pod["metadata"].get("ownerReferences") or []:
+        if ref.get("kind") == "DaemonSet":
+            return True
+    ann = pod["metadata"].get("annotations") or {}
+    return "kubernetes.io/config.mirror" in ann
+
+
+nodes_json, pods_json = sys.argv[1], sys.argv[2]
+ceiling = float(sys.argv[3]) if len(sys.argv) > 3 else 0.85
+
+nodes = {}
+for n in json.load(open(nodes_json))["items"]:
+    name = n["metadata"]["name"]
+    unsched = (n.get("spec") or {}).get("unschedulable", False)
+    nodes[name] = {
+        "alloc": cpu_m((n.get("status") or {}).get("allocatable", {}).get("cpu")),
+        "cordoned": bool(unsched),
+    }
+
+pinned_by_node = defaultdict(int)
+movable_total = 0
+movable_by_node = defaultdict(int)
+
+for p in json.load(open(pods_json))["items"]:
+    node = (p.get("spec") or {}).get("nodeName")
+    if not node or node not in nodes:
+        continue
+    if (p.get("status") or {}).get("phase") in ("Succeeded", "Failed"):
+        continue
+    c = sum(
+        cpu_m(((ct.get("resources") or {}).get("requests") or {}).get("cpu"))
+        for ct in p["spec"].get("containers", [])
+    )
+    if pinned(p):
+        pinned_by_node[node] += c
+    else:
+        movable_total += c
+        movable_by_node[node] += c
+
+live = [n for n, d in nodes.items() if not d["cordoned"]]
+if not live:
+    print("no schedulable nodes")
+    sys.exit(1)
+
+print(f"{'node':<48}{'alloc':>9}{'pinned':>9}{'movable':>10}{'room':>9}")
+for n in sorted(live):
+    d = nodes[n]
+    room = int((d["alloc"] - pinned_by_node[n]) * ceiling)
+    print(f"{n:<48}{str(d['alloc']) + 'm':>9}{str(pinned_by_node[n]) + 'm':>9}"
+          f"{str(movable_by_node[n]) + 'm':>10}{str(room) + 'm':>9}")
+
+# Room per node is allocatable minus what can never leave it, times the
+# ceiling the planner will not pack above. Sorted descending and consumed
+# greedily: the planner is first-fit-decreasing, so the best case is the
+# emptiest-of-pinned nodes absorbing everything.
+rooms = sorted(
+    (int((nodes[n]["alloc"] - pinned_by_node[n]) * ceiling) for n in live),
+    reverse=True,
+)
+need, acc = 0, 0
+for r in rooms:
+    if acc >= movable_total:
+        break
+    acc += r
+    need += 1
+
+drainable = len(live) - need if acc >= movable_total else 0
+
+print()
+print(f"  schedulable nodes    {len(live)}")
+print(f"  movable CPU          {movable_total}m")
+print(f"  usable room          {sum(rooms)}m  (allocatable minus pinned, x{ceiling} ceiling)")
+print(f"  nodes it needs       {need}")
+print()
+
+# The verdict, in the terms the run cares about. Two is the threshold rather
+# than one because a single drainable node gives one shot: if that step is
+# rated Red, or its target is where the executor happens to be sitting, the
+# run has nothing else to offer and the trip is wasted.
+print("  A capacity ceiling, not a plan: constraints (PDBs, spread, affinity)")
+print("  can only take nodes off this number. Zero here is decisive.")
+print()
+
+if drainable >= 2:
+    print(f"  OK — capacity for {drainable} drains. Enough to execute one and still have a spare.")
+elif drainable == 1:
+    print("  THIN — exactly 1 node is drainable. If that step is rated Red there is")
+    print("  no second option, and the run demonstrates nothing.")
+    print("  Add nodes (REAL_NODES) rather than shrinking the demo: the movable load")
+    print("  is what makes the plan interesting.")
+else:
+    print("  TOO PACKED — nothing can be drained. This is the 2026-08-15 run repeating:")
+    print(f"  {movable_total}m of movable work needs every one of {len(live)} nodes.")
+    print("  Relaunch with more nodes. The demo workload is the point; the fleet is not.")
+
+sys.exit(0 if drainable >= 1 else 2)

--- a/hack/capture/postrun.sh
+++ b/hack/capture/postrun.sh
@@ -55,6 +55,21 @@ for c in planner ui-backend executor; do
     > "$OUT/log-$c-previous.txt" 2>/dev/null && green "  $OUT/log-$c-previous.txt"
 done
 
+# JSON as well as YAML, so the headroom question can be re-asked after the
+# cluster is gone. The 2026-08-15 capture has nodes.yaml and a pod listing
+# without requests in it, which is not enough to reconstruct why that run had
+# nowhere to move anything.
+keep nodes.json         kubectl --context "$CTX" get nodes -o json
+keep pods-all.json      kubectl --context "$CTX" get pods -A -o json
+if python3 "$(dirname "${BASH_SOURCE[0]}")/headroom.py" \
+     "$OUT/nodes.json" "$OUT/pods-all.json" > "$OUT/headroom.txt" 2>&1; then
+  green "  $OUT/headroom.txt"
+else
+  # Exit 2 means nothing was drainable, which is a finding rather than a
+  # failure of the capture.
+  warn "  $OUT/headroom.txt (nothing drainable — kept, and worth reading)"
+fi
+
 say "the workloads under test"
 keep demo-pods.txt      kubectl --context "$CTX" -n "$DEMO_NS" get pods -o wide
 keep demo-all.yaml      kubectl --context "$CTX" -n "$DEMO_NS" get all,pdb -o yaml

--- a/hack/capture/run.sh
+++ b/hack/capture/run.sh
@@ -96,6 +96,24 @@ warn "  Item 1 is the stop condition: if Review shows no steps on a cluster"
 warn "  with half-empty nodes, capture and stop — everything else is downstream."
 echo
 
+# ------------------------------------------------------ can it drain at all
+# Before anything else worth reading, because it is the question the last run
+# failed to ask. That run planned beautifully and never executed a drain: the
+# cluster was 88.5% requested and there was nowhere to move pods to, which
+# nobody knew until minute forty of a forty-five minute cluster.
+#
+# Answered here from the live cluster, at minute three, while relaunching with
+# a bigger fleet still costs nothing but time.
+bold "==> is there room to drain anything?"
+kubectl --context "$CTX" get nodes -o json > /tmp/dencer-headroom-n.json 2>/dev/null
+kubectl --context "$CTX" get pods -A -o json > /tmp/dencer-headroom-p.json 2>/dev/null
+python3 "$HERE/headroom.py" /tmp/dencer-headroom-n.json /tmp/dencer-headroom-p.json
+case $? in
+  2) red "  Relaunch before spending the window: REAL_NODES=8 make gcp-play"
+     red "  Everything below this line will look fine and prove nothing." ;;
+esac
+echo
+
 # ------------------------------------------------------------------ the run
 bold "==> first look"
 if [[ -n "$TOKEN" ]]; then


### PR DESCRIPTION
Towards #225.

The GKE run planned beautifully and never executed a drain — the cluster was 88.5% requested and there was nowhere to move pods to. Nobody knew until minute forty of a forty-five minute cluster.

This asks at minute three, while relaunching still costs only time.

## Measured, not modelled

A formula was tried on paper first and **was wrong**. The obvious reading of the last run's data is that a managed node spends ~470m on system pods, leaving ~470m of an `e2-medium` for workloads. It does not — most of that is *Deployments* (kube-dns alone is 270m) which move like anything else. Only DaemonSets and static pods are genuinely per-node, and that is **276m, not 470m**. Guessing wrong in that direction declares a cluster hopeless when it is fine.

So `headroom.py` reads the live cluster and splits pods the way the planner splits them. It reports a **capacity ceiling and says so**: constraints (PDBs, spread, affinity) can only take nodes off that number, so a zero is decisive and a healthy number is necessary rather than sufficient.

## Why the guidance is `REAL_NODES=8`

On the measured numbers, at the 0.85 packing ceiling:

```
per-node room   (940 - 276) x 0.85 = 564m
movable total   ~2658m   (system Deployments + the release + the demo)

  6 nodes -> needs 5, 1 drainable   <- the run that happened
  7 nodes -> needs 5, 2 drainable
  8 nodes -> needs 5, 3 drainable
```

And why it is to *add nodes* rather than shrink the demo: the movable load is what makes the plan worth looking at. Cost goes from ~20¢ to ~27¢.

## Wiring

- `run.sh` runs it before anything else and shouts if the answer is no
- `postrun.sh` captures `nodes.json` and `pods-all.json` beside it — the existing capture has a pod listing *without requests*, so it cannot answer this after the fact, which is why the 2026-08-15 numbers had to be re-derived by hand
- `CHECKLIST.md` now leads with execution; the planning question is answered, and sections 1–7 are regression checks

Verified against the live OrbStack cluster, and rehearsed end to end through `postrun.sh`.