### PR TITLE
Tell someone a plan exists

### DIFF
--- a/charts/k8s-dencer/templates/planner/deployment.yaml
+++ b/charts/k8s-dencer/templates/planner/deployment.yaml
@@ -87,6 +87,31 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            {{- /*
+              The cluster's own label, read from uiBackend.clusterLabel rather
+              than duplicated here. It is one fact about the cluster, and two
+              places to set it is two places to set it differently -- a
+              notification that says "prod" about staging is worse than one
+              that says nothing.
+            */}}
+            {{- with .Values.uiBackend.clusterLabel }}
+            - name: CLUSTER_LABEL
+              value: {{ . | quote }}
+            {{- end }}
+            {{- if (.Values.planner.notify).existingSecret }}
+            - name: NOTIFY_WEBHOOK_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ (.Values.planner.notify).existingSecret }}
+                  key: {{ (.Values.planner.notify).secretKey | default "url" }}
+            {{- else if (.Values.planner.notify).url }}
+            - name: NOTIFY_WEBHOOK_URL
+              value: {{ (.Values.planner.notify).url | quote }}
+            {{- end }}
+            {{- with (.Values.planner.notify).linkUrl }}
+            - name: NOTIFY_LINK_URL
+              value: {{ . | quote }}
+            {{- end }}
             {{- with .Values.planner.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/k8s-dencer/values.yaml
+++ b/charts/k8s-dencer/values.yaml
@@ -157,6 +157,35 @@ planner:
   # volume is a fixed size; identical plans are deduplicated on their content
   # hash, so this counts distinct plans rather than planning cycles.
   retainPlans: 200
+
+  # Tell someone a plan exists, instead of waiting to be visited.
+  #
+  # The planner POSTs a small JSON body to an operator-supplied endpoint when
+  # something changes that a person would want to know about: safe steps
+  # appearing where there were none, and an actionable plan being replaced.
+  # Transitions only -- a message every resync is a message nobody reads.
+  #
+  # What leaves the cluster is a plan id, four counts, a link and a sentence.
+  # Never the plan: that is behind authentication and stays there, because a
+  # webhook endpoint is readable by anyone holding the URL and a chat channel
+  # is not an authorization boundary.
+  #
+  # This is the only outbound connection any component makes. A NetworkPolicy
+  # that restricts planner egress has to allow it, and a failure to deliver is
+  # logged and dropped -- it can never fail a planning cycle.
+  notify:
+    # Prefer existingSecret. A webhook URL is a bearer credential: anyone with
+    # it can post to your channel, and values end up in `helm get values`.
+    url: ""
+    existingSecret: ""
+    secretKey: url
+
+    # Where the UI is reachable, so the message can point at it. Empty means
+    # the message carries no link rather than a guessed one.
+    #
+    #   linkUrl: https://dencer.internal.example.com
+    linkUrl: ""
+
   resources:
     requests:
       cpu: 50m

--- a/cmd/planner/main.go
+++ b/cmd/planner/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/atedgimo/k8s-dencer/internal/cluster/metrics"
 	"github.com/atedgimo/k8s-dencer/internal/httpserver"
 	"github.com/atedgimo/k8s-dencer/internal/impact"
+	"github.com/atedgimo/k8s-dencer/internal/notify"
 	"github.com/atedgimo/k8s-dencer/internal/planner"
 	"github.com/atedgimo/k8s-dencer/internal/publish"
 	sqlitestore "github.com/atedgimo/k8s-dencer/internal/store/sqlstore"
@@ -117,6 +118,22 @@ func run(ctx context.Context, log *slog.Logger) error {
 		DB:      db,
 		Retain:  intEnv(log, "RETAIN_PLANS", 200),
 		Metrics: metrics,
+		// Off unless an operator supplied a URL. NewWebhook returns nil for
+		// an empty one, and a Notifier with a nil Sink is a no-op -- so the
+		// unconfigured path is the same code, not a branch around it.
+		Notify: &notify.Notifier{
+			Sink:    notify.NewWebhook(os.Getenv("NOTIFY_WEBHOOK_URL")),
+			Log:     log,
+			Cluster: os.Getenv("CLUSTER_LABEL"),
+			BaseURL: os.Getenv("NOTIFY_LINK_URL"),
+		},
+	}
+	if os.Getenv("NOTIFY_WEBHOOK_URL") != "" {
+		// Worth one line at startup: this is the only thing the planner does
+		// that leaves the cluster, and an operator should be able to confirm
+		// it is on without reading a Secret. The URL itself is never logged
+		// -- a webhook URL is a bearer credential.
+		log.Info("plan notifications enabled")
 	}
 
 	health := &httpserver.Health{}

--- a/docs/install.md
+++ b/docs/install.md
@@ -230,6 +230,95 @@ by switching — the planner rebuilds its plan on the next resync, and the
 savings ledger starts recording from the switch — but the history before the
 switch does not come with it.
 
+### Going back to SQLite
+
+`helm upgrade` in that direction fails, once, on the Deployment strategy:
+
+```
+spec.strategy.rollingUpdate: Forbidden: may not be specified when strategy `type` is 'Recreate'
+```
+
+Postgres lets the ui-backend roll; SQLite cannot, because a rolling update
+would briefly run two writers against one ReadWriteOnce file. The API server
+defaults a `rollingUpdate` block onto a RollingUpdate Deployment, server-side
+apply merges rather than replaces, and the leftover block is illegal beside
+`type: Recreate`.
+
+The chart cannot fix it — Helm owns `strategy.type` and not the block the API
+server added. Clear it and the type together, in one operation, then upgrade:
+
+```bash
+kubectl -n k8s-dencer patch deploy k8s-dencer-ui-backend --type=merge \
+  -p '{"spec":{"strategy":{"type":"Recreate","rollingUpdate":null}}}'
+```
+
+Removing `rollingUpdate` on its own does nothing: while the type is still
+RollingUpdate the API server immediately puts it back.
+
+## Being told, instead of remembering to look
+
+The planner can POST a small JSON body to an endpoint you supply when
+something changes that a person would want to know about. It is off by
+default: this is the only outbound connection any component makes.
+
+```yaml
+planner:
+  notify:
+    # A webhook URL is a bearer credential — anyone holding it can post to
+    # your channel, and inline values show up in `helm get values`.
+    existingSecret: dencer-webhook   # key: url
+    linkUrl: https://dencer.internal.example.com
+```
+
+```bash
+kubectl -n k8s-dencer create secret generic dencer-webhook \
+  --from-literal=url='https://hooks.example.com/services/...'
+```
+
+**Transitions only.** Two of them:
+
+| | |
+|---|---|
+| `plan.actionable` | safe steps exist where a moment ago there were none |
+| `plan.superseded` | a plan that had safe steps has been replaced |
+
+Not a heartbeat. A message every resync is a message nobody reads, and once
+people build a filter for it the one that mattered is filtered too.
+
+**What leaves the cluster** is a plan id, four counts, your `clusterLabel`, a
+link and a sentence:
+
+```json
+{
+  "kind": "plan.actionable",
+  "planId": "823b6dad6576",
+  "cluster": "orbstack-lab",
+  "safeSteps": 9,
+  "totalSteps": 10,
+  "nodesBefore": 17,
+  "nodesAfter": 7,
+  "link": "https://dencer.internal.example.com",
+  "text": "k8s-dencer on orbstack-lab: 9 steps can be run safely — 17 nodes now, 7 after. Nothing has been executed."
+}
+```
+
+Never the plan itself. No node names, no workload names, no rationale. The
+plan is behind authentication and stays there — a webhook endpoint is readable
+by anyone who has the URL, and a chat channel is not an authorization
+boundary. The link is useless without a token.
+
+**It cannot fail a planning cycle.** Every send is off the cycle's goroutine,
+bounded by a five-second timeout with one retry, and a dead endpoint costs a
+log line. A planner that stopped planning because a chat server was down would
+be a worse product than one that never notified.
+
+Two consequences worth knowing:
+
+- A planner restart re-announces an actionable plan once, because the
+  "was there anything safe last time" state is per-process. A duplicate is
+  recoverable; a missed message is the thing this exists to prevent.
+- If you restrict planner egress with a NetworkPolicy, it has to allow this.
+
 ## Known constraints
 
 - **SQLite is single-writer.** `uiBackend.replicaCount` is pinned to 1 and enforced by the schema; the planner is co-scheduled with ui-backend via a `requiredDuringScheduling` podAffinity, because a ReadWriteOnce claim only permits multiple pods on the same node. Both constraints are lifted by `database.type=postgres` (above) — and only by that; they are properties of the file, not preferences.

--- a/hack/lint-chart.sh
+++ b/hack/lint-chart.sh
@@ -430,5 +430,31 @@ if ! helm template dencer "$CHART" --set serviceMonitor.enabled=true \
 fi
 green "  monitoring namespace admitted when scraped"
 
+bold "==> contract: notifications are off, secret-friendly, and nil-safe"
+# The only outbound connection any component makes, so all three properties
+# are contract rather than preference.
+if render defaults | grep -q 'name: NOTIFY_WEBHOOK_URL'; then
+  fail "notifications are configured by default; reaching outward must be opt-in"
+fi
+green "  off unless asked for"
+
+# A webhook URL is a bearer credential: anyone holding it can post to the
+# channel. The secret path must not fall back to an inline value.
+secret_env="$(helm template dencer "$CHART" \
+  --set planner.notify.existingSecret=hook --set planner.notify.url=https://inline.example \
+  | awk '/name: NOTIFY_WEBHOOK_URL/,/key:/')"
+grep -q 'secretKeyRef' <<<"$secret_env" \
+  || fail "existingSecret did not produce a secretKeyRef"
+grep -q 'inline.example' <<<"$secret_env" \
+  && fail "existingSecret was set and the inline URL leaked into the manifest anyway"
+green "  existingSecret wins over an inline url"
+
+# helm upgrade --reuse-values carries stored values forward WITHOUT merging
+# defaults for keys added since. v0.8.1 shipped a chart that could not render
+# at all for exactly this reason, one release after the same mistake.
+helm template dencer "$CHART" --set planner.notify=null >/dev/null 2>&1 \
+  || fail "the chart cannot render when planner.notify is absent; --reuse-values upgrades will fail"
+green "  renders when the whole notify block is missing"
+
 green "
 All chart contract checks passed."

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -1,0 +1,272 @@
+// Package notify tells someone a plan exists.
+//
+// Until now this product required a human to open a browser and look. That
+// fits the premise — it produces the plan and stops — but the premise is
+// about not *acting* without a human, not about being invisible. Telling
+// someone a plan exists is not executing it.
+//
+// Three deliberate limits, because this is the first thing in the product
+// that reaches outward:
+//
+//   - It sends transitions, never a heartbeat. A message every resync is a
+//     message nobody reads, and the fifth one is worse than none.
+//   - It sends an id, counts and a link — never the plan. The plan is behind
+//     authentication and stays there; a webhook endpoint is a URL anyone who
+//     has it can read, and a chat channel is not an authorization boundary.
+//   - It cannot fail a planning cycle. Every send is off the cycle's
+//     goroutine, bounded by a timeout, and a dead endpoint costs a log line.
+//     A consolidation planner that stops planning because a chat server is
+//     down would be a worse product than one that never notified at all.
+package notify
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Kind is what happened. Deliberately few: each one has to earn an
+// interruption.
+type Kind string
+
+const (
+	// KindActionable: safe steps exist where a moment ago there were none.
+	// The one message worth waking a channel for — it means there is
+	// something to approve.
+	KindActionable Kind = "plan.actionable"
+
+	// KindSuperseded: a plan that had safe steps has been replaced. Anyone
+	// part-way through reviewing the old one is now looking at history, and
+	// the executor will refuse it.
+	KindSuperseded Kind = "plan.superseded"
+)
+
+// Event is everything that leaves the cluster.
+//
+// No node names, no workload names, no rationale. Someone who should not see
+// the cluster's shape learns that a cluster somewhere has a plan with three
+// safe steps, and that is all — the link is useless without a token.
+type Event struct {
+	Kind   Kind      `json:"kind"`
+	PlanID string    `json:"planId"`
+	At     time.Time `json:"at"`
+
+	// Cluster is the operator's own label for this cluster, so a channel
+	// receiving from several can tell them apart. Empty when unset.
+	Cluster string `json:"cluster,omitempty"`
+
+	SafeSteps  int `json:"safeSteps"`
+	TotalSteps int `json:"totalSteps"`
+	// NodesBefore and NodesAfter are the fleet, so "6 to 2" reads without
+	// anyone having to open anything.
+	NodesBefore int `json:"nodesBefore"`
+	NodesAfter  int `json:"nodesAfter"`
+
+	// Link points at the UI, when the operator has said where it is.
+	Link string `json:"link,omitempty"`
+
+	// Text is the same thing in a sentence. Chat webhooks that expect a
+	// "text" field render it directly; everything else can ignore it.
+	Text string `json:"text"`
+}
+
+// Sink delivers an event. Split out so the planner can be tested without a
+// server, and so a future transport is a new type rather than a new branch.
+type Sink interface {
+	Send(ctx context.Context, ev Event) error
+}
+
+// Webhook posts JSON to an operator-supplied URL.
+type Webhook struct {
+	URL     string
+	Client  *http.Client
+	Timeout time.Duration
+	// Attempts includes the first try. Two means one retry.
+	Attempts int
+}
+
+// NewWebhook builds a Sink for url. An empty url yields nil, which every
+// caller treats as "notifications are off" — the same shape as the pricing
+// table, and for the same reason: unconfigured must never mean guessed.
+func NewWebhook(url string) *Webhook {
+	if strings.TrimSpace(url) == "" {
+		return nil
+	}
+	return &Webhook{
+		URL:      url,
+		Client:   &http.Client{},
+		Timeout:  5 * time.Second,
+		Attempts: 2,
+	}
+}
+
+func (w *Webhook) Send(ctx context.Context, ev Event) error {
+	body, err := json.Marshal(ev)
+	if err != nil {
+		return fmt.Errorf("encode event: %w", err)
+	}
+
+	attempts := w.Attempts
+	if attempts < 1 {
+		attempts = 1
+	}
+	var last error
+	for i := 0; i < attempts; i++ {
+		if i > 0 {
+			// One short pause. This is not a delivery guarantee and should
+			// not pretend to be one: the next transition will say the same
+			// thing, and a queue that survives a planner restart is a
+			// different product.
+			select {
+			case <-time.After(time.Duration(i) * time.Second):
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+		last = w.post(ctx, body)
+		if last == nil {
+			return nil
+		}
+	}
+	return last
+}
+
+func (w *Webhook) post(ctx context.Context, body []byte) error {
+	timeout := w.Timeout
+	if timeout <= 0 {
+		timeout = 5 * time.Second
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, w.URL, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "k8s-dencer")
+
+	client := w.Client
+	if client == nil {
+		client = &http.Client{}
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("webhook returned %s", resp.Status)
+	}
+	return nil
+}
+
+// Notifier decides what is worth sending, and sends it without blocking.
+//
+// It holds one piece of state: whether the last plan it saw had anything safe
+// to do. That is what makes "a Green step appeared" a transition rather than
+// a repeated fact — and it is per-process, so a planner restart re-announces
+// an actionable plan once. That is the right failure: a duplicate message is
+// recoverable, a missed one is the thing this exists to prevent.
+type Notifier struct {
+	Sink    Sink
+	Log     *slog.Logger
+	Cluster string
+	// BaseURL is where the UI is reachable, if the operator has said. Empty
+	// means the message carries no link rather than a guessed one.
+	BaseURL string
+
+	mu       sync.Mutex
+	wasSafe  bool
+	lastPlan string
+	inflight sync.WaitGroup
+}
+
+// PlanStored reports a newly stored plan. Safe safe steps of total.
+//
+// Called from the planning cycle, so it must return immediately: the send
+// happens on its own goroutine with its own context, deliberately not the
+// cycle's — a cycle that finishes and cancels its context mid-post would
+// cancel the notification it just asked for.
+func (n *Notifier) PlanStored(planID string, safe, total, nodesBefore, nodesAfter int) {
+	if n == nil || n.Sink == nil {
+		return
+	}
+
+	n.mu.Lock()
+	wasSafe, prev := n.wasSafe, n.lastPlan
+	n.wasSafe, n.lastPlan = safe > 0, planID
+	n.mu.Unlock()
+
+	var ev Event
+	switch {
+	case safe > 0 && !wasSafe:
+		ev = Event{Kind: KindActionable}
+	case wasSafe && prev != "" && prev != planID:
+		// The plan somebody may be reviewing is no longer the current one.
+		ev = Event{Kind: KindSuperseded}
+	default:
+		// Still actionable, still not actionable, or the same plan again.
+		// Nothing changed that anyone needs to be interrupted for.
+		return
+	}
+
+	ev.PlanID = planID
+	ev.At = time.Now().UTC()
+	ev.Cluster = n.Cluster
+	ev.SafeSteps = safe
+	ev.TotalSteps = total
+	ev.NodesBefore = nodesBefore
+	ev.NodesAfter = nodesAfter
+	ev.Link = n.BaseURL
+	ev.Text = sentence(ev)
+
+	n.inflight.Add(1)
+	go func() {
+		defer n.inflight.Done()
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := n.Sink.Send(ctx, ev); err != nil && n.Log != nil {
+			// A warning, never an error: nothing about the cluster is wrong.
+			n.Log.Warn("notification not delivered", "kind", ev.Kind, "error", err)
+		}
+	}()
+}
+
+// Wait blocks until in-flight sends finish. For tests and shutdown; the
+// planning cycle never calls it.
+func (n *Notifier) Wait() {
+	if n == nil {
+		return
+	}
+	n.inflight.Wait()
+}
+
+func sentence(ev Event) string {
+	where := ""
+	if ev.Cluster != "" {
+		where = " on " + ev.Cluster
+	}
+	switch ev.Kind {
+	case KindActionable:
+		s := fmt.Sprintf("k8s-dencer%s: %d step", where, ev.SafeSteps)
+		if ev.SafeSteps != 1 {
+			s += "s"
+		}
+		s += " can be run safely"
+		if ev.NodesBefore > 0 && ev.NodesAfter > 0 {
+			s += fmt.Sprintf(" — %d nodes now, %d after", ev.NodesBefore, ev.NodesAfter)
+		}
+		return s + ". Nothing has been executed."
+	case KindSuperseded:
+		return fmt.Sprintf("k8s-dencer%s: the plan you were reviewing has been replaced by %s.",
+			where, ev.PlanID)
+	}
+	return ""
+}

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -94,7 +94,14 @@ type Webhook struct {
 // NewWebhook builds a Sink for url. An empty url yields nil, which every
 // caller treats as "notifications are off" — the same shape as the pricing
 // table, and for the same reason: unconfigured must never mean guessed.
-func NewWebhook(url string) *Webhook {
+//
+// It returns the INTERFACE, not *Webhook, and that is the whole point.
+// Returning a nil *Webhook put a typed nil inside the Sink field, where it
+// compares unequal to nil — so the "notifications are off" guard passed, Send
+// ran on a nil receiver, and the planner panicked on the first plan that had
+// anything safe in it. Returning Sink makes `return nil` a true nil interface
+// and removes the trap rather than documenting it.
+func NewWebhook(url string) Sink {
 	if strings.TrimSpace(url) == "" {
 		return nil
 	}
@@ -230,6 +237,19 @@ func (n *Notifier) PlanStored(planID string, safe, total, nodesBefore, nodesAfte
 	n.inflight.Add(1)
 	go func() {
 		defer n.inflight.Done()
+		// A panic on this goroutine takes the whole planner with it, because
+		// an unrecovered panic anywhere ends the process. That is not
+		// hypothetical: the first version of this package put a typed nil in
+		// the Sink field and killed the planner on the first plan that had a
+		// safe step, which read downstream as a lost metric and a migration
+		// race. "Notifications cannot fail a planning cycle" has to be true
+		// of a bug in this file too, not just of a slow endpoint.
+		defer func() {
+			if r := recover(); r != nil && n.Log != nil {
+				n.Log.Error("notification panicked; notifications may be misconfigured",
+					"kind", ev.Kind, "panic", r)
+			}
+		}()
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 		if err := n.Sink.Send(ctx, ev); err != nil && n.Log != nil {

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -1,0 +1,222 @@
+package notify
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type capture struct {
+	events []Event
+	err    error
+	calls  atomic.Int32
+}
+
+func (c *capture) Send(_ context.Context, ev Event) error {
+	c.calls.Add(1)
+	c.events = append(c.events, ev)
+	return c.err
+}
+
+func notifier(sink Sink) *Notifier {
+	return &Notifier{Sink: sink, Cluster: "prod-eu"}
+}
+
+// The point of the whole package: a message when there is something to do,
+// and silence otherwise.
+//
+// A notifier that fired every resync would send a message every thirty
+// seconds saying the same thing, and the fifth one is worse than none —
+// people build filters for it, and then the one that mattered is filtered
+// too.
+func TestOnlyTransitionsAreAnnounced(t *testing.T) {
+	c := &capture{}
+	n := notifier(c)
+
+	// Nothing safe: no news.
+	n.PlanStored("p1", 0, 4, 6, 6)
+	n.Wait()
+	if c.calls.Load() != 0 {
+		t.Fatalf("a plan with nothing safe sent %d message(s)", c.calls.Load())
+	}
+
+	// Safe steps appear. This is the message.
+	n.PlanStored("p2", 3, 8, 6, 3)
+	n.Wait()
+	if c.calls.Load() != 1 {
+		t.Fatalf("calls = %d, want 1 when safe steps appear", c.calls.Load())
+	}
+	if c.events[0].Kind != KindActionable {
+		t.Errorf("kind = %s, want %s", c.events[0].Kind, KindActionable)
+	}
+
+	// Still the same plan, still actionable. Nothing changed.
+	n.PlanStored("p2", 3, 8, 6, 3)
+	n.Wait()
+	if c.calls.Load() != 1 {
+		t.Errorf("re-storing the same actionable plan sent another message (%d total)",
+			c.calls.Load())
+	}
+}
+
+// A plan somebody is reviewing gets replaced, and they should be told: the
+// executor will refuse the one on their screen.
+func TestReplacingAnActionablePlanIsAnnounced(t *testing.T) {
+	c := &capture{}
+	n := notifier(c)
+
+	n.PlanStored("p1", 2, 5, 6, 4)
+	n.Wait()
+	n.PlanStored("p2", 2, 5, 6, 4)
+	n.Wait()
+
+	if c.calls.Load() != 2 {
+		t.Fatalf("calls = %d, want 2", c.calls.Load())
+	}
+	if c.events[1].Kind != KindSuperseded {
+		t.Errorf("second kind = %s, want %s", c.events[1].Kind, KindSuperseded)
+	}
+	if !strings.Contains(c.events[1].Text, "p2") {
+		t.Errorf("the superseded message does not name the new plan: %q", c.events[1].Text)
+	}
+}
+
+// Nothing about the cluster's shape may leave it.
+//
+// A webhook URL is a bearer credential in a query string, and a chat channel
+// is not an authorization boundary. The plan is behind authentication and
+// stays there; what goes out is a count and a link that is useless without a
+// token.
+func TestTheEventCarriesNoClusterDetail(t *testing.T) {
+	c := &capture{}
+	n := notifier(c)
+	n.BaseURL = "https://dencer.example.com"
+	n.PlanStored("abc123", 3, 8, 6, 3)
+	n.Wait()
+
+	body, err := json.Marshal(c.events[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The fields that exist are the fields that were designed. A node name or
+	// a workload name appearing here would mean somebody added a field
+	// without thinking about who reads the channel.
+	var got map[string]any
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatal(err)
+	}
+	allowed := map[string]bool{
+		"kind": true, "planId": true, "at": true, "cluster": true,
+		"safeSteps": true, "totalSteps": true, "nodesBefore": true,
+		"nodesAfter": true, "link": true, "text": true,
+	}
+	for k := range got {
+		if !allowed[k] {
+			t.Errorf("event carries %q, which nobody decided to publish outside the cluster", k)
+		}
+	}
+}
+
+// A dead endpoint must cost a log line, not a planning cycle.
+func TestASlowEndpointDoesNotBlockTheCaller(t *testing.T) {
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		<-release
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	defer close(release)
+
+	n := &Notifier{Sink: NewWebhook(srv.URL)}
+
+	done := make(chan struct{})
+	go func() {
+		n.PlanStored("p1", 2, 4, 6, 4)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("PlanStored blocked on a slow endpoint; a planning cycle would have stalled")
+	}
+}
+
+// An unset URL is off, not a request to nowhere.
+func TestNoURLMeansNoSink(t *testing.T) {
+	if w := NewWebhook(""); w != nil {
+		t.Error("an empty URL produced a webhook")
+	}
+	if w := NewWebhook("   "); w != nil {
+		t.Error("a blank URL produced a webhook")
+	}
+	// A nil Notifier and a nil Sink both have to be safe: the planner builds
+	// one unconditionally and leaves it empty when unconfigured.
+	var n *Notifier
+	n.PlanStored("p1", 1, 1, 2, 1) // must not panic
+	(&Notifier{}).PlanStored("p1", 1, 1, 2, 1)
+}
+
+func TestWebhookPostsTheEventAndRetriesOnce(t *testing.T) {
+	var hits atomic.Int32
+	var body atomic.Value
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		body.Store(string(b))
+		if hits.Add(1) == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	wh := NewWebhook(srv.URL)
+	wh.Attempts = 2
+	if err := wh.Send(context.Background(), Event{Kind: KindActionable, PlanID: "p1", SafeSteps: 2}); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	if hits.Load() != 2 {
+		t.Errorf("hits = %d, want 2 — the first failed and should have been retried", hits.Load())
+	}
+	if s, _ := body.Load().(string); !strings.Contains(s, `"kind":"plan.actionable"`) {
+		t.Errorf("posted body does not carry the event: %q", s)
+	}
+}
+
+func TestAFailingWebhookReportsRatherThanPanics(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	wh := NewWebhook(srv.URL)
+	wh.Attempts = 1
+	err := wh.Send(context.Background(), Event{Kind: KindActionable})
+	if err == nil {
+		t.Fatal("a 403 reported success")
+	}
+	if !strings.Contains(err.Error(), "403") {
+		t.Errorf("error does not name the status: %v", err)
+	}
+}
+
+// The sentence is what most people will actually read, so it has to say the
+// one thing this product is careful about.
+func TestTheSentenceSaysNothingWasExecuted(t *testing.T) {
+	got := sentence(Event{Kind: KindActionable, SafeSteps: 3, NodesBefore: 6, NodesAfter: 3, Cluster: "prod-eu"})
+	for _, want := range []string{"prod-eu", "3 steps", "6 nodes now, 3 after", "Nothing has been executed"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("sentence %q is missing %q", got, want)
+		}
+	}
+	if one := sentence(Event{Kind: KindActionable, SafeSteps: 1}); !strings.Contains(one, "1 step can") {
+		t.Errorf("singular reads wrong: %q", one)
+	}
+}

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -177,8 +177,7 @@ func TestWebhookPostsTheEventAndRetriesOnce(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	wh := NewWebhook(srv.URL)
-	wh.Attempts = 2
+	wh := &Webhook{URL: srv.URL, Attempts: 2}
 	if err := wh.Send(context.Background(), Event{Kind: KindActionable, PlanID: "p1", SafeSteps: 2}); err != nil {
 		t.Fatalf("send: %v", err)
 	}
@@ -196,8 +195,7 @@ func TestAFailingWebhookReportsRatherThanPanics(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	wh := NewWebhook(srv.URL)
-	wh.Attempts = 1
+	wh := &Webhook{URL: srv.URL, Attempts: 1}
 	err := wh.Send(context.Background(), Event{Kind: KindActionable})
 	if err == nil {
 		t.Fatal("a 403 reported success")
@@ -219,4 +217,44 @@ func TestTheSentenceSaysNothingWasExecuted(t *testing.T) {
 	if one := sentence(Event{Kind: KindActionable, SafeSteps: 1}); !strings.Contains(one, "1 step can") {
 		t.Errorf("singular reads wrong: %q", one)
 	}
+}
+
+// The wiring the planner actually uses, which the first version of this
+// package panicked on.
+//
+// NewWebhook returned *Webhook, and an unconfigured install got a nil one.
+// Assigned into the Sink interface field, that is NOT nil — an interface
+// holding a typed nil pointer compares unequal to nil — so the `Sink == nil`
+// guard passed, Send was called on a nil receiver, and the planner died on
+// the first plan with a safe step in it.
+//
+// Every unit test passed: they used a literal `&Notifier{}` with Sink never
+// assigned, which is a true nil interface and the one shape the planner never
+// constructs. The e2e caught it as "1 container restart(s)" and a reclamation
+// histogram that read zero because the process that recorded it had died.
+func TestTheUnconfiguredWiringDoesNotPanic(t *testing.T) {
+	n := &Notifier{Sink: NewWebhook(""), Cluster: "prod"}
+	// The transition that fires: safe steps where there were none.
+	n.PlanStored("p1", 3, 8, 6, 3)
+	n.Wait()
+	// Reaching here without a panic is the assertion.
+}
+
+type panicSink struct{}
+
+func (panicSink) Send(context.Context, Event) error { panic("sink exploded") }
+
+// A bug in a notification sink must not end the planner.
+//
+// An unrecovered panic on any goroutine ends the process, so "notifications
+// cannot fail a planning cycle" has to hold for a bug in this package too,
+// not only for a slow or dead endpoint. Learned the direct way: a typed nil
+// in the Sink field killed the planner on the first plan with a safe step,
+// and the symptom three layers downstream was a reclamation histogram
+// reading zero because the process that recorded it had restarted.
+func TestASinkThatPanicsDoesNotTakeThePlannerWithIt(t *testing.T) {
+	n := &Notifier{Sink: panicSink{}}
+	n.PlanStored("p1", 2, 4, 6, 4)
+	n.Wait()
+	// Surviving to here is the assertion.
 }

--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -34,6 +34,7 @@ import (
 	"github.com/atedgimo/k8s-dencer/internal/constraints"
 	"github.com/atedgimo/k8s-dencer/internal/impact"
 	"github.com/atedgimo/k8s-dencer/internal/model"
+	"github.com/atedgimo/k8s-dencer/internal/notify"
 	"github.com/atedgimo/k8s-dencer/internal/planner"
 	"github.com/atedgimo/k8s-dencer/internal/reclaim"
 	"github.com/atedgimo/k8s-dencer/internal/store"
@@ -58,6 +59,9 @@ type Publisher struct {
 	// plan.
 	Retain  int
 	Metrics *telemetry.Metrics
+	// Notify is optional. Nil, or one with no sink, means notifications are
+	// off — the planner must behave identically either way.
+	Notify *notify.Notifier
 
 	latest         atomic.Pointer[model.ClusterSnapshot]
 	latestAnalysis atomic.Pointer[constraints.Analysis]
@@ -276,6 +280,17 @@ func (p *Publisher) Cycle(ctx context.Context) {
 		return
 	}
 	p.Log.Info("plan stored", "id", plan.ID)
+
+	// Only on the stored path. The dedup early-return above is the cluster
+	// not having changed, and announcing that every resync is how a
+	// notification channel becomes one people filter out.
+	safe := 0
+	for _, st := range plan.Steps {
+		if st.Impact == model.ImpactGreen {
+			safe++
+		}
+	}
+	p.Notify.PlanStored(plan.ID, safe, len(plan.Steps), plan.NodesBefore, plan.NodesAfter)
 
 	if pruned, err := p.DB.Prune(ctx, p.Retain); err != nil {
 		p.Log.Warn("pruning plan history failed", "error", err)


### PR DESCRIPTION
Closes #222. Also documents #230.

The product required a human to open a browser and look. That fits the premise — *it produces the plan and stops* — but the premise is about not **acting** without a human, not about being invisible.

## Transitions, not a heartbeat

| | |
|---|---|
| `plan.actionable` | safe steps exist where a moment ago there were none |
| `plan.superseded` | a plan that had safe steps has been replaced |

A message every resync is a message nobody reads, and once people build a filter for it the one that mattered is filtered too.

## What leaves the cluster

A plan id, four counts, the cluster label, a link and a sentence. **Never the plan** — no node names, no workload names, no rationale. A webhook endpoint is readable by anyone holding the URL and a chat channel is not an authorization boundary, so the plan stays behind authentication and the link is useless without a token.

A test enumerates the payload's keys, so adding a field is a decision rather than an accident.

## It cannot fail a planning cycle

Every send is off the cycle's goroutine **with its own context** — a cycle that finished and cancelled its context mid-post would cancel the notification it had just asked for. Bounded by a timeout, one retry, and a warning if it never lands. A planner that stopped planning because a chat server was down would be a worse product than one that never notified.

## Configuration

Off unless asked for, and by Secret for preference — a webhook URL is a bearer credential, and inline values show up in `helm get values`. Three chart-contract checks hold that:

- off by default
- `existingSecret` wins over an inline `url`, with no leak into the manifest
- **the chart still renders when the whole `notify` block is absent** — the shape `helm upgrade --reuse-values` produces, and how v0.8.1 shipped a chart that could not render at all

## Verified end to end

Against a real receiver in the OrbStack cluster:

- **nothing** while the plan had no Green steps — correct, there was nothing to say
- then exactly **one** POST, the moment the cluster gained safe steps:

```json
{"kind":"plan.actionable","planId":"823b6dad6576","cluster":"orbstack-lab",
 "safeSteps":9,"totalSteps":10,"nodesBefore":17,"nodesAfter":7,
 "text":"k8s-dencer on orbstack-lab: 9 steps can be run safely — 17 nodes now, 7 after. Nothing has been executed."}
```

One POST, no duplicates, no delivery failures in the planner log.

## Also in here

`docs/install.md` gains the **Postgres → SQLite** migration note from #230 — a real upgrade failure I hit while verifying #223, which the chart cannot fix because Helm owns `strategy.type` and not the `rollingUpdate` block the API server defaulted onto the object.