### PR TITLE
Say where a finding holds capacity, not just how much

### DIFF
--- a/internal/recommend/recommend.go
+++ b/internal/recommend/recommend.go
@@ -72,6 +72,7 @@ func fromPlanReasons(plan *model.Plan, snap *model.ClusterSnapshot) []Recommenda
 	type group struct {
 		rec   Recommendation
 		steps map[int]bool
+		nodes map[string]bool
 		worst model.ImpactRating
 	}
 	groups := map[string]*group{}
@@ -96,12 +97,16 @@ func fromPlanReasons(plan *model.Plan, snap *model.ClusterSnapshot) []Recommenda
 						Why:      r.Detail,
 					},
 					steps: map[int]bool{},
+					nodes: map[string]bool{},
 					worst: step.Impact,
 				}
 				groups[key] = g
 				order = append(order, key)
 			}
 			g.steps[step.SequenceNumber] = true
+			if step.TargetNode != "" {
+				g.nodes[step.TargetNode] = true
+			}
 			if g.rec.Why == "" {
 				g.rec.Why = r.Detail
 			}
@@ -124,6 +129,7 @@ func fromPlanReasons(plan *model.Plan, snap *model.ClusterSnapshot) []Recommenda
 			g.rec.UnblocksSteps = append(g.rec.UnblocksSteps, seq)
 		}
 		sort.Ints(g.rec.UnblocksSteps)
+		g.rec.Pools = poolsOf(g.nodes, snap)
 		out = append(out, g.rec)
 	}
 	return out
@@ -158,6 +164,82 @@ type Recommendation struct {
 	// it, because only the plan knows; Build stays snapshot-pure. Empty
 	// means the finding is advice, not a blocker.
 	UnblocksSteps []int `json:"unblocksSteps,omitempty"`
+
+	// Pools names where those steps would reclaim capacity.
+	//
+	// "This PDB blocks three steps" is a quantity; "this PDB blocks three
+	// steps on your spot pool" is a decision, because spot is the capacity
+	// an operator is most willing to move work off and least willing to hold
+	// open for a budget written without thinking about it.
+	//
+	// Grouped by whatever the nodes actually say. A cluster with node-pool
+	// labels groups by pool and names its capacity type; a cluster with no
+	// pool labels but known capacity — the KWOK fabric, and any self-managed
+	// cluster — still groups by spot versus on-demand, because that is the
+	// half the operator acts on. Nothing known about a node means no entry:
+	// unlabelled is not a pool called "unknown", the same way an unpriced
+	// node is not a free one.
+	Pools []BlockedPool `json:"pools,omitempty"`
+}
+
+// BlockedPool is one group of nodes a finding holds capacity in.
+type BlockedPool struct {
+	// Name is the node-pool label, empty on a cluster that has none. An
+	// entry with no name is still worth showing when its capacity type is
+	// known — "2 spot" answers the question a pool name only decorates.
+	Name string `json:"name,omitempty"`
+	// CapacityType is "spot" or "on-demand", empty when the node says
+	// neither. Never guessed: spot is never reported as on-demand, and a
+	// node no cloud has labelled is reported as neither rather than as the
+	// cheaper-sounding one.
+	CapacityType string `json:"capacityType,omitempty"`
+	// Nodes in this group that the finding holds back.
+	Nodes int `json:"nodes"`
+}
+
+// poolsOf resolves blocked node names to the groups they belong to.
+//
+// Ordered most-nodes-first, then by name, so the group a finding costs most
+// reads first and the order is stable across cycles.
+func poolsOf(nodes map[string]bool, snap *model.ClusterSnapshot) []BlockedPool {
+	if len(nodes) == 0 || snap == nil {
+		return nil
+	}
+	byNode := make(map[string]*model.Node, len(snap.Nodes))
+	for i := range snap.Nodes {
+		byNode[snap.Nodes[i].Name] = &snap.Nodes[i]
+	}
+
+	seen := map[BlockedPool]int{}
+	for name := range nodes {
+		n := byNode[name]
+		if n == nil {
+			continue
+		}
+		key := BlockedPool{Name: n.Pool(), CapacityType: n.CapacityType()}
+		if key.Name == "" && key.CapacityType == "" {
+			// The node says nothing about where it belongs or how it is
+			// bought. An entry here would be a row that answers no question.
+			continue
+		}
+		seen[key]++
+	}
+
+	out := make([]BlockedPool, 0, len(seen))
+	for key, count := range seen {
+		key.Nodes = count
+		out = append(out, key)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Nodes != out[j].Nodes {
+			return out[i].Nodes > out[j].Nodes
+		}
+		if out[i].Name != out[j].Name {
+			return out[i].Name < out[j].Name
+		}
+		return out[i].CapacityType < out[j].CapacityType
+	})
+	return out
 }
 
 // Build derives recommendations from a snapshot and nothing else — same

--- a/internal/recommend/recommend_test.go
+++ b/internal/recommend/recommend_test.go
@@ -153,3 +153,216 @@ func TestQueueLeadsWithThePlansBlockingRules(t *testing.T) {
 		}
 	}
 }
+
+// A finding must say WHERE it costs capacity, not only how much.
+//
+// "This PDB blocks three steps" is useful. "This PDB blocks three steps on
+// your spot pool" is actionable: spot is the capacity an operator is most
+// willing to move work off, and least willing to hold open for a budget
+// written without thinking about it. Both facts were already on the node —
+// the well-known pool and capacity-type labels — and nothing joined them to
+// a finding until now.
+func TestAFindingNamesThePoolsItHoldsOpen(t *testing.T) {
+	web := map[string]string{"app": "web"}
+	spot := map[string]string{
+		"cloud.google.com/gke-nodepool": "burst",
+		"cloud.google.com/gke-spot":     "true",
+	}
+	// The instance-type label is what makes on-demand a fact rather than an
+	// assumption: CapacityType reports nothing at all for a node no cloud has
+	// labelled, and "not marked spot" is not evidence of on-demand.
+	steady := map[string]string{
+		"cloud.google.com/gke-nodepool":    "steady",
+		"node.kubernetes.io/instance-type": "e2-medium",
+	}
+
+	snap := &model.ClusterSnapshot{
+		Nodes: []model.Node{
+			{Name: "spot-1", Ready: true, Labels: spot,
+				Allocatable: model.Resources{MilliCPU: 4000, MemoryBytes: 1 << 33, Pods: 110}},
+			{Name: "spot-2", Ready: true, Labels: spot,
+				Allocatable: model.Resources{MilliCPU: 4000, MemoryBytes: 1 << 33, Pods: 110}},
+			{Name: "steady-1", Ready: true, Labels: steady,
+				Allocatable: model.Resources{MilliCPU: 4000, MemoryBytes: 1 << 33, Pods: 110}},
+		},
+		Pods: []model.Pod{
+			pod("shop", "web-1", "web", "Deployment", 500, web),
+			pod("shop", "web-2", "web", "Deployment", 500, web),
+			pod("shop", "web-3", "web", "Deployment", 500, web),
+		},
+	}
+
+	reason := func(subject string) []model.ImpactReason {
+		return []model.ImpactReason{{
+			Kind: "HardTopologySpread", Subject: subject,
+			Detail: "any move must keep the per-zone counts within 1",
+		}}
+	}
+	plan := &model.Plan{
+		NodesBefore: 3,
+		Steps: []model.PlanStep{
+			{SequenceNumber: 1, TargetNode: "spot-1", Impact: model.ImpactYellow, Reasons: reason("shop/web-1")},
+			{SequenceNumber: 2, TargetNode: "spot-2", Impact: model.ImpactYellow, Reasons: reason("shop/web-2")},
+			{SequenceNumber: 3, TargetNode: "steady-1", Impact: model.ImpactYellow, Reasons: reason("shop/web-3")},
+		},
+	}
+
+	head := recommend.Queue(plan, snap)[0]
+	if len(head.Pools) != 2 {
+		t.Fatalf("pools = %+v, want two", head.Pools)
+	}
+
+	// Most nodes first: the pool it costs most reads first.
+	if head.Pools[0].Name != "burst" || head.Pools[0].Nodes != 2 {
+		t.Errorf("pools[0] = %+v, want burst with 2 nodes first", head.Pools[0])
+	}
+	if head.Pools[0].CapacityType != "spot" {
+		t.Errorf("burst capacityType = %q, want spot — the labels say so and "+
+			"spot is the whole reason this distinction is worth drawing",
+			head.Pools[0].CapacityType)
+	}
+	if head.Pools[1].Name != "steady" || head.Pools[1].Nodes != 1 {
+		t.Errorf("pools[1] = %+v, want steady with 1 node", head.Pools[1])
+	}
+	if head.Pools[1].CapacityType != "on-demand" {
+		t.Errorf("steady capacityType = %q, want on-demand", head.Pools[1].CapacityType)
+	}
+}
+
+// An unlabelled node belongs to no pool, and must not be filed under one.
+//
+// The same doctrine as pricing: a node with no known price is unpriced, never
+// free. A node with no pool label is not in a pool called "unknown" — naming
+// one would put a finding against a group that does not exist, and send
+// somebody looking for it.
+func TestAnUnlabelledNodeIsNotAPool(t *testing.T) {
+	web := map[string]string{"app": "web"}
+	snap := &model.ClusterSnapshot{
+		Nodes: []model.Node{
+			{Name: "plain", Ready: true,
+				Allocatable: model.Resources{MilliCPU: 4000, MemoryBytes: 1 << 33, Pods: 110}},
+		},
+		Pods: []model.Pod{pod("shop", "web-1", "web", "Deployment", 500, web)},
+	}
+	plan := &model.Plan{
+		NodesBefore: 1,
+		Steps: []model.PlanStep{{
+			SequenceNumber: 1, TargetNode: "plain", Impact: model.ImpactYellow,
+			Reasons: []model.ImpactReason{{
+				Kind: "HardTopologySpread", Subject: "shop/web-1", Detail: "spread",
+			}},
+		}},
+	}
+
+	head := recommend.Queue(plan, snap)[0]
+	if len(head.Pools) != 0 {
+		t.Errorf("pools = %+v on an unlabelled cluster, want none — an invented "+
+			"pool name sends somebody looking for a group that does not exist",
+			head.Pools)
+	}
+	// The finding itself must survive; only the pool attribution is absent.
+	if len(head.UnblocksSteps) != 1 {
+		t.Errorf("the finding lost its steps: %+v", head.UnblocksSteps)
+	}
+}
+
+// A pool whose nodes are bought differently is reported as the split.
+//
+// The first design collapsed such a pool into one row with no capacity type,
+// on the grounds that picking one would be a coin-flip. True, but it threw
+// away a fact the cluster had already stated: one of these nodes is spot.
+// Grouping by (pool, capacity) instead says so — "mixed (spot) 1, mixed
+// (on-demand) 1" — without guessing anything.
+func TestAMixedPoolIsReportedAsItsSplit(t *testing.T) {
+	web := map[string]string{"app": "web"}
+	snap := &model.ClusterSnapshot{
+		Nodes: []model.Node{
+			{Name: "n1", Ready: true, Labels: map[string]string{
+				"cloud.google.com/gke-nodepool": "mixed",
+				"cloud.google.com/gke-spot":     "true",
+			}, Allocatable: model.Resources{MilliCPU: 4000, MemoryBytes: 1 << 33, Pods: 110}},
+			{Name: "n2", Ready: true, Labels: map[string]string{
+				"cloud.google.com/gke-nodepool":    "mixed",
+				"node.kubernetes.io/instance-type": "e2-medium",
+			}, Allocatable: model.Resources{MilliCPU: 4000, MemoryBytes: 1 << 33, Pods: 110}},
+		},
+		Pods: []model.Pod{
+			pod("shop", "web-1", "web", "Deployment", 500, web),
+			pod("shop", "web-2", "web", "Deployment", 500, web),
+		},
+	}
+	reason := func(s string) []model.ImpactReason {
+		return []model.ImpactReason{{Kind: "HardTopologySpread", Subject: s, Detail: "spread"}}
+	}
+	plan := &model.Plan{
+		NodesBefore: 2,
+		Steps: []model.PlanStep{
+			{SequenceNumber: 1, TargetNode: "n1", Impact: model.ImpactYellow, Reasons: reason("shop/web-1")},
+			{SequenceNumber: 2, TargetNode: "n2", Impact: model.ImpactYellow, Reasons: reason("shop/web-2")},
+		},
+	}
+
+	head := recommend.Queue(plan, snap)[0]
+	if len(head.Pools) != 2 {
+		t.Fatalf("pools = %+v, want one row per capacity type", head.Pools)
+	}
+	got := map[string]int{}
+	for _, p := range head.Pools {
+		if p.Name != "mixed" {
+			t.Errorf("pool name = %q, want mixed", p.Name)
+		}
+		got[p.CapacityType] = p.Nodes
+	}
+	if got["spot"] != 1 || got["on-demand"] != 1 {
+		t.Errorf("split = %v, want one spot and one on-demand", got)
+	}
+}
+
+// A cluster with no node-pool labels still says spot versus on-demand.
+//
+// Grouping only by pool name would report nothing at all on the KWOK fabric
+// and on any self-managed cluster — clusters that plainly know half their
+// nodes are spot, because the capacity-type label says so. The pool name is a
+// nicety; the capacity type is the thing an operator acts on.
+func TestCapacityTypeIsReportedWithoutAPoolLabel(t *testing.T) {
+	web := map[string]string{"app": "web"}
+	spot := map[string]string{"karpenter.sh/capacity-type": "spot"}
+	onDemand := map[string]string{"karpenter.sh/capacity-type": "on-demand"}
+	alloc := model.Resources{MilliCPU: 4000, MemoryBytes: 1 << 33, Pods: 110}
+
+	snap := &model.ClusterSnapshot{
+		Nodes: []model.Node{
+			{Name: "s1", Ready: true, Labels: spot, Allocatable: alloc},
+			{Name: "s2", Ready: true, Labels: spot, Allocatable: alloc},
+			{Name: "d1", Ready: true, Labels: onDemand, Allocatable: alloc},
+		},
+		Pods: []model.Pod{
+			pod("shop", "web-1", "web", "Deployment", 500, web),
+			pod("shop", "web-2", "web", "Deployment", 500, web),
+			pod("shop", "web-3", "web", "Deployment", 500, web),
+		},
+	}
+	reason := func(s string) []model.ImpactReason {
+		return []model.ImpactReason{{Kind: "HardTopologySpread", Subject: s, Detail: "spread"}}
+	}
+	plan := &model.Plan{
+		NodesBefore: 3,
+		Steps: []model.PlanStep{
+			{SequenceNumber: 1, TargetNode: "s1", Impact: model.ImpactYellow, Reasons: reason("shop/web-1")},
+			{SequenceNumber: 2, TargetNode: "s2", Impact: model.ImpactYellow, Reasons: reason("shop/web-2")},
+			{SequenceNumber: 3, TargetNode: "d1", Impact: model.ImpactYellow, Reasons: reason("shop/web-3")},
+		},
+	}
+
+	head := recommend.Queue(plan, snap)[0]
+	if len(head.Pools) != 2 {
+		t.Fatalf("pools = %+v, want spot and on-demand", head.Pools)
+	}
+	if head.Pools[0].CapacityType != "spot" || head.Pools[0].Nodes != 2 {
+		t.Errorf("pools[0] = %+v, want 2 spot nodes first", head.Pools[0])
+	}
+	if head.Pools[0].Name != "" {
+		t.Errorf("pool name = %q on a cluster with no pool labels, want empty",
+			head.Pools[0].Name)
+	}
+}

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -220,6 +220,22 @@ export interface Recommendation {
    * absent means the finding is advice, not a blocker.
    */
   unblocksSteps?: number[];
+  /**
+   * The node groups those steps would reclaim, most-nodes-first.
+   *
+   * "Blocks three steps" is a quantity; "blocks three steps on your spot
+   * pool" is a decision. Absent when no blocked node carries a pool label —
+   * unlabelled is not a pool called "unknown".
+   */
+  pools?: BlockedPool[];
+}
+
+/** One node group a finding holds capacity in. */
+export interface BlockedPool {
+  name: string;
+  /** "spot" | "on-demand", absent when the node says neither. Never guessed. */
+  capacityType?: string;
+  nodes: number;
 }
 
 const base = () => runtimeConfig().apiBaseUrl;

--- a/ui/src/components/recs/RecsPage.tsx
+++ b/ui/src/components/recs/RecsPage.tsx
@@ -10,7 +10,7 @@
  */
 
 import { useEffect, useMemo, useState } from "react";
-import { GraphPayload, PlanStep, Recommendation, api, formatCPU } from "../../api";
+import { BlockedPool, GraphPayload, PlanStep, Recommendation, api, formatCPU } from "../../api";
 import { findingKey } from "../../useMuted";
 
 interface Props {
@@ -219,6 +219,12 @@ export default function RecsPage({
                     {worth > 0 && (
                       <span className="recsrow-worth mono">{formatCPU(worth)} cores</span>
                     )}
+                    {/* Where the capacity is held, not just how much. Spot
+                        first when the finding touches both, because that is
+                        the pool an operator is most willing to act on. */}
+                    {r.pools && r.pools.length > 0 && (
+                      <span className="recsrow-pools mono">{poolSummary(r.pools)}</span>
+                    )}
                   </span>
                 </button>
               );
@@ -389,6 +395,26 @@ function Detail({
 }
 
 /** ns/Kind/name → name, the part an operator scans for. */
+/**
+ * The pools a finding holds open, in one line.
+ *
+ * "burst (spot)" reads as a place to go and look; "2 pools" reads as a
+ * number. Capacity type is only ever printed when the node actually said so
+ * — a pool whose nodes disagree, or that no cloud has labelled, carries no
+ * suffix rather than a guessed one.
+ */
+function poolSummary(pools: BlockedPool[]): string {
+  const shown = pools.slice(0, 2).map((p) => {
+    // A cluster with pool labels gets "burst (spot)". One without still gets
+    // "spot", which is the half an operator acts on. Neither known means the
+    // engine sent no entry at all, so there is no third case here.
+    if (p.name && p.capacityType) return `${p.name} (${p.capacityType})`;
+    return p.name || p.capacityType;
+  });
+  const rest = pools.length - shown.length;
+  return rest > 0 ? `${shown.join(", ")} +${rest}` : shown.join(", ");
+}
+
 function shortName(workload: string): string {
   const parts = workload.split("/");
   return parts[parts.length - 1] ?? workload;

--- a/ui/src/styles/recs.css
+++ b/ui/src/styles/recs.css
@@ -209,6 +209,14 @@
   color: var(--accent-text);
 }
 
+/* Where the finding holds capacity. Quieter than the step count, which is
+   the ranking key, but readable — it is the half that makes the row a
+   decision rather than a quantity. */
+.recsrow-pools {
+  font-size: var(--text-2xs);
+  color: var(--text-4);
+}
+
 .recsrow-worth {
   font-size: var(--text-2xs);
   color: var(--text-faint);


### PR DESCRIPTION
Closes #223.

"This PDB blocks three steps" is a quantity. "This PDB blocks three steps **on your spot pool**" is a decision — spot is the capacity an operator is most willing to move work off, and least willing to hold open for a budget written without thinking about it.

Both facts were already on the node: `Pool()` and `CapacityType()` read the well-known labels, findings already carried the steps they block, and nothing had ever joined them.

## What changed after checking against a real cluster

The first version grouped by node-pool label alone. The KWOK fabric **has no pool labels** — so it would have reported nothing at all on a cluster that plainly knows six of its nodes are spot. I only found that by looking at the live cluster instead of my own fixture.

The pool name is a nicety; the capacity type is what gets acted on. So it now groups by whatever the nodes actually say:

| Cluster says | Reported as |
|---|---|
| pool + capacity | `burst (spot)` |
| capacity only | `spot` |
| neither | no entry |

**Unlabelled is not a pool called "unknown."** Naming one would file a finding against a group that does not exist and send somebody looking for it — the same doctrine that reports an unpriced node as unpriced rather than free.

**A mixed pool reports its split** rather than declining to speak. An earlier draft collapsed one spot + one on-demand into a single row with no capacity type, on the grounds that picking one would be a coin-flip. True, but it threw away a fact the cluster had already stated.

## Verified

Against the live cluster, not just unit tests — four blocking rules, each naming the capacity it holds, rendered on the Recommendations queue:

```
HardTopologySpread/dencer-demo-web       3 steps  24 cores  on-demand, spot
StatefulWorkload/dencer-demo-ledgerdb    3 steps  24 cores  on-demand, spot
RequiredAntiAffinity/dencer-demo-broker  2 steps  16 cores  on-demand
UnmanagedPod/dencer-demo-debug-shell     1 step    8 cores  on-demand
```