### PR TITLE
Document v0.10.0, and bump the chart to match

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,9 +268,16 @@ Full index: **[docs/](docs/README.md)**. The ones most people want first:
 execution, and maintenance windows. Phase 4 — hardening toward 1000 nodes and
 50,000 pods — is in progress, with metrics, CI and the release pipeline landed.
 
-**v0.9.0 is published** — images, chart and CLI binaries on `ghcr.io` and the
+**v0.10.0 is published** — images, chart and CLI binaries on `ghcr.io` and the
 [releases page](https://github.com/atedgimo/k8s-dencer/releases), installable by
 the command above.
+
+v0.10.0 is the release that stops waiting to be visited. The planner can tell
+you a plan exists — a small JSON body to an endpoint you supply, on transitions
+only, carrying counts and a link but never the plan itself. Findings now say
+*where* they hold capacity ("blocks three steps on your spot pool"), and
+History states what its bars have been saying rather than leaving you to read
+it off the chart.
 
 > **Upgrading from v0.8.x?** A plan is identified by its *actions*, so a planner
 > that explained the same drain better produced the same id and the store kept

--- a/charts/k8s-dencer/Chart.yaml
+++ b/charts/k8s-dencer/Chart.yaml
@@ -10,8 +10,8 @@ type: application
 
 # Chart version tracks the chart; appVersion tracks the images. Component image
 # tags default to appVersion so a chart release pins a coherent image set.
-version: 0.9.0
-appVersion: "0.9.0"
+version: 0.10.0
+appVersion: "0.10.0"
 
 # controller-runtime and the policy/v1 PDB API used here are stable from 1.21,
 # but the chart relies on 1.27-era defaults for restricted Pod Security

--- a/docs/product-roadmap.md
+++ b/docs/product-roadmap.md
@@ -5,7 +5,7 @@ milestones. The engineering history behind each item, with measurements and
 design reasoning, is in **[roadmap.md](roadmap.md)**; this page is the view for
 deciding what to build next and telling users what they get.
 
-*Last updated: 2026-08-15.*
+*Last updated: 2026-08-16.*
 
 ## Shipped
 
@@ -293,6 +293,26 @@ something else, a step list that collapsed to zero height at 1100px, and
 display headlines inheriting body leading. Two more — `--space-5` and
 `--text-primary`, neither of which exists — had been silently deleting whole
 declarations since the redesign. All five are now gates.
+
+### It reaches out, and it says where (2026-08-16)
+- **A plan can tell you it exists** — an operator-supplied webhook, fired on
+  transitions rather than on a timer. Counts and a link, never the plan: a
+  chat channel is not an authorization boundary. Off by default, because it
+  is the only outbound connection any component makes
+- **Findings name the pool they hold open** — "blocks three steps on your spot
+  pool" rather than "blocks three steps". Grouped by whatever the nodes
+  actually say, and silent where they say nothing
+- **History states its own trend** — reservation and usage as two separate
+  numbers, over a window it names, and no sentence at all when the window is
+  too short to support one
+
+The notifier shipped with a bug worth recording: `NewWebhook` returned a typed
+nil pointer into an interface field, where it compares unequal to nil, so an
+unconfigured install panicked the planner on the first plan with a safe step.
+Every unit test passed — they exercised a shape the planner never builds. The
+e2e caught it as a reclamation histogram reading zero. The fix returns the
+interface, and the send goroutine now recovers, so "notifications cannot fail
+a planning cycle" is true of a bug in that file too.
 
 ## Next
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -14,6 +14,38 @@ they hid rather than by release, are in [findings.md](findings.md).
 
 ---
 
+## v0.10.0 — 2026-08-16
+
+The release that stops waiting to be visited.
+
+**The planner can tell you a plan exists.** A small JSON body to an endpoint
+you supply, on two transitions — safe steps appearing where there were none,
+and an actionable plan being replaced. Off by default; this is the only
+outbound connection any component makes. What leaves the cluster is a plan id,
+four counts, your cluster label and a sentence — never the plan, because a
+webhook endpoint is readable by anyone holding the URL and a chat channel is
+not an authorization boundary. See
+[install.md](install.md#being-told-instead-of-remembering-to-look).
+
+**Findings say where they hold capacity**, not just how much: "blocks three
+steps on your spot pool" rather than "blocks three steps". Grouped by whatever
+the nodes actually say — pool and capacity type where both are labelled,
+capacity type alone where only that is, and nothing at all where neither is,
+because an unlabelled node is not a pool called "unknown".
+
+**History states what its bars have been saying.** "Over the past 16 days your
+workloads reserved 28% of the fleet and used 6% of it." Reservation and usage
+stay separate on purpose: the GKE run measured ~890m requested against ~50m
+used of 940m allocatable, and consolidation only ever addresses the first.
+It declines to speak on a window too short to support the claim, and reports
+no usage at all rather than averaging a measured number against a zero that
+only meant nobody was looking.
+
+Also: a documented migration for going **back** to SQLite from Postgres, where
+`helm upgrade` fails once on the Deployment strategy — the API server defaults
+a `rollingUpdate` block that is illegal beside `type: Recreate`, and Helm does
+not own it, so the chart cannot clear it.
+
 ## v0.9.0 — 2026-08-15
 
 The release the first GKE run produced. That run answered the question it


### PR DESCRIPTION
The release that stops waiting to be visited.

| | |
|---|---|
| #222 | the planner can tell you a plan exists |
| #223 | findings say which pool they hold open |
| #224 | History states the trend its bars have been drawing |
| #230 | documented migration for going back to SQLite from Postgres |

## Worth reading in the notes

The notifier shipped a bug in review and it is recorded rather than quietly fixed: `NewWebhook` returned a typed nil pointer into an interface field, where it **compares unequal to nil** — so an unconfigured install panicked the planner on the first plan that had a safe step in it.

Every unit test passed. They built `&Notifier{}` with the sink never assigned, which is a true nil interface and the one shape the planner never constructs. The e2e caught it, deterministically, as a reclamation histogram reading zero and — on Postgres, which says it more plainly — "1 container restart(s)".

Fixed twice over: `NewWebhook` returns the interface so `return nil` is really nil, and the send goroutine recovers, so *"notifications cannot fail a planning cycle"* is true of a bug in that file too and not only of a slow endpoint.

`version` and `appVersion` both move to `0.10.0`; the release job refuses to publish if they do not match the tag.