### PR TITLE
Say what the History bars have been saying

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,7 @@ jobs:
       # Density mode reads optional fields; a field that stops arriving renders
       # as zero rather than failing, so the arithmetic is asserted directly.
       - run: npm run test:density
+      - run: npm run test:trend
       # A build failure is a real failure: the frontend ships as a static
       # bundle, so anything tsc lets through still has to survive Vite.
       - run: npm run build

--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ build: ## Compile the Go binaries locally
 test: ## Run Go and UI tests
 	go vet ./...
 	go test ./...
-	cd ui && npm run typecheck && npm run test:density
+	cd ui && npm run typecheck && npm run test:density && npm run test:trend
 
 .PHONY: images
 images: ## Build native-arch images for the local cluster

--- a/ui/package.json
+++ b/ui/package.json
@@ -9,7 +9,8 @@
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "typecheck": "tsc -b --noEmit",
-    "test:density": "esbuild test/density.ts --bundle --platform=node --format=cjs --outfile=node_modules/.cache/density.cjs --log-level=error && node node_modules/.cache/density.cjs"
+    "test:density": "esbuild test/density.ts --bundle --platform=node --format=cjs --outfile=node_modules/.cache/density.cjs --log-level=error && node node_modules/.cache/density.cjs",
+    "test:trend": "esbuild test/trend.ts --bundle --platform=node --format=cjs --outfile=node_modules/.cache/trend.cjs --log-level=error && node node_modules/.cache/trend.cjs"
   },
   "dependencies": {
     "@fontsource-variable/ibm-plex-sans": "^5.3.0",

--- a/ui/src/components/History.tsx
+++ b/ui/src/components/History.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { HistoryResponse, api, formatCPU } from "../api";
+import { estateTrend, windowLabel } from "../trend";
 
 /**
  * History (assets/design/README.md, 2e): the estate over time as needed vs
@@ -83,6 +84,46 @@ export default function History({ pricing }: { pricing?: Pricing }) {
   );
 }
 
+/* ----------------------------------------------------------- estate trend */
+
+/**
+ * What the bars have been saying, in a sentence.
+ *
+ * The chart above shows the shape and never states it. This is the line
+ * somebody quotes in a budget conversation, which is exactly why it declines
+ * to speak on a window too short to support it.
+ *
+ * Reservation and usage stay separate on purpose. The GKE run measured ~890m
+ * requested against ~50m used of 940m allocatable — full by reservation and
+ * idle by usage. Consolidation only addresses the first; collapsing both into
+ * one "over-provisioned" number would point an operator at the wrong lever.
+ */
+function EstateTrend({ data }: { data: HistoryResponse }) {
+  const trend = useMemo(() => estateTrend(data.samples), [data]);
+  if (!trend) return null;
+
+  const period = windowLabel(trend.hours);
+  return (
+    <p className="estate-trend">
+      Over the past <strong>{period}</strong> your workloads reserved{" "}
+      <strong>{Math.round(trend.reservedPct)}%</strong> of the fleet
+      {trend.usedPct === undefined ? (
+        <>
+          . Usage is unmeasured, so how much of that was needed is unknown —
+          set <code>planner.usageSource</code> to find out.
+        </>
+      ) : (
+        <>
+          {" "}
+          and used <strong>{Math.round(trend.usedPct)}%</strong> of it. Reserved
+          capacity is held whether or not it is used, so the gap is a
+          right-sizing question rather than a consolidation one.
+        </>
+      )}
+    </p>
+  );
+}
+
 /* ------------------------------------------------------------ estate bars */
 
 const BUCKETS = 48;
@@ -143,6 +184,8 @@ function EstateBars({ data }: { data: HistoryResponse }) {
           </span>
         </div>
       </div>
+
+      <EstateTrend data={data} />
 
       <div className="estate-chart">
         <div className="estate-yaxis mono" aria-hidden="true">

--- a/ui/src/styles/history.css
+++ b/ui/src/styles/history.css
@@ -94,6 +94,26 @@
   background: var(--caution);
 }
 
+/* The sentence the bars have been implying. Sits between the headline and
+   the chart because it is the reading, not a footnote to it. */
+.estate-trend {
+  margin: 0 0 var(--space-4);
+  max-width: 68ch;
+  font-size: var(--text-sm);
+  line-height: 1.55;
+  color: var(--text-3);
+}
+
+.estate-trend strong {
+  font-weight: 600;
+  color: var(--text-1);
+}
+
+.estate-trend code {
+  font-size: var(--text-xs);
+  color: var(--text-4);
+}
+
 .estate-chart {
   display: flex;
   align-items: flex-end;

--- a/ui/src/trend.ts
+++ b/ui/src/trend.ts
@@ -1,0 +1,92 @@
+/**
+ * What the stored samples say about the estate over time.
+ *
+ * History already draws needed-versus-spare bars and never says what they
+ * mean. "Your fleet has been 89% reserved and 6% used for the past six days"
+ * is the sentence that gets a budget conversation started, and every number
+ * in it is already in the store.
+ *
+ * Two claims, deliberately kept apart, because the GKE run showed how easily
+ * they are confused: on `e2-medium` nodes the fleet was ~890m requested and
+ * ~50m used of 940m allocatable — **full by reservation and idle by usage**.
+ * Consolidation only ever addresses the first. Collapsing both into one
+ * "over-provisioned" percentage would point an operator at the wrong lever,
+ * which is exactly the confusion Rightsizing exists to clear up.
+ *
+ * And it declines to speak when it cannot. A trend drawn over four hours of
+ * samples is not a trend; a window where measurement started halfway through
+ * is two different claims averaged together.
+ */
+import type { HistorySample } from "./api";
+
+export interface EstateTrend {
+  /** Hours actually covered by the samples, not the range that was asked for. */
+  hours: number;
+  samples: number;
+  /** Requests as a percentage of allocatable, meaned over the window. */
+  reservedPct: number;
+  /**
+   * Measured usage as a percentage of allocatable. Absent unless every
+   * sample in the window carried a measurement — a window that begins
+   * unmeasured and ends measured would otherwise report the average of a
+   * real number and a zero that only meant "nobody was looking".
+   */
+  usedPct?: number;
+}
+
+/**
+ * A trend needs a window long enough to be one.
+ *
+ * Half a day, and enough points to have watched it rather than glanced twice.
+ * Both are floors rather than targets: the sentence names the window it
+ * actually had, so a reader weighs a claim made over half a day differently
+ * from one made over a month.
+ *
+ * Twelve rather than twenty-four because the shortest range the History
+ * screen offers IS twenty-four hours, and the samples inside a window always
+ * span slightly less than the window itself — a 7-day range measures 167.99
+ * hours, a 24-hour one just under 24. A floor equal to the smallest
+ * selectable range would refuse on that range every time, by a rounding
+ * error, which is the least defensible reason to say nothing.
+ */
+export const MIN_HOURS = 12;
+export const MIN_SAMPLES = 12;
+
+export function estateTrend(samples: HistorySample[]): EstateTrend | null {
+  // A sample from a moment when the fleet reported no allocatable CPU says
+  // nothing about reservation, and dividing by it says something false.
+  const usable = samples.filter((s) => s.cpuAllocMilli > 0);
+  if (usable.length < MIN_SAMPLES) return null;
+
+  const t0 = Date.parse(usable[0].takenAt);
+  const t1 = Date.parse(usable[usable.length - 1].takenAt);
+  const hours = (t1 - t0) / 36e5;
+  if (!Number.isFinite(hours) || hours < MIN_HOURS) return null;
+
+  const mean = (f: (s: HistorySample) => number) =>
+    usable.reduce((acc, s) => acc + f(s), 0) / usable.length;
+
+  const reservedPct = mean((s) => (s.cpuReqMilli / s.cpuAllocMilli) * 100);
+
+  const measuredThroughout = usable.every((s) => s.hasUsage);
+  const usedPct = measuredThroughout
+    ? mean((s) => (s.cpuUsedMilli / s.cpuAllocMilli) * 100)
+    : undefined;
+
+  return {
+    hours,
+    samples: usable.length,
+    reservedPct,
+    usedPct,
+  };
+}
+
+/** "6 days" / "31 hours" — the window, in the unit a person would say it in. */
+export function windowLabel(hours: number): string {
+  if (hours >= 48) {
+    const d = Math.round(hours / 24);
+    return `${d} day${d === 1 ? "" : "s"}`;
+  }
+  const h = Math.round(hours);
+  return `${h} hour${h === 1 ? "" : "s"}`;
+}

--- a/ui/test/trend.ts
+++ b/ui/test/trend.ts
@@ -1,0 +1,135 @@
+/**
+ * Estate-trend arithmetic, and the cases where it must refuse to answer.
+ *
+ * Same shape as density.ts: no test runner in this project's UI, esbuild is
+ * already here for the build, so this bundles and runs under node.
+ *
+ * The refusals matter more than the arithmetic. A trend sentence is the one
+ * thing on the History screen a person would quote in a budget conversation,
+ * so a wrong one travels further than any other bug in this product — and
+ * every wrong version of it is a plausible-looking percentage rather than a
+ * blank space.
+ *
+ *   npm run test:trend
+ */
+import { estateTrend, windowLabel, MIN_HOURS, MIN_SAMPLES } from "../src/trend";
+import type { HistorySample } from "../src/api";
+
+let failures = 0;
+const check = (label: string, got: unknown, want: unknown) => {
+  const ok = JSON.stringify(got) === JSON.stringify(want);
+  if (!ok) {
+    failures++;
+    console.log(`  FAIL ${label}: got ${JSON.stringify(got)} want ${JSON.stringify(want)}`);
+  } else console.log(`  ok   ${label} = ${JSON.stringify(got)}`);
+};
+
+const HOUR = 36e5;
+
+/** n samples, one per hour, with the given reservation and usage fractions. */
+const series = (
+  n: number,
+  opts: { reqFrac: number; usedFrac?: number; alloc?: number } = { reqFrac: 0.9 },
+): HistorySample[] => {
+  const alloc = opts.alloc ?? 940;
+  const start = Date.parse("2026-08-01T00:00:00Z");
+  return Array.from({ length: n }, (_, i) => ({
+    takenAt: new Date(start + i * HOUR).toISOString(),
+    nodes: 6,
+    pods: 40,
+    cpuReqMilli: Math.round(alloc * opts.reqFrac),
+    cpuAllocMilli: alloc,
+    memReqBytes: 0,
+    memAllocBytes: 0,
+    cpuUsedMilli: opts.usedFrac === undefined ? 0 : Math.round(alloc * opts.usedFrac),
+    memUsedBytes: 0,
+    hasUsage: opts.usedFrac !== undefined,
+    reclaimable: 1,
+  }));
+};
+
+// ---------------------------------------------------------------- refusals
+
+// Four hours of samples is not six weeks of evidence, and the difference is
+// the entire worth of the sentence.
+check("a short window says nothing", estateTrend(series(5, { reqFrac: 0.9 })), null);
+
+// Two readings a fortnight apart span a long time and observed almost none of
+// it. The span test alone would have let this through.
+const sparse = [series(1)[0], { ...series(1)[0], takenAt: "2026-08-15T00:00:00Z" }];
+check("a long span with too few points says nothing", estateTrend(sparse), null);
+
+check("exactly at the floor is not enough on its own", estateTrend(series(MIN_SAMPLES - 1)), null);
+
+// --------------------------------------------------------------- the claim
+
+const measured = estateTrend(series(30, { reqFrac: 0.9, usedFrac: 0.05 }))!;
+check("the window is the one actually observed, in hours", Math.round(measured.hours), 29);
+check("samples are counted", measured.samples, 30);
+check("reserved is requests over allocatable", Math.round(measured.reservedPct), 90);
+check("used is measured usage over allocatable", Math.round(measured.usedPct!), 5);
+
+// The GKE shape: full by reservation, idle by usage. The two numbers must
+// stay apart -- collapsing them into one "over-provisioned" percentage points
+// an operator at consolidation when the lever is right-sizing.
+check(
+  "reservation and usage are not the same number",
+  measured.reservedPct > 80 && measured.usedPct! < 10,
+  true,
+);
+
+// ------------------------------------------------------- unmeasured usage
+
+const unmeasured = estateTrend(series(30, { reqFrac: 0.9 }))!;
+check("reservation still reported without a usage source", Math.round(unmeasured.reservedPct), 90);
+check("usage is absent, not zero", unmeasured.usedPct, undefined);
+
+// A window that begins unmeasured and ends measured would otherwise average a
+// real number against a zero that only ever meant "nobody was looking" --
+// reporting, say, 2.5% usage for a cluster that was at 5% the whole time it
+// was watched.
+const halfMeasured = [
+  ...series(15, { reqFrac: 0.9 }),
+  ...series(15, { reqFrac: 0.9, usedFrac: 0.05 }),
+].map((s, i) => ({ ...s, takenAt: new Date(Date.parse("2026-08-01T00:00:00Z") + i * HOUR).toISOString() }));
+check(
+  "a window only half measured reports no usage rather than half of it",
+  estateTrend(halfMeasured)!.usedPct,
+  undefined,
+);
+
+// --------------------------------------------------------- divide-by-zero
+
+// A moment when the fleet reported no allocatable CPU says nothing about
+// reservation, and dividing by it says something false (Infinity, which
+// renders as a very confident percentage).
+const withZeroes = [
+  ...series(30, { reqFrac: 0.9, usedFrac: 0.05 }),
+  { ...series(1)[0], cpuAllocMilli: 0, takenAt: "2026-08-03T00:00:00Z" },
+];
+const survived = estateTrend(withZeroes)!;
+check("a zero-allocatable sample is skipped, not divided by", Number.isFinite(survived.reservedPct), true);
+check("and it does not distort the mean", Math.round(survived.reservedPct), 90);
+
+// ------------------------------------------------------------ the wording
+
+check("two days reads as days", windowLabel(48), "2 days");
+check("six days reads as days", windowLabel(24 * 6), "6 days");
+check("one day still reads in hours, where it is honest about being short", windowLabel(30), "30 hours");
+check("singular hour", windowLabel(1), "1 hour");
+check("the floor is half a day", MIN_HOURS, 12);
+
+// The boundary that prompted the floor to move. Samples inside a window span
+// slightly less than the window: measured against the live API, a 7-day range
+// covers 167.99 hours and a 24-hour range just under 24. A floor equal to the
+// smallest selectable range would therefore refuse on that range every time,
+// by a rounding error.
+const aDay = series(24, { reqFrac: 0.9 }).slice(0, 24);
+check(
+  "a 24h range, which spans just under 24h, still gets a sentence",
+  estateTrend(aDay) !== null,
+  true,
+);
+
+console.log(failures === 0 ? "\nALL TREND CHECKS PASSED" : `\n${failures} FAILURES`);
+process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
Closes #224.

History draws needed-versus-spare over time and never states it. *"Over the past 16 days your workloads reserved 28% of the fleet"* is the line somebody quotes in a budget conversation, and every number in it was already in the store — no new collection, no new endpoint.

## Reservation and usage stay separate

The GKE run measured **~890m requested against ~50m used** of 940m allocatable — full by reservation and idle by usage. Consolidation only ever addresses the first. Collapsing both into a single "over-provisioned" percentage would point an operator at the wrong lever, which is exactly the confusion Rightsizing exists to clear up.

So the sentence says both, or says it cannot:

> Over the past **16 days** your workloads reserved **28%** of the fleet and used **6%** of it. Reserved capacity is held whether or not it is used, so the gap is a right-sizing question rather than a consolidation one.

## The refusals matter more than the arithmetic

A trend sentence travels further than any other number in this product, so every wrong version of it is a plausible-looking percentage rather than a blank space.

- **fewer than 12 samples, or a window under 12 hours** → no sentence. A trend over four hours is not a trend, and two readings a fortnight apart span a long time while observing almost none of it (the span check alone would have let that through).
- **usage measured for only part of the window** → reports *no* usage rather than the average of a real number and a zero that only meant "nobody was looking".
- **a sample with zero allocatable** → skipped, not divided by. Otherwise `Infinity`, which renders as a very confident percentage.

## Why the floor is 12 hours, not 24

Samples inside a window span slightly *less* than the window — measured against the live API, a 7-day range covers 167.99 hours. A floor equal to the smallest selectable range (24h) would refuse on that range every time, by a rounding error, which is the least defensible reason to say nothing.

## Testing

Same shape as `density.ts` — esbuild bundles it, node runs it. No test runner added for one pure function. Wired into `make test` and CI.

Verified against the live cluster, which has no usage source configured and therefore exercises the honest branch.