### PR TITLE
Give the docs one index, and the README a status you can read

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,20 +253,14 @@ until the next snapshot says where they truly landed.
 
 ## Documentation
 
+Full index: **[docs/](docs/README.md)**. The ones most people want first:
+
 | | |
 |---|---|
-| [Installation and configuration](docs/install.md) | Chart values, profiles, and the constraints each choice carries |
-| [CLI](docs/cli.md) | `dencer` and `kubectl dencer`, for operators who don't want the UI |
-| [Architecture](docs/architecture.md) | Components, analyzer, planner, impact ratings, API, UI |
-| [Authentication and authorization](docs/security.md) | Token delegation, OIDC/SSO, verifying the privilege split |
-| [Execution and safety](docs/execution.md) | Per-step behaviour, the guard's rails, maintenance windows, audit |
-| [Observability](docs/observability.md) | Prometheus metrics per component |
-| [Development](docs/development.md) | Local loop, KWOK fabric, CI gates, releases |
-| [The GCP playground](docs/gcp-playground.md) | A timed, self-destructing GKE cluster with real workloads and a random scenario |
-| [Benchmarks](docs/benchmarks.md) | Measured cost, growth curves, the ceiling |
-| [Product roadmap](docs/product-roadmap.md) | Shipped capabilities and what comes next, as features |
-| [Engineering roadmap](docs/roadmap.md) | The milestone history — built, planned, and deliberately dropped |
-| [Design document](docs/k8s-consolidation-agent-architecture.md) | The original architecture and its reasoning |
+| **Running it** | [Installation](docs/install.md) · [CLI](docs/cli.md) · [Execution and safety](docs/execution.md) · [Auth](docs/security.md) · [Observability](docs/observability.md) |
+| **Understanding it** | [Architecture](docs/architecture.md) · [Benchmarks](docs/benchmarks.md) |
+| **Working on it** | [Development](docs/development.md) · [The GCP playground](docs/gcp-playground.md) |
+| **History** | [Releases](docs/releases.md) · [Capabilities](docs/product-roadmap.md) · [Milestones](docs/roadmap.md) · [Findings](docs/findings.md) |
 
 ## Status
 
@@ -278,132 +272,45 @@ execution, and maintenance windows. Phase 4 — hardening toward 1000 nodes and
 [releases page](https://github.com/atedgimo/k8s-dencer/releases), installable by
 the command above.
 
-v0.9.0 is the release the first GKE run produced. That run answered the
-question it existed to ask — the product plans on a real managed cluster, 4
-steps, 6 nodes to 2 — and then found what a laptop could not.
+> **Upgrading from v0.8.x?** A plan is identified by its *actions*, so a planner
+> that explained the same drain better produced the same id and the store kept
+> the old wording — which made v0.8.1's rationale fix inert on any plan that
+> already existed. v0.9.0 refreshes what a step *says* as well as what it *is*.
+> Full notes in [docs/releases.md](docs/releases.md).
 
-**Upgrade if you have ever read a rationale that repeated itself.** A plan is
-identified by its *actions*: the strategy, the sequence, the target nodes and
-the moves. That is the right identity, and it meant a planner that explained
-the same drain better produced the same id, took the deduplication path, and
-left the old wording in the store. The v0.8.1 fix for a stuttering rationale
-shipped, ran, and changed nothing on any plan that already existed. The store
-now refreshes what a step *says* as well as what it *is*.
-
-v0.9.0 also stops hiding nodes that are already free — a node carrying only
-DaemonSets read as empty, so "N nodes now" described the subset the packer had
-work for rather than the fleet — puts a monthly rate and a per-step forecast on
-Review rather than on the least-visited screen, and exports a plan as a
-**change record** in Markdown, for a PR body or a ticket.
-
-The UI now survives a narrow viewport, read path only: three tiers, and below
-the smallest one everything that evicts a pod disappears. Nobody drains a node
-from a phone. Someone does get paged, look at their phone, and need to know
-whether the cluster is fine.
-
-v0.8.1 before it fixed three bugs found by driving the UI rather than reading
-it: the fix queue reported **0 findings for a full minute after sign-in** on a
-cluster with 34, because three polling hooks never re-read when a token
-arrived; a step's rationale printed the same reason twice when several pods
-shared one rule; and the review footer called an empty selection "All Green"
-while the screen above it said nothing was safe. It also made the chart
-nil-safe for `helm upgrade --reuse-values` into v0.8.0, which added a key and
-could not render at all — Helm carries stored values forward without merging
-defaults for keys added since.
-
-v0.8.0 before it is the release that went looking. Every fix in it came from running the
-product rather than reading it: the CLI could not find its own backend unless
-the Helm release happened to be named `k8s-dencer`; it reported a plan the
-planner had just re-confirmed as twenty hours old, contradicting the UI about
-the same plan; and a ui-backend whose database had gone away answered every
-request with `internal error`, which named nothing. The API now returns `503
-plan store unavailable`, and the e2e runs against **both** plan stores — the
-gap that let v0.6.0 ship a Postgres backend unable to record a drain.
-
-v0.7.0 before it repaired the Postgres store that v0.6.0 shipped. **If you are running v0.6.0
-on Postgres, upgrade**: the reclamation ledger there could not record a single
-drain, and per-node history was silently dead. Three bugs — a bool bound into
-an integer column, a statement that skipped placeholder rewriting, and SQLite's
-64-bit `INTEGER` translated to Postgres's 32-bit one, which capped every
-memory column at 2 GiB. Schema v15 widens those columns on upgrade. The
-underlying cause was a test suite that claimed to run against both backends and
-did not; it does now, which is what found the third bug. Migration also takes a
-cross-process lock, so the planner and ui-backend no longer race on a fresh
-install, and `database.postgres.sslRootCert` lets an install verify the
-server's certificate rather than only encrypting the connection.
-
-v0.6.0 added the **Postgres plan store**. Set `database.type=postgres` and the
-PersistentVolumeClaim, the `/data` mount, the required pod affinity and the
-PriorityClass all disappear, because all four exist only to keep two writers
-off one file. `uiBackend.replicaCount` becomes an ordinary value.
-
-The reason is not availability, which is what the roadmap had assumed when it
-recorded Postgres as dropped. SQLite's ReadWriteOnce claim permits multiple
-pods only on the same node, so the planner is co-scheduled onto the
-ui-backend's node and has exactly one node it may occupy — on a packed cluster
-it loses the scheduling race and sits `Pending`. It is one store speaking both
-dialects rather than two implementations, and the same test suite runs against
-both backends in CI: that suite failed fourteen tests the first time it met a
-real Postgres, one of which let two executors claim the same run.
-
-v0.5.0 before it is the release that made the product work on managed clusters. A real GKE
-run found that it could not plan at all there — see below — and fixing that
-brought the rest with it: the savings ledger in money when you say what your
-machines cost, rightsizing and maintenance windows and resilience simulation
-all given screens after being built and never surfaced, an empty plan that
-explains itself rather than rendering blank, per-node history so a node that
-is quietly idle can be told from one that spikes nightly, and a single Stop
-control on a run in flight — one rather than the designed two, because a pod
-that has been evicted cannot be un-evicted and two buttons would promise an
-undo that does not exist.
-
-**The UI has been rebuilt against a full design handoff** (2026-08-01): twelve
-mockup frames, a dual-theme token system with computed-contrast guards, and
-the two capabilities the design demanded of the backend — a real packing
-ceiling (`planner.packCeiling`, default 0.85, recorded on every plan) and
-per-node measured usage in the graph. The handoff itself lives in
-[assets/design/](assets/design/), and `make demo-video` re-records the
-walkthrough of the real product ([assets/demo/walkthrough.webm](assets/demo/walkthrough.webm)).
+### What is proven
 
 Every release is verified end to end before it ships: CI stands up a five-node
 k3d cluster with PodSecurity enforcing `restricted`, installs the chart behind a
 real ingress controller on a named StorageClass, plans against real workloads
 with real readiness probes, drains a node through the eviction API, asserts the
-workload came back Ready, then deletes the node and confirms the reclamation
-was observed. That is what
-[`make e2e`](hack/e2e.sh) does, and it runs on every pull request.
+workload came back Ready, then deletes the node and confirms the reclamation was
+observed. That is [`make e2e`](hack/e2e.sh), on every pull request, against both
+plan stores.
 
-**It has now run against a real cloud cluster.** `make cloud-e2e` stands up a
-five-node GKE cluster, installs the published images, drains a node, and then
-waits — touching nothing — while **Google's own cluster autoscaler** decides the
-node is unneeded and removes it. Observed and timed at **11m9s** on
-2026-07-31. That is the reclamation loop confirmed against a reclaimer nobody
-here wrote, which is the one thing k3d structurally cannot prove.
+It has also run against real GKE. The reclamation loop was confirmed against
+**Google's own cluster autoscaler** — drain, then touch nothing, and watch it
+remove the node 11m9s later — and the planner has been watched producing a
+correct plan on a managed cluster. Three cloud runs, what each cost and what
+each found, are in [docs/releases.md](docs/releases.md#what-the-cloud-runs-found).
 
-**A second cloud run, on 2026-08-07, found that the product could not plan at
-all on a managed cluster** — and that is the most useful twenty cents this
-project has spent. GKE runs kube-proxy as a static pod owned by the node
-itself; the analyser recognised only DaemonSets as pinned, so it tried to
-reschedule a pod nothing can move, failed, and marked every node undrainable.
-Converge reported nothing to do while Google's own autoscaler reclaimed two
-nodes from the same cluster three minutes later.
+### What is not
 
-None of it was reachable from CI, because kwok nodes run no system pods at
-all — 0m of system CPU locally against 276m minimum on GKE, where the daemons
-take between 29% and 82% of a node's allocatable before a workload is
-scheduled. [`test/fixtures/gke-managed.yaml`](test/fixtures/gke-managed.yaml)
-now reproduces that fleet to within 2m per node, so the whole class of bug is
-a millisecond test rather than a cloud bill.
-
-Still unproven, and worth saying: this has not run against anyone's
-*production* cluster, only a throwaway one. Workload Identity and IRSA remain
-half-tested — the chart's annotations render and are accepted, but k8s-dencer
-makes no cloud API calls, so there is no credential path to exercise.
+- **No drain has ever been executed on a managed cluster.** Cordon → evict →
+  verify → reclaim is proven by CI and locally; on GKE the product has planned
+  but never run. [#225](https://github.com/atedgimo/k8s-dencer/issues/225).
+- **This has not run against anyone's production cluster**, only throwaway ones.
+- **Workload Identity and IRSA are half-tested** — the chart's annotations render
+  and are accepted, but k8s-dencer makes no cloud API calls, so there is no
+  credential path to exercise.
 
 Treat the read-only path as ready to try, and the executor as something to
 enable deliberately, on something you can afford to be wrong about.
 
-Full milestone history in [docs/roadmap.md](docs/roadmap.md).
+**History** — [release notes](docs/releases.md) ·
+[capabilities](docs/product-roadmap.md) ·
+[milestones and measurements](docs/roadmap.md) ·
+[bugs, by how they hid](docs/findings.md)
 
 ## Security
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,22 +1,55 @@
 # Documentation
 
+Grouped by what you are trying to do, because a flat list of fifteen files
+tells you nothing about which one to open first.
+
+## Running it
+
+Start here if you want it on a cluster.
+
 | | |
 |---|---|
 | **[Installation and configuration](install.md)** | Installing the chart, values profiles, and the constraints each choice carries |
 | **[CLI](cli.md)** | `dencer` and `kubectl dencer` — inspect and run plans without the UI |
-| **[Architecture](architecture.md)** | Components, the constraint analyzer, the planner, impact ratings, the API and the UI |
-| **[Authentication and authorization](security.md)** | TokenReview and SubjectAccessReview delegation, OIDC/SSO, and how to verify the privilege split yourself |
 | **[Execution and safety](execution.md)** | What the executor does per step, the Safety Guard's rails, maintenance windows, and the audit trail |
+| **[Authentication and authorization](security.md)** | TokenReview and SubjectAccessReview delegation, OIDC/SSO, and how to verify the privilege split yourself |
 | **[Observability](observability.md)** | Prometheus metrics and what each component publishes |
+
+## Understanding it
+
+How the thing is built, and why it decides what it decides.
+
+| | |
+|---|---|
+| **[Architecture](architecture.md)** | Components, the constraint analyzer, the planner, impact ratings, the API and the UI |
+| **[Benchmarks](benchmarks.md)** | Measured cost per operation, and where each stage stops being usable |
+
+## Working on it
+
+| | |
+|---|---|
+| **[Development](development.md)** | The local loop, the KWOK fake-node fabric, the CI gates, and cutting a release |
 | **[Running the cloud test on GCP](gcp-setup.md)** | Account, project, billing, quota — everything to do by hand, once |
 | **[The GCP playground](gcp-playground.md)** | A timed, self-destructing GKE cluster with real workloads and a random scenario |
-| **[Development](development.md)** | The local loop, the KWOK fake-node fabric, the CI gates, and cutting a release |
-| **[Benchmarks](benchmarks.md)** | Measured cost per operation, and where each stage stops being usable |
-| **[Findings](findings.md)** | Bugs and gaps found by running it — what hid, and why |
+
+## What happened, and what is next
+
+Four views of the same history, kept apart because they answer different
+questions.
+
+| | |
+|---|---|
+| **[Release history](releases.md)** | What changed in each release, and whether you should hurry |
 | **[Product roadmap](product-roadmap.md)** | Shipped capabilities and what comes next, as features rather than milestones |
-| **[Engineering roadmap and status](roadmap.md)** | The milestone history — measurements, design reasoning, what was dropped and why |
+| **[Engineering roadmap](roadmap.md)** | The milestone history — measurements, design reasoning, what was dropped and why |
+| **[Findings](findings.md)** | Bugs and gaps found by running it, grouped by *how they hid* rather than by when |
+
+## Reference
+
+| | |
+|---|---|
 | **[Security policy](../SECURITY.md)** | Reporting a vulnerability, and what is in scope |
-| **[Design document](k8s-consolidation-agent-architecture.md)** | The original architecture and the reasoning behind it |
+| **[Original design document](k8s-consolidation-agent-architecture.md)** | Historical: what was intended, before the code disagreed. See [architecture.md](architecture.md) for what actually runs |
 
 ---
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -58,7 +58,7 @@ no layout thrash.
 M18 made the planner fast enough; M17 addresses what it costs to *hold* and
 *keep* a cluster this size. Three changes, each measured.
 
-**Stored plans are gzipped** ([sqlite.go](../internal/store/sqlite/sqlite.go)).
+**Stored plans are gzipped** ([sqlstore.go](../internal/store/sqlstore/sqlstore.go)).
 JSON of a cluster snapshot is extremely repetitive, and the snapshot and
 analysis BLOBs compress accordingly. The encoding is self-describing via the
 gzip magic bytes, so no migration was needed and rows written before this change

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,0 +1,205 @@
+# Release history
+
+What changed in each release, and — where it matters — whether you should
+hurry. Newest first.
+
+This lived in the project README until it was longer than the rest of the page
+put together. The README now carries the current state; this carries how it got
+there.
+
+Milestone-level engineering history, with measurements and the reasoning behind
+design changes, is in [roadmap.md](roadmap.md). Capabilities as features are in
+[product-roadmap.md](product-roadmap.md). The bugs themselves, grouped by how
+they hid rather than by release, are in [findings.md](findings.md).
+
+---
+
+## v0.9.0 — 2026-08-15
+
+The release the first GKE run produced. That run answered the question it
+existed to ask — the product plans on a real managed cluster, 4 steps, 6 nodes
+to 2 — and then found what a laptop could not.
+
+**Upgrade if you have ever read a rationale that repeated itself.** A plan is
+identified by its *actions*: the strategy, the sequence, the target nodes and
+the moves. That is the right identity, and it meant a planner that explained
+the same drain better produced the same id, took the deduplication path, and
+left the old wording in the store. The v0.8.1 fix for a stuttering rationale
+shipped, ran, and changed nothing on any plan that already existed. The store
+now refreshes what a step *says* as well as what it *is*.
+
+Also in it:
+
+- **Nodes already free stopped being invisible.** A node carrying only
+  DaemonSets read as empty, so "N nodes now" described the subset the packer
+  had work for rather than the fleet — and a node you could take today was
+  never offered.
+- **The money moved to the screen where the decision is made** — a monthly rate
+  on Review and a per-step forecast, with the doctrine intact: unknown is never
+  zero, spot is never on-demand, a rate is never a total.
+- **A plan exports as a change record** — Markdown for a PR body or a ticket:
+  what changes, why each step is rated as it is, what the run does, how to
+  reverse it.
+- **The read path survives a narrow viewport.** Three tiers; below the smallest,
+  everything that evicts a pod disappears. Nobody drains a node from a phone —
+  but someone gets paged, looks at their phone, and needs to know whether the
+  cluster is fine.
+- **The landing screen leads with the answer**, the rail separates deciding from
+  understanding, and an empty plan reads as a cluster packed as tightly as its
+  rules allow rather than as an absence.
+
+## v0.8.1 — 2026-08-15
+
+Three bugs found by driving the UI rather than reading it:
+
+- the fix queue reported **0 findings for a full minute after sign-in** on a
+  cluster with 34, because three polling hooks never re-read when a token
+  arrived
+- a step's rationale printed the same reason twice when several pods shared one
+  rule
+- the review footer called an empty selection "All Green" while the screen
+  above it said nothing was safe
+
+**Upgrade from v0.8.0 if you use `--reuse-values`.** That release added
+`database.postgres.sslRootCert`, and `helm upgrade --reuse-values` carries
+stored values forward without merging defaults for keys added since — so the
+template hit a nil pointer and the upgrade would not render at all. It is
+nil-safe now.
+
+## v0.8.0 — 2026-08-14
+
+The release that went looking. Every fix in it came from running the product
+rather than reading it:
+
+- the CLI could not find its own backend unless the Helm release happened to be
+  named `k8s-dencer`
+- it reported a plan the planner had just re-confirmed as twenty hours old,
+  contradicting the UI about the same plan
+- a ui-backend whose database had gone away answered every request with
+  `internal error`, which named nothing. The API now returns `503 plan store
+  unavailable`
+
+The e2e also runs against **both** plan stores from here on — the gap that let
+v0.6.0 ship a Postgres backend unable to record a drain.
+
+## v0.7.0 — 2026-08-12
+
+Repaired the Postgres store that v0.6.0 shipped.
+
+**If you are running v0.6.0 on Postgres, upgrade.** The reclamation ledger
+there could not record a single drain, and per-node history was silently dead.
+Three bugs: a bool bound into an integer column, a statement that skipped
+placeholder rewriting, and SQLite's 64-bit `INTEGER` translated to Postgres's
+32-bit one — which capped every memory column at 2 GiB. Schema v15 widens those
+columns on upgrade.
+
+The underlying cause was a test suite that claimed to run against both backends
+and did not. It does now, which is what found the third bug.
+
+Migration also takes a cross-process lock, so the planner and ui-backend no
+longer race on a fresh install, and `database.postgres.sslRootCert` lets an
+install verify the server's certificate rather than only encrypting the
+connection.
+
+## v0.6.0 — 2026-08-12
+
+Added the **Postgres plan store**. Set `database.type=postgres` and the
+PersistentVolumeClaim, the `/data` mount, the required pod affinity and the
+PriorityClass all disappear, because all four exist only to keep two writers off
+one file. `uiBackend.replicaCount` becomes an ordinary value.
+
+The reason is not availability, which is what the roadmap had assumed when it
+recorded Postgres as dropped. SQLite's ReadWriteOnce claim permits multiple pods
+only on the same node, so the planner is co-scheduled onto the ui-backend's node
+and has exactly one node it may occupy — on a packed cluster it loses the
+scheduling race and sits `Pending`.
+
+It is one store speaking both dialects rather than two implementations. That
+suite failed fourteen tests the first time it met a real Postgres, one of which
+let two executors claim the same run.
+
+> Superseded by v0.7.0 — see above before installing this.
+
+## v0.5.0 — 2026-08-01
+
+The release that made the product work on managed clusters. A real GKE run
+found that it could not plan at all there ([see below](#what-the-cloud-runs-found)),
+and fixing that brought the rest with it:
+
+- the savings ledger in money, when you say what your machines cost
+- rightsizing, maintenance windows and resilience simulation given screens
+  after being built and never surfaced
+- an empty plan that explains itself rather than rendering blank
+- per-node history, so a node that is quietly idle can be told from one that
+  spikes nightly
+- a single Stop control on a run in flight — one rather than the designed two,
+  because a pod that has been evicted cannot be un-evicted and two buttons
+  would promise an undo that does not exist
+
+**The UI was rebuilt against a full design handoff** in the same window: twelve
+mockup frames, a dual-theme token system with computed-contrast guards, and the
+two capabilities the design demanded of the backend — a real packing ceiling
+(`planner.packCeiling`, default 0.85, recorded on every plan) and per-node
+measured usage in the graph. The handoff lives in
+[assets/design/](../assets/design/), and `make demo-video` re-records the
+walkthrough of the real product
+([assets/demo/walkthrough.webm](../assets/demo/walkthrough.webm)).
+
+---
+
+## What the cloud runs found
+
+Three runs against real managed clusters, and each one earned its cost.
+
+### 2026-07-31 — the reclamation loop, against a reclaimer nobody here wrote
+
+`make cloud-e2e` stands up a five-node GKE cluster, installs the published
+images, drains a node, and then waits — touching nothing — while **Google's own
+cluster autoscaler** decides the node is unneeded and removes it. Observed and
+timed at **11m9s**.
+
+That is the one thing k3d structurally cannot prove.
+
+### 2026-08-07 — it could not plan on a managed cluster at all
+
+The most useful twenty cents this project has spent.
+
+GKE runs kube-proxy as a static pod owned by the node itself. The analyser
+recognised only DaemonSets as pinned, so it tried to reschedule a pod nothing
+can move, failed, and marked every node undrainable. Converge reported nothing
+to do while Google's own autoscaler reclaimed two nodes from the same cluster
+three minutes later.
+
+None of it was reachable from CI, because kwok nodes run no system pods at all
+— 0m of system CPU locally against 276m minimum on GKE, where the daemons take
+between 29% and 82% of a node's allocatable before a workload is scheduled.
+[`test/fixtures/gke-managed.yaml`](../test/fixtures/gke-managed.yaml) now
+reproduces that fleet to within 2m per node, so the whole class of bug is a
+millisecond test rather than a cloud bill.
+
+### 2026-08-15 — it plans, and the numbers off a laptop are different
+
+First plan on contact: **4 steps, 6 nodes → 2**, with GKE's DaemonSets and
+static pods correctly read as pinned rather than movable, and the resilience
+audit reporting 0 findings — so none of them are misreported as at-risk either.
+
+Postgres was verified on real infrastructure in the same run: schema 15, 0
+`int4` columns, 2/2 ui-backend replicas, 0 restarts across three components
+migrating at once. That last line is the advisory lock's first test against real
+network latency.
+
+Two measurements worth keeping:
+
+| | |
+|---|---|
+| **Over-provisioning** | 940m allocatable, ~845–931m requested, ~45–55m used — roughly **18× over-requested**. Full by reservation and idle by usage, which no amount of consolidation fixes and is precisely what Rightsizing exists to name. |
+| **Managed-node overhead** | system CPU per node min 301m, max 595m, mean 474m of 940m allocatable; kube-dns alone is 270m. Up to 63% of a 2 vCPU machine is gone before any workload lands. |
+
+**It did not execute a drain.** The cluster was 88.5% requested and there was
+nowhere to move pods to. Tracked as
+[#225](https://github.com/atedgimo/k8s-dencer/issues/225); `run.sh` now measures
+that before the window is spent rather than after.
+
+---
+
+[← Documentation index](README.md) · [Project README](../README.md)

--- a/test/docs/links_test.go
+++ b/test/docs/links_test.go
@@ -1,0 +1,151 @@
+// Package docs_test keeps the documentation navigable.
+//
+// Two failures this catches, both of which had already happened:
+//
+//   - benchmarks.md linked to internal/store/sqlite/sqlite.go for months after
+//     the two stores were unified into sqlstore. Nothing breaks, nothing warns;
+//     a reader following the one link that would have shown them the code gets
+//     a 404 instead.
+//   - the project README carried its own copy of the documentation table,
+//     which drifted until it was missing three files that existed. Two indexes
+//     is worse than one, because the wrong one is always the one you read.
+package docs_test
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// [text](path) and [text](path#anchor), skipping absolute URLs.
+var linkRE = regexp.MustCompile(`\[([^\]]*)\]\(([^)]+)\)`)
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	abs, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return abs
+}
+
+// markdownFiles returns the pages a reader actually navigates: the project
+// README and everything under docs/. Deliberately not every .md in the tree —
+// assets/ and hack/ carry their own local notes with their own conventions.
+func markdownFiles(t *testing.T) []string {
+	t.Helper()
+	root := repoRoot(t)
+	files := []string{filepath.Join(root, "README.md")}
+	entries, err := os.ReadDir(filepath.Join(root, "docs"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".md") {
+			files = append(files, filepath.Join(root, "docs", e.Name()))
+		}
+	}
+	return files
+}
+
+// Every relative link must point at something that exists.
+func TestEveryLinkResolves(t *testing.T) {
+	root := repoRoot(t)
+	for _, f := range markdownFiles(t) {
+		body, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, m := range linkRE.FindAllStringSubmatch(string(body), -1) {
+			link := m[2]
+			if strings.HasPrefix(link, "http://") ||
+				strings.HasPrefix(link, "https://") ||
+				strings.HasPrefix(link, "mailto:") ||
+				strings.HasPrefix(link, "#") {
+				continue
+			}
+			// Strip an anchor; the file is what has to exist.
+			if i := strings.IndexByte(link, '#'); i >= 0 {
+				link = link[:i]
+			}
+			if link == "" {
+				continue
+			}
+			target := filepath.Join(filepath.Dir(f), link)
+			if _, err := os.Stat(target); err != nil {
+				rel, _ := filepath.Rel(root, f)
+				t.Errorf("%s: [%s](%s) points at nothing", rel, m[1], m[2])
+			}
+		}
+	}
+}
+
+// Every page under docs/ must be reachable from the documentation index.
+//
+// A doc nobody links is a doc nobody reads, and it rots without anyone
+// noticing — which is a worse outcome than not having written it.
+func TestEveryDocIsInTheIndex(t *testing.T) {
+	root := repoRoot(t)
+	index, err := os.ReadFile(filepath.Join(root, "docs", "README.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(filepath.Join(root, "docs"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasSuffix(name, ".md") || name == "README.md" {
+			continue
+		}
+		if !strings.Contains(string(index), "("+name+")") &&
+			!strings.Contains(string(index), "("+name+"#") {
+			t.Errorf("docs/%s is not linked from docs/README.md — an unlinked doc "+
+				"is one nobody reads and nobody notices going stale", name)
+		}
+	}
+}
+
+// The project README must point at the index rather than duplicate it.
+//
+// It used to carry its own table of every document. That table drifted: by the
+// time anyone looked it was missing gcp-setup.md, findings.md and releases.md,
+// and a reader who trusted it never learned those existed.
+func TestTheReadmeDefersToTheIndex(t *testing.T) {
+	root := repoRoot(t)
+	body, err := os.ReadFile(filepath.Join(root, "README.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	readme := string(body)
+
+	if !strings.Contains(readme, "docs/README.md") {
+		t.Error("the README does not link the documentation index")
+	}
+
+	// Count distinct docs/*.md links in the README. A short signpost is the
+	// intent; a full second catalogue is the failure mode.
+	linked := map[string]bool{}
+	for _, m := range linkRE.FindAllStringSubmatch(readme, -1) {
+		if strings.HasPrefix(m[2], "docs/") && strings.HasSuffix(m[2], ".md") {
+			linked[m[2]] = true
+		}
+	}
+	entries, _ := os.ReadDir(filepath.Join(root, "docs"))
+	total := 0
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".md") && e.Name() != "README.md" {
+			total++
+		}
+	}
+	// Signposting most of them is fine and useful. Listing every single one,
+	// index included, means the README has become the index again.
+	if len(linked) > total {
+		t.Errorf("the README links %d docs of %d — it has grown back into a "+
+			"second index; keep it a signpost and let docs/README.md be the catalogue",
+			len(linked), total)
+	}
+}


### PR DESCRIPTION
Two problems, one shape: things had accumulated where they were first written rather than where they belong.

## The Status section was a changelog

**137 lines**, back to v0.5.0, on the page someone reads to decide whether to try this at all — longer than the problem statement, the safety model and the scale numbers put together.

Release notes move to **[docs/releases.md](docs/releases.md)**, where they can be as long as they need to be. What stays is the current state: which phase, what is published, the one upgrade note that matters *right now*, and — separated, because they are the two questions a reader actually has — **what is proven** and **what is not**.

Status is now 49 lines. The README is 428 → 335.

## There were two indexes

`docs/README.md` listed fifteen files flat, in no order. The README carried its own copy of the same table, which had drifted until it was **missing `gcp-setup.md` and `findings.md`** — and would have been missing `releases.md` the moment it existed. Two indexes is worse than one, because the wrong one is always the one you read.

Now `docs/README.md` is the catalogue, grouped by what you are trying to do:

| | |
|---|---|
| **Running it** | install · CLI · execution · auth · observability |
| **Understanding it** | architecture · benchmarks |
| **Working on it** | development · GCP setup · playground |
| **What happened** | releases · capabilities · milestones · findings |
| **Reference** | security policy · original design (historical) |

The README is a signpost to it, not a copy of it.

## One link was already broken

`benchmarks.md` pointed at `internal/store/sqlite/sqlite.go`, which stopped existing when the two stores were unified into `sqlstore`. Nothing warns about that — the one link that would have shown a reader the actual code was a 404 instead.

## Guards

Three, and I verified each one fails when it should rather than trusting that it would:

- every relative link in the README and `docs/` resolves
- every page under `docs/` is reachable from the index
- the README does not grow back into a second catalogue